### PR TITLE
Fix #114: Adjust placement of main-content class on landing page

### DIFF
--- a/idea_town/frontend/static-src/app/templates/landing-page.js
+++ b/idea_town/frontend/static-src/app/templates/landing-page.js
@@ -1,5 +1,5 @@
 export default `
-  <section class="page" data-hook="landing-page">
+  <section class="page main-content" data-hook="landing-page">
     {{^loggedIn}}
       <div class="firefox-logo"></div>
       <h1 class="hero">Introducing Idea Town</h1>

--- a/idea_town/frontend/templates/idea_town/frontend/index.html
+++ b/idea_town/frontend/templates/idea_town/frontend/index.html
@@ -6,14 +6,8 @@
     <link rel="stylesheet" href="{{ static('styles/main.css') }}">
 </head>
 <body>
-  <div class="main-content">
-    <header></header>
-    <div data-hook="page-container"></div>
-
-    <!-- absolutely-positioned, conditionally-displayed components at the bottom of the page -->
-    <!-- notification bar will pop down from the top of the screen -->
-    <div id="notification-bar" hidden></div>
-  </div>
+  <header></header>
+  <div data-hook="page-container"></div>
   <div id="main-footer" class="wash">
     <div class="wrapper">
       <a href="https://www.mozilla.org" class="moz-logo"></a>


### PR DESCRIPTION
r? @meandavejustice @lmorchard 

The landing page uses a main-content class on the outermost wrapper div to set a fixed width for header + body. The other pages have a full-width header, so in those cases, we don't want to fix the width.

I think the header needs to be managed by the page manager (#110), but in the meantime, this patch fixes the issue by moving the main-content class down to the topmost node rendered by the PageManager.

This patch introduces a very minor bug: the tabzilla position is slightly off. I suspect that moving the header into the control of the PageManager will fix this bug, since the header node will become a child of the page-container, and its width will again be set by the main-content class, not the viewport.

...and now it's time for the visual aids:

---

Here's the current 101-style branch without this patch applied:

Landing page. Note, tabzilla tab is in the right spot:
<img width="1349" alt="screenshot 2015-10-01 14 05 18" src="https://cloud.githubusercontent.com/assets/96396/10233795/98fb0a22-6845-11e5-9002-d11c86002165.png">

Home page. Note, header is weirdly truncated:
<img width="1349" alt="screenshot 2015-10-01 14 05 09" src="https://cloud.githubusercontent.com/assets/96396/10233805/a8411238-6845-11e5-9c81-050fba447446.png">

---

And here are screenshots of the fixes introduced by this patch:

Landing page. Note, tabzilla is shuffling off into the corner
<img width="1349" alt="screenshot 2015-10-01 14 04 48" src="https://cloud.githubusercontent.com/assets/96396/10233815/bc228fa2-6845-11e5-856d-18ce39a63680.png">

Home page, header looks nice
<img width="1349" alt="screenshot 2015-10-01 14 04 36" src="https://cloud.githubusercontent.com/assets/96396/10233819/c824b1ea-6845-11e5-9eb7-5985101bd031.png">
