### PR TITLE
Issue #63: Add /api/users/self endpoint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[*.js]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ server:
     - DEBUG=True
     - ALLOWED_HOSTS=localhost,127.0.0.1,
     - SECRET_KEY=59114b6a-2858-4caf-8878-482a24ee9542
+    - ADDON_URL=https://github.com/mozilla/idea-town-addon/blob/master/dist/idea-town-addon-0.0.1.xpi?raw=true
     - FXA_ACCESS_TOKEN_URL=https://oauth-stable.dev.lcip.org/v1/token
     - FXA_AUTHORIZE_URL=https://oauth-stable.dev.lcip.org/v1/authorization
     - FXA_PROFILE_URL=https://stable.dev.lcip.org/profile/v1/profile

--- a/idea_town/frontend/static-src/app/lib/router.js
+++ b/idea_town/frontend/static-src/app/lib/router.js
@@ -17,7 +17,7 @@ export default Router.extend({
   },
 
   landing() {
-    if (app.me.session && app.me.hasAddon) {
+    if (app.me.user.id && app.me.hasAddon) {
       this.redirectTo('home');
     } else {
       app.trigger('router:new-page', {page: 'landing'});
@@ -25,7 +25,7 @@ export default Router.extend({
   },
 
   home() {
-    if (!app.me.session || !app.me.hasAddon) {
+    if (!app.me.user.id || !app.me.hasAddon) {
       this.redirectTo('');
     } else {
       app.trigger('router:new-page', {page: 'home'});
@@ -34,7 +34,7 @@ export default Router.extend({
 
   // 'experiment' is a URL slug: for example, 'universal-search'
   experimentDetail(experiment) {
-    if (!app.me.session || !app.me.hasAddon) {
+    if (!app.me.user.id || !app.me.hasAddon) {
       this.redirectTo('');
     } else {
       if (app.experiments.get(experiment, 'slug')) {

--- a/idea_town/frontend/static-src/app/main.js
+++ b/idea_town/frontend/static-src/app/main.js
@@ -1,3 +1,7 @@
+import es6Promise from 'es6-promise';
+es6Promise.polyfill();
+import 'isomorphic-fetch';
+
 import app from 'ampersand-app';
 
 import webChannel from './lib/web-channel';
@@ -8,33 +12,46 @@ import PageManager from './lib/page-manager';
 import Router from './lib/router';
 
 app.extend({
+
   initialize() {
-    app.experiments = new ExperimentsCollection();
-    app.experiments.fetch();
     app.webChannel = webChannel;
-    app.me = new Me();
 
-    // session won't change without a hard refresh, but addon state could, so:
-    // if addon state changes, dump user back to '/' and let the router handle
-    // redirecting to the correct landing page
-    app.me.on('change:hasAddon', () => { app.router.reload(); });
+    fetch('/api/me?format=json', {
+      credentials: 'same-origin'
+    }).then((response) => response.json()).then((userData) => {
+      app.me = new Me({
+        user: userData
+      });
 
-    // the header is independent of the page container logic, so it lives
-    // outside the page container element
-    // TODO: seems like the PageManager should know when to refresh / hide
-    //       the header
-    app.headerView = new HeaderView({el: document.querySelector('header') });
-    app.headerView.render();
+      app.experiments = new ExperimentsCollection();
+      app.experiments.fetch();
 
-    app.pageManager = new PageManager({
-      pageContainer: document.querySelector('[data-hook=page-container]')
+      // session won't change without a hard refresh, but addon state could, so:
+      // if addon state changes, dump user back to '/' and let the router handle
+      // redirecting to the correct landing page
+      app.me.on('change:hasAddon', () => { app.router.reload(); });
+
+      // the header is independent of the page container logic, so it lives
+      // outside the page container element
+      // TODO: seems like the PageManager should know when to refresh / hide
+      //       the header
+      app.headerView = new HeaderView({el: document.querySelector('header') });
+      app.headerView.render();
+
+      app.pageManager = new PageManager({
+        pageContainer: document.querySelector('[data-hook=page-container]')
+      });
+
+      app.router = new Router();
+      app.router.history.start();
+    }).catch((err) => {
+      // for now, log the error in the console & do nothing in the UI
+      console && console.error(err); // eslint-disable-line no-console
     });
-    app.router = new Router();
-    app.router.history.start();
   }
+
 });
 app.initialize();
-
 
 // make app accessible from window for debuggin'
 window.app = app;

--- a/idea_town/frontend/static-src/app/models/me.js
+++ b/idea_town/frontend/static-src/app/models/me.js
@@ -8,18 +8,16 @@ import State from 'ampersand-state';
 //       some kind of session-check API that sends over the user model
 //       (email, name, avatar, addon status) if the user's logged in.
 export default State.extend({
+
   props: {
-    hasAddon: ['boolean', true, false]
+    user: 'object',
+    hasAddon: {type: 'boolean', required: true, default: false}
   },
 
   derived: {
     csrfToken: {
       cache: false,
       fn: () => { return cookies.get('csrftoken'); }
-    },
-    session: {
-      cache: false,
-      fn: () => { return window.sadface.userId; }
     }
   },
 

--- a/idea_town/frontend/static-src/app/views/header-view.js
+++ b/idea_town/frontend/static-src/app/views/header-view.js
@@ -1,5 +1,4 @@
 import app from 'ampersand-app';
-import xhr from 'xhr';
 
 import BaseView from './base-view';
 
@@ -15,7 +14,7 @@ export default BaseView.extend({
   initialize() {
     // since we reload the page on every session change, no need to observe
     // the model; just treat it as a static data structure
-    this.session = app.me.session;
+    this.session = app.me.user.id;
   },
 
   render() {
@@ -30,20 +29,15 @@ export default BaseView.extend({
   //       to pick up csrftoken cookie changes.
   logout(evt) {
     evt.preventDefault();
-    xhr({
+    fetch('/accounts/logout/', {
       method: 'POST',
-      uri: '/accounts/logout/',
-      headers: {
-        'X-CSRFTOKEN': app.me.csrfToken
-      }
-    // note, the xhr callback also has a third 'body' argument
-    }, (err, resp) => {
-      if (err || resp.statusCode >= 400) {
-        // for now, log the error in the console & do nothing in the UI
-        console && console.error(err); // eslint-disable-line no-console
-      } else {
-        window.location.reload();
-      }
+      credentials: 'same-origin',
+      headers: { 'X-CSRFTOKEN': app.me.csrfToken }
+    }).then(() => {
+      window.location.reload();
+    }).catch((err) => {
+      // for now, log the error in the console & do nothing in the UI
+      console && console.error(err); // eslint-disable-line no-console
     });
   }
 });

--- a/idea_town/frontend/static-src/app/views/landing-page.js
+++ b/idea_town/frontend/static-src/app/views/landing-page.js
@@ -2,12 +2,6 @@ import app from 'ampersand-app';
 
 import BaseView from './base-view';
 
-// TODO replace with an api endpoint that exposes idea town addon info
-const addonInfo = {
-  name: window.sadface.addon.name,
-  url: window.sadface.addon.url
-};
-
 export default BaseView.extend({
   _template: `<section class="page {{#loggedIn}} loggedIn {{/loggedIn}}">
                 {{^loggedIn}}
@@ -26,8 +20,8 @@ export default BaseView.extend({
               </section>`,
 
   render() {
-    this.loggedIn = !!app.me.session;
-    this.downloadUrl = addonInfo.url;
+    this.loggedIn = !!app.me.user.id;
+    this.downloadUrl = app.me.user.addon.url;
     BaseView.prototype.render.apply(this, arguments);
   }
 });

--- a/idea_town/frontend/templates/idea_town/frontend/index.html
+++ b/idea_town/frontend/templates/idea_town/frontend/index.html
@@ -21,21 +21,7 @@
   <!-- notification bar will pop down from the top of the screen -->
   <div id="notification-bar" hidden></div>
 
-  {# TODO: this fails csp and breaks if the html page is cached; use an api endpoint instead #}
-  <script>
-    'use strict';
-    window.sadface = {
-      csrfToken: '{{ csrf_token }}',
-      userId: '{{ user_id }}',
-      addon: {
-        name: 'Idea Town',
-        url: 'https://github.com/mozilla/idea-town-addon/blob/master/dist/idea-town-addon-0.0.1.xpi?raw=true'
-      }
-    };
-  </script>
-
   <script src="{{ static('app/app.js') }}"></script>
-
 
 </body>
 </html>

--- a/idea_town/settings.py
+++ b/idea_town/settings.py
@@ -19,6 +19,10 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 SITE_ID = 1
 
+ADDON_URL = config(
+    'ADDON_URL',
+    default='https://example.com/configure-your-addon-url')
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 

--- a/idea_town/urls.py
+++ b/idea_town/urls.py
@@ -4,11 +4,13 @@ from django.contrib import admin
 from rest_framework import routers
 
 from .experiments import views as experiment_views
+from .users import views as users_views
 from .metrics import views as metrics_view
 
 # Allow apps to contribute API parts
 router = routers.DefaultRouter(trailing_slash=False)
 experiment_views.register_views(router)
+users_views.register_views(router)
 
 urlpatterns = patterns(
     '',

--- a/idea_town/users/tests.py
+++ b/idea_town/users/tests.py
@@ -1,0 +1,90 @@
+from django.conf import settings
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from django.test import Client
+from django.contrib.auth.models import User
+
+from ..experiments.models import (Experiment, UserInstallation)
+
+import json
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class MeViewSetTests(TestCase):
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.username = 'johndoe'
+        cls.password = 'top_secret'
+        cls.email = '%s@example.com' % cls.username
+        cls.user = User.objects.create_user(
+            username=cls.username,
+            email=cls.email,
+            password=cls.password)
+
+        cls.experiments = dict((obj.slug, obj) for obj in (
+            Experiment.objects.create(**kwargs) for kwargs in (
+                dict(title='Test 1', slug='test-1', description='This is a test'),
+                dict(title='Test 2', slug='test-2', description='This is a test'),
+                dict(title='Test 3', slug='test-3', description='This is a test'),
+            )))
+
+        cls.addonData = {
+            'name': 'Idea Town',
+            'url': settings.ADDON_URL
+        }
+
+        cls.url = reverse('me-list')
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_anonymous(self):
+        resp = self.client.get(self.url)
+        data = json.loads(str(resp.content, encoding='utf8'))
+
+        self.assertEqual(len(data.keys()), 0)
+
+    def test_get_logged_in(self):
+        self.client.login(username=self.username,
+                          password=self.password)
+
+        resp = self.client.get(self.url)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                'id': self.email,
+                'addon': self.addonData,
+                'installed': []
+            }
+        )
+
+        UserInstallation.objects.create(
+            experiment=self.experiments['test-1'],
+            user=self.user
+        )
+
+        resp = self.client.get(self.url)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                'id': self.email,
+                'addon': self.addonData,
+                'installed': [
+                    {
+                        'id': 4,
+                        'description': 'This is a test',
+                        'details_url': 'http://testserver/api/experiments/4/details',
+                        'slug': 'test-1',
+                        'thumbnail': None,
+                        'title': 'Test 1',
+                        'url': 'http://testserver/api/experiments/4',
+                        'xpi_url': ''
+                    }
+                ]
+            }
+        )

--- a/idea_town/users/views.py
+++ b/idea_town/users/views.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+
+from ..experiments.models import (UserInstallation)
+from ..experiments.serializers import ExperimentSerializer
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class MeViewSet(ViewSet):
+    permission_classes = []
+
+    def list(self, request):
+
+        if not request.user.is_authenticated():
+            return Response({})
+
+        user = request.user
+
+        return Response({
+            "id": user.email,
+            "addon": {
+                "name": "Idea Town",
+                "url": settings.ADDON_URL
+            },
+            "installed": [
+                ExperimentSerializer(x.experiment,
+                                     context={'request': request}).data
+                for x in UserInstallation.objects.filter(user=user)
+            ]
+        })
+
+
+def register_views(router):
+    router.register(r'me', MeViewSet, base_name='me')

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "ampersand-state": "^4.5.6",
     "ampersand-view": "^8.0.1",
     "ampersand-view-switcher": "^2.0.0",
+    "es6-promise": "^3.0.2",
+    "isomorphic-fetch": "^2.1.1",
     "js-cookie": "^2.0.3",
     "lodash": "^3.10.1",
     "mozilla-tabzilla": "^0.4.0",
@@ -24,8 +26,7 @@
     "node-bourbon": "^4.2.3",
     "node-neat": "^1.7.2",
     "nodemon": "^1.4.1",
-    "normalize.css": "^3.0.3",
-    "xhr": "^2.0.4"
+    "normalize.css": "^3.0.3"
   },
   "devDependencies": {
     "babel": "^5.8.21",

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
 commands = make -C docs html
 
 [testenv:eslint]
-whitelist_externals = 
+whitelist_externals =
     node
     npm
 commands =


### PR DESCRIPTION
- Add /api/me API endpoint to expose data about the currently
  logged in user. (i.e. user ID, installed experiments)
- Add API, user, and addon props to overall Me model
- Move sadface JS data and some hardcoded URLs into index.html markup
- Frontend client tweaks to use the API
- Add .editorconfig to idea_town/frontend/static-src so my editor can do
  different indenting in Python & JS
- Tweak tox.ini to use python3.4
- Server-side tests
