### PR TITLE
Fixes #105: router handling/multiple race conditions

### DIFF
--- a/idea_town/frontend/static-src/app/lib/router.js
+++ b/idea_town/frontend/static-src/app/lib/router.js
@@ -32,7 +32,7 @@ export default Router.extend({
     }
   },
 
-  // 'experiment' is a URL slug: for example, 'universal-search'
+  // 'experiment' is a URL slug: for example, 'universal_search'
   experimentDetail(experiment) {
     if (!app.me.user.id || !app.me.hasAddon) {
       this.redirectTo('');

--- a/idea_town/frontend/static-src/app/models/me.js
+++ b/idea_town/frontend/static-src/app/models/me.js
@@ -22,10 +22,18 @@ export default State.extend({
   },
 
   initialize() {
-    // note: when the server exposes addon info, these listeners can go away
-    app.on('webChannel:addon-available', () => { this.hasAddon = true; });
-    app.on('webChannel:addon-self:installed', () => { app.me.hasAddon = true; });
-    app.on('webChannel:addon-self:uninstalled', () => { app.me.hasAddon = false; });
+    app.on('webChannel:addon-available', () => {
+      if (!app.me.hasAddon) app.me.hasAddon = true;
+    });
+
+    app.on('webChannel:addon-self:installed', () => {
+      if (!app.me.hasAddon) app.me.hasAddon = true;
+    });
+
+    app.on('webChannel:addon-self:uninstalled', () => {
+      if (app.me.hasAddon) app.me.hasAddon = false;
+    });
+
     this.addonCheck();
   },
 

--- a/idea_town/frontend/static-src/app/views/base-view.js
+++ b/idea_town/frontend/static-src/app/views/base-view.js
@@ -7,6 +7,7 @@ import mustache from 'mustache';
 export default AmpersandView.extend({
   // override _template with a mustache template
   _template: '',
+
   template(ctx) {
     return mustache.render(this._template, ctx);
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ampersand-state": "^4.5.6",
     "ampersand-view": "^8.0.1",
     "ampersand-view-switcher": "^2.0.0",
+    "domready": "^1.0.8",
     "es6-promise": "^3.0.2",
     "isomorphic-fetch": "^2.1.1",
     "js-cookie": "^2.0.3",


### PR DESCRIPTION
fixes #105 #125 

There were some race conditions with the addon-status and experiments model.
- Addon status is now set as a variable `ideatownAddon` in the addon on `window.navigator`. This saves us a round trip to the server on hard refreshes [addon pr](https://github.com/mozilla/idea-town-addon/pull/31).
- There was a race condition where we could not navigate to an experiment detail page because the experiments collection was not populated. We now ensure that the collection is populated before calling `blastoff()`
