### PR TITLE
Issue #63: Add /api/users/self endpoint

### DIFF
--- a/idea_town/frontend/static-src/.editorconfig
+++ b/idea_town/frontend/static-src/.editorconfig
@@ -1,0 +1,12 @@
+# http://editorconfig.org
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/idea_town/frontend/static-src/app/lib/router.js
+++ b/idea_town/frontend/static-src/app/lib/router.js
@@ -17,7 +17,7 @@ export default Router.extend({
   },
 
   landing() {
-    if (app.me.session && app.me.hasAddon) {
+    if (app.me.user.id && app.me.hasAddon) {
       this.redirectTo('home');
     } else {
       app.trigger('router:new-page', {page: 'landing'});
@@ -25,7 +25,7 @@ export default Router.extend({
   },
 
   home() {
-    if (!app.me.session || !app.me.hasAddon) {
+    if (!app.me.user.id || !app.me.hasAddon) {
       this.redirectTo('');
     } else {
       app.trigger('router:new-page', {page: 'home'});
@@ -34,7 +34,7 @@ export default Router.extend({
 
   // 'experiment' is a URL slug: for example, 'universal-search'
   experimentDetail(experiment) {
-    if (!app.me.session || !app.me.hasAddon) {
+    if (!app.me.user.id || !app.me.hasAddon) {
       this.redirectTo('');
     } else {
       if (app.experiments.get(experiment, 'slug')) {

--- a/idea_town/frontend/static-src/app/main.js
+++ b/idea_town/frontend/static-src/app/main.js
@@ -1,5 +1,6 @@
 import app from 'ampersand-app';
 
+import xhr from 'xhr';
 import webChannel from './lib/web-channel';
 import ExperimentsCollection from './collections/experiments';
 import HeaderView from './views/header-view';
@@ -7,12 +8,41 @@ import Me from './models/me';
 import PageManager from './lib/page-manager';
 import Router from './lib/router';
 
+function getDocHeadLink(relName, attrName) {
+  return document
+    .querySelector('head link[rel="' + relName + '"]')
+    .getAttribute(attrName);
+}
+
 app.extend({
+
   initialize() {
+
     app.experiments = new ExperimentsCollection();
     app.experiments.fetch();
+
+    xhr({
+      method: 'GET',
+      uri: getDocHeadLink('x-current-user', 'href'),
+      headers: { 'Accept': 'application/json' }
+    }, (err, resp, body) => {
+      var data;
+      try { data = JSON.parse(body); }
+      catch (err) { /* no-op */ }
+      return this.dataReady(data);
+    });
+
+  },
+
+  dataReady(userData) {
+
     app.webChannel = webChannel;
-    app.me = new Me();
+
+    app.me = new Me({
+      user: userData,
+      addonUrl: getDocHeadLink('x-addon', 'href'),
+      addonName: getDocHeadLink('x-addon', 'title')
+    });
 
     // session won't change without a hard refresh, but addon state could, so:
     // if addon state changes, dump user back to '/' and let the router handle
@@ -29,12 +59,13 @@ app.extend({
     app.pageManager = new PageManager({
       pageContainer: document.querySelector('[data-hook=page-container]')
     });
+
     app.router = new Router();
     app.router.history.start();
   }
+
 });
 app.initialize();
-
 
 // make app accessible from window for debuggin'
 window.app = app;

--- a/idea_town/frontend/static-src/app/models/me.js
+++ b/idea_town/frontend/static-src/app/models/me.js
@@ -8,18 +8,18 @@ import State from 'ampersand-state';
 //       some kind of session-check API that sends over the user model
 //       (email, name, avatar, addon status) if the user's logged in.
 export default State.extend({
+
   props: {
-    hasAddon: ['boolean', true, false]
+    user: 'object',
+    addonUrl: 'string',
+    addonName: 'string',
+    hasAddon: {type: 'boolean', required: true, default: false}
   },
 
   derived: {
     csrfToken: {
       cache: false,
       fn: () => { return cookies.get('csrftoken'); }
-    },
-    session: {
-      cache: false,
-      fn: () => { return window.sadface.userId; }
     }
   },
 

--- a/idea_town/frontend/static-src/app/views/header-view.js
+++ b/idea_town/frontend/static-src/app/views/header-view.js
@@ -15,7 +15,7 @@ export default BaseView.extend({
   initialize() {
     // since we reload the page on every session change, no need to observe
     // the model; just treat it as a static data structure
-    this.session = app.me.session;
+    this.session = app.me.user.id;
   },
 
   render() {

--- a/idea_town/frontend/static-src/app/views/landing-page.js
+++ b/idea_town/frontend/static-src/app/views/landing-page.js
@@ -2,12 +2,6 @@ import app from 'ampersand-app';
 
 import BaseView from './base-view';
 
-// TODO replace with an api endpoint that exposes idea town addon info
-const addonInfo = {
-  name: window.sadface.addon.name,
-  url: window.sadface.addon.url
-};
-
 export default BaseView.extend({
   _template: `<section class="page {{#loggedIn}} loggedIn {{/loggedIn}}">
                 {{^loggedIn}}
@@ -26,8 +20,12 @@ export default BaseView.extend({
               </section>`,
 
   render() {
-    this.loggedIn = !!app.me.session;
-    this.downloadUrl = addonInfo.url;
+
+    this.loggedIn = !!app.me.user.id;
+
+    // TODO replace with an api endpoint that exposes idea town addon info?
+    this.downloadUrl = app.me.addonUrl;
+
     BaseView.prototype.render.apply(this, arguments);
   }
 });

--- a/idea_town/frontend/templates/idea_town/frontend/index.html
+++ b/idea_town/frontend/templates/idea_town/frontend/index.html
@@ -3,6 +3,9 @@
 <head>
     <title>Idea Town</title>
     <link rel="stylesheet" href="{{ static('styles/main.css') }}">
+    <link rel="x-current-user" href="{{ url('users_self') }}">
+    {# TODO: Make this a dev / prod setting? Or, expose in an API endpoint? #}
+    <link rel="x-addon" title="Idea Town" href="https://github.com/mozilla/idea-town-addon/blob/master/dist/idea-town-addon-0.0.1.xpi?raw=true">
 </head>
 <body>
   <header></header>
@@ -21,21 +24,7 @@
   <!-- notification bar will pop down from the top of the screen -->
   <div id="notification-bar" hidden></div>
 
-  {# TODO: this fails csp and breaks if the html page is cached; use an api endpoint instead #}
-  <script>
-    'use strict';
-    window.sadface = {
-      csrfToken: '{{ csrf_token }}',
-      userId: '{{ user_id }}',
-      addon: {
-        name: 'Idea Town',
-        url: 'https://github.com/mozilla/idea-town-addon/blob/master/dist/idea-town-addon-0.0.1.xpi?raw=true'
-      }
-    };
-  </script>
-
   <script src="{{ static('app/app.js') }}"></script>
-
 
 </body>
 </html>

--- a/idea_town/urls.py
+++ b/idea_town/urls.py
@@ -4,11 +4,13 @@ from django.contrib import admin
 from rest_framework import routers
 
 from .experiments import views as experiment_views
+from .users import views as users_views
 from .metrics import views as metrics_view
 
 # Allow apps to contribute API parts
 router = routers.DefaultRouter(trailing_slash=False)
 experiment_views.register_views(router)
+users_views.register_views(router)
 
 urlpatterns = patterns(
     '',
@@ -17,6 +19,7 @@ urlpatterns = patterns(
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api/', include(router.urls)),
     url(r'^api/metrics/', metrics_view.MetricsView.as_view(), name='metrics'),
+    url(r'^api/users/self', users_views.SelfView.as_view(), name='users_self'),
     # Catch-all fallback to frontend client view
     url(r'', include('idea_town.frontend.urls')),
 )

--- a/idea_town/users/tests.py
+++ b/idea_town/users/tests.py
@@ -1,0 +1,80 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User
+
+from ..experiments.models import (Experiment, UserInstallation)
+
+import json
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class SelfViewTests(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.username = 'johndoe'
+        cls.password = 'top_secret'
+        cls.email = '%s@example.com' % cls.username
+        cls.user = User.objects.create_user(
+            username=cls.username,
+            email=cls.email,
+            password=cls.password)
+
+        cls.experiments = dict((obj.slug, obj) for obj in (
+            Experiment.objects.create(**kwargs) for kwargs in (
+                dict(title='Test 1', slug='test-1', description='This is a test'),
+                dict(title='Test 2', slug='test-2', description='This is a test'),
+                dict(title='Test 3', slug='test-3', description='This is a test'),
+            )))
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_anonymous(self):
+        url = reverse('users_self')
+        resp = self.client.get(url)
+        data = json.loads(str(resp.content, encoding='utf8'))
+
+        self.assertEqual(len(data.keys()), 0)
+
+    def test_get_logged_in(self):
+        url = reverse('users_self')
+
+        self.client.login(username=self.username,
+                          password=self.password)
+
+        resp = self.client.get(url)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                'id': self.email,
+                'installed': []
+            }
+        )
+
+        UserInstallation.objects.create(
+            experiment=self.experiments['test-1'],
+            user=self.user
+        )
+
+        resp = self.client.get(url)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                'id': self.email,
+                'installed': [
+                    {
+                        'description': 'This is a test',
+                        'details_url': 'http://testserver/api/experiments/4/details/',
+                        'slug': 'test-1',
+                        'thumbnail': None,
+                        'title': 'Test 1',
+                        'url': 'http://testserver/api/experiments/4/',
+                        'xpi_url': ''
+                    }
+                ]
+            }
+        )

--- a/idea_town/users/views.py
+++ b/idea_town/users/views.py
@@ -1,0 +1,32 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from ..experiments.models import (UserInstallation)
+from ..experiments.serializers import ExperimentSerializer
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class SelfView(APIView):
+    permission_classes = []
+
+    def get(self, request):
+
+        if not request.user.is_authenticated():
+            return Response({})
+
+        user = request.user
+
+        return Response({
+            "id": user.email,
+            "installed": [
+                ExperimentSerializer(x.experiment,
+                                     context={'request': request}).data
+                for x in UserInstallation.objects.filter(user=user)
+            ]
+        })
+
+
+def register_views(router):
+    pass


### PR DESCRIPTION
- Add /api/users/self API endpoint to expose data about the currently
  logged in user. (i.e. user ID, installed experiments)
- Move sadface JS data into template markup
- Add the user and addon props to overall Me model
- Frontend client tweaks to use the API
- Add .editorconfig to idea_town/frontend/static-src so my editor can do
  different indenting in Python & JS
- Server-side tests
