### PR TITLE
Prevents JS error when unauthenticated.

### DIFF
--- a/idea_town/frontend/static-src/app/views/landing-page.js
+++ b/idea_town/frontend/static-src/app/views/landing-page.js
@@ -20,8 +20,9 @@ export default BaseView.extend({
               </section>`,
 
   render() {
-    this.loggedIn = !!app.me.user.id;
-    this.downloadUrl = app.me.user.addon.url;
+    const isLoggedIn = !!app.me.user.id;
+    this.loggedIn = isLoggedIn;
+    this.downloadUrl = isLoggedIn && app.me.user.addon.url;
     BaseView.prototype.render.apply(this, arguments);
   }
 });


### PR DESCRIPTION
`app.me.user` [is empty](https://github.com/mozilla/idea-town/blob/master/idea_town/users/views.py#L18-L19) when unauthenticated, so an attempt to access `app.me.user.addon` throws an error blocking page load when you haven't yet authenticated:

```
TypeError: _ampersandApp2.default.me.user.addon is undefined
```

This prevents the error and allows login by only setting `downloadUrl` when logged in.
