### PR TITLE
Add endpoint for metrics

### DIFF
--- a/idea_town/metrics/views.py
+++ b/idea_town/metrics/views.py
@@ -1,0 +1,33 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.permissions import IsAuthenticated
+from django.conf import settings
+import datadog
+import json
+import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
+datadog.initialize(**settings.DATADOG_KEYS)
+
+
+class MetricsView(APIView):
+    permission_classes = (IsAuthenticated,)
+
+    def get(self, request):
+        return Response(request.data)
+
+    def post(self, request):
+        d = request.data
+        if 'title' not in d:
+            d['title'] = 'ideatown-generic-event'
+        d['created'] = datetime.datetime.now().isoformat()
+        handle_metric(d)
+        return Response(d)
+
+
+def handle_metric(metric):
+    # will eventually handle multiple types of metrics, including
+    # statsd types.
+    datadog.api.Event.create(title=metric['title'], text=json.dumps(metric))

--- a/idea_town/settings.py
+++ b/idea_town/settings.py
@@ -117,6 +117,10 @@ ROOT_URLCONF = 'idea_town.urls'
 
 WSGI_APPLICATION = 'idea_town.wsgi.application'
 
+DATADOG_KEYS = {
+    'api_key': '4f3b967bbf13c7769ac4fa89efda0fae',
+    'app_key': 'ddd45a7b3a3cb90ff1baf20ae8cfab04d1937038'
+}
 
 # Database
 # https://docs.djangoproject.com/en/1.7/ref/settings/#databases

--- a/idea_town/urls.py
+++ b/idea_town/urls.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from rest_framework import routers
 
 from .experiments import views as experiment_views
-
+from .metrics import views as metrics_view
 
 # Allow apps to contribute API parts
 router = routers.DefaultRouter()
@@ -16,6 +16,7 @@ urlpatterns = patterns(
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/', include(router.urls)),
+    url(r'^api/metrics/', metrics_view.MetricsView.as_view(), name='metrics'),
     # Catch-all fallback to frontend client view
     url(r'', include('idea_town.frontend.urls')),
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,3 +143,9 @@ django-filter==0.11.0
 
 # sha256: CYQuyxx8OOWmZsBLz6kk9oLvHoLZyECA8Zwot3HQgMU
 djangorestframework==3.2.3
+
+# sha256: lcqHHird1Z7KXjs75h6v8_Zpx0YOV6jOs8j5u238DTQ
+datadog==0.9.0
+
+# sha256: IX5Hl9o6mkqfvmci4NuYBwuEQ6iCEtes29JBp2aBQdk
+simplejson==3.8.0


### PR DESCRIPTION
endpoint is at `/api/metrics`.

For our first run we will just push events to `datadog`. Going forward we can setup datadog's statsd integration.
