### PR TITLE
Fix #113: Default avatar / fix gulpfile of linting errors

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,5 @@
 const autoprefixer = require('gulp-autoprefixer');
 const babelify = require('babelify');
-const bourbon = require('node-bourbon');
 const browserify = require('browserify');
 const buffer = require('vinyl-buffer');
 const cache = require('gulp-cache');
@@ -13,7 +12,6 @@ const gulpif = require('gulp-if');
 const gutil = require('gulp-util');
 const imagemin = require('gulp-imagemin');
 const minifycss = require('gulp-minify-css');
-const neat = require('node-neat');
 const normalize = require('node-normalize-scss');
 const rename = require('gulp-rename');
 const runSequence = require('run-sequence');

--- a/idea_town/experiments/views.py
+++ b/idea_town/experiments/views.py
@@ -2,7 +2,7 @@ from rest_framework import viewsets
 from rest_framework.decorators import detail_route
 from rest_framework.response import Response
 from .models import (Experiment, ExperimentDetail)
-from .serializers import (ExperimentSerializer, ExperimentDeepSerializer,
+from .serializers import (ExperimentDeepSerializer,
                           ExperimentDetailSerializer)
 
 import logging

--- a/idea_town/frontend/static-src/app/templates/header-view.js
+++ b/idea_town/frontend/static-src/app/templates/header-view.js
@@ -10,7 +10,7 @@ export default `
           </header>
           <div class="town-background"></div>
           <div id="avatar-wrapper">
-            <p>Logged in as {{session}} <button data-hook="logout">Log out</button>
+            <span class="default-avatar" data-hook="logout"></span>
           </div>
         </div>
       </div>

--- a/idea_town/frontend/static-src/styles/modules/_avatar.scss
+++ b/idea_town/frontend/static-src/styles/modules/_avatar.scss
@@ -1,10 +1,10 @@
 #avatar-wrapper {
   @include flex-container(default, center, center, nowrap, false);
-  border: 1px solid $white;
   border-radius: 50%;
   cursor: pointer;
   flex: 0 0 48px;
   height: 48px;
+  z-index: 2;
   
   .default-avatar {
     @include hidpi-background-image('default-avatar', 41px 41px);


### PR DESCRIPTION
- Got rid of white border around avatar.(not in mockups)
- click avatar to logout
- remove unused deps from `gulpfile` (they've been making the travis build fail)
- bump z-index of avatar so it's clickable fixes #112 
