### PR TITLE
Fix #111: implement hover styles on experiment list

### DIFF
--- a/idea_town/frontend/static-src/app/templates/experiment-row-view.js
+++ b/idea_town/frontend/static-src/app/templates/experiment-row-view.js
@@ -1,10 +1,8 @@
 export default `
-  <li class="idea-card" data-hook="show-detail"
-    // toggle a class for styling purposes:
-    class="{{#isInstalled}} active {{/isInstalled}}">
-    <img width="200" height="200" src="{{thumbnail}}">
+  <li data-hook="show-detail" class="idea-card {{#isInstalled}} active {{/isInstalled}}">
+    <div class="idea-preview-image" style="background: url({{thumbnail}}) no-repeat"></div>
     <h2>{{title}}</h2>
-    <p>Status: {{^isInstalled}} Not {{/isInstalled}} Installed</p>
+    <p>{{description}}</p>
   </li>
 `;
 

--- a/idea_town/frontend/static-src/app/views/experiment-row-view.js
+++ b/idea_town/frontend/static-src/app/views/experiment-row-view.js
@@ -14,6 +14,7 @@ export default BaseView.extend({
     this.model.on('change:isInstalled', this.renderButton, this);
 
     this.title = this.model.title;
+    this.description = this.model.description;
     this.thumbnail = this.model.thumbnail;
     this.isInstalled = this.model.isInstalled;
   },

--- a/idea_town/frontend/static-src/styles/modules/_list-view.scss
+++ b/idea_town/frontend/static-src/styles/modules/_list-view.scss
@@ -75,7 +75,6 @@
 }
 
 .idea-preview-image {
-  background: $light;
   border-radius: 50%;
   flex: 0 0 172px;
   height: 172px;


### PR DESCRIPTION
@meandavejustice @lmorchard R? (@johngruen comments welcome, but you're probably asleep right now ^_^)

It seemed like the intent of the wires was to use CSS tricks to render thumbnail images as circular images, but the scratchpad site hacked around this by using round images.

We can't simply use an img here to create that effect, because replaced els don't work with pseudoclasses. Instead, use a div, with the ::before hacks seen on the scratchpad site, but set the div's background via inline style attribute, so that the JS templating code can insert the correct URL.

inactive:

<img width="337" alt="screenshot 2015-10-01 13 07 01" src="https://cloud.githubusercontent.com/assets/96396/10232596/70bd8e4c-683e-11e5-97a6-6b2f360508ea.png">

inactive hovered:

<img width="394" alt="screenshot 2015-10-01 13 07 05" src="https://cloud.githubusercontent.com/assets/96396/10232598/781d4b46-683e-11e5-9c23-f1ceddc3434f.png">

active:

<img width="404" alt="screenshot 2015-10-01 13 07 20" src="https://cloud.githubusercontent.com/assets/96396/10232603/83c65906-683e-11e5-92ce-5f430beb59c6.png">

active hovered:

<img width="370" alt="screenshot 2015-10-01 13 07 27" src="https://cloud.githubusercontent.com/assets/96396/10232609/89da0de2-683e-11e5-9344-2699b432fb81.png">
