### PR TITLE
Hide Docker insanity behind a (mediocre) shell script

### DIFF
--- a/bin/docker-build.sh
+++ b/bin/docker-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This is an absolutely terrible shell script which should always
+# successfully rebuild the client image, and probably also always
+# emit confusing semi-meaningless error messages.
+
+docker-machine create -driver virtualbox default
+docker-machine start default
+eval "$(docker-machine env default)"
+docker rmi $(docker images -f dangling=true -q)
+npm install
+docker-compose build
+docker-compose up


### PR DESCRIPTION
Docker is a little bit of a rough ride. It might be nice to abstract away some of the most common papercuts behind some kind of a shell script.

I've created a really terrible first version of such a script below, in a classic open source nerdbait move: if you build it (badly), they will come (and make it better).

Thoughts? I'm not at all attached to using bash over python or javascript, just copied the commands that I most often use successfully and pasted them into this file.
