### PR TITLE
Alternative docker-compose manifest that supports host-side Gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,19 @@ Idea Town is not intended to replace trains for most features, nor is it a test 
     docker-compose -f docker-compose-s3.yml build
     docker-compose -f docker-compose-s3.yml up
   ```
- 
+
+* If you'd like to run Gulp on your host computer because there are issues
+  running it in a Docker container, try this:
+  ```
+  docker-compose -f docker-compose-only-server.yml build
+  docker-compose -f docker-compose-only-server.yml up
+  ```
+  Then, in a second terminal, you can run Gulp like this (assuming you have
+  node.js installed locally):
+  ```
+  npm install
+  gulp
+  ```
 
 Testing
 -------------

--- a/docker-compose-only-server.yml
+++ b/docker-compose-only-server.yml
@@ -1,0 +1,8 @@
+db:
+  image: postgres:9.3
+server:
+  extends:
+    file: docker-compose-base.yml
+    service: server
+  links:
+    - db


### PR DESCRIPTION
Gulp-in-a-container seems to be going not as smoothly as I'd hoped. Here's an alternative that just runs the server and lets you run Gulp on the host without problems. It works like so:

```
docker-compose -f docker-compose-only-server.yml build
docker-compose -f docker-compose-only-server.yml up
```

That builds and runs just the Django server and Postgres, and skips setting up Gulp in a container. Then, you can do this on the host like usual:

```
npm install
gulp
```

If this works a lot better than the everything-in-Docker approach, maybe we back away from that and make this the `docker-compose.yml` replacement altogether.

@meandavejustice, you might like to try this out
