### PR TITLE
List user profile info for contributors on experiment detail page

### DIFF
--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -18,6 +18,8 @@ class ExperimentAdmin(admin.ModelAdmin):
 
     prepopulated_fields = {"slug": ("title",)}
 
+    raw_id_fields = ('contributors',)
+
     inlines = (ExperimentDetailInline,)
 
 

--- a/idea_town/experiments/migrations/0003_experiment_contributors.py
+++ b/idea_town/experiments/migrations/0003_experiment_contributors.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('experiments', '0002_auto_20150831_1658'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='contributors',
+            field=models.ManyToManyField(related_name='contributor', to=settings.AUTH_USER_MODEL),
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -17,6 +17,7 @@ class Experiment(models.Model):
     xpi_url = models.URLField()
 
     users = models.ManyToManyField(User, through='UserInstallation')
+    contributors = models.ManyToManyField(User, related_name='contributor')
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)

--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -1,7 +1,9 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test import Client
+from django.contrib.auth.models import User
 
+from ..users.models import UserProfile
 from .models import (Experiment)  # , ExperimentDetail, UserInstallation)
 
 import logging
@@ -10,20 +12,100 @@ logger = logging.getLogger(__name__)
 
 class ExperimentViewTests(TestCase):
 
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
+        cls.experiments = dict((obj.slug, obj) for (obj, created) in (
+            Experiment.objects.get_or_create(
+                slug="test-%s" % idx, defaults=dict(
+                    title="Test %s" % idx,
+                    description="This is a test"
+                )) for idx in range(1, 4)))
 
-        cls.experiments = dict((obj.slug, obj) for obj in (
-            Experiment.objects.create(**kwargs) for kwargs in (
-                dict(title="Test 1", slug="test-1", description="This is a test"),
-                dict(title="Test 2", slug="test-2", description="This is a test"),
-                dict(title="Test 3", slug="test-3", description="This is a test"),
-            )))
+        cls.users = dict((obj.username, obj) for obj in (
+            User.objects.create_user(
+                username='experimenttest-%s' % idx,
+                email='experimenttest-%s@example.com' % idx,
+                password='trustno%s' % idx
+            ) for idx in range(0, 5)))
 
     def setUp(self):
         self.client = Client()
 
     def test_index(self):
+        """Experiment list API resource should include all experiments"""
         url = reverse('experiment-list')
         resp = self.client.get(url)
-        logger.debug(resp.content)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                "count": 3,
+                "next": None,
+                "previous": None,
+                "results": sorted(
+                    ({
+                        "id": obj.pk,
+                        "url": "http://testserver/api/experiments/%s" %
+                               obj.pk,
+                        "title": obj.title,
+                        "slug": obj.slug,
+                        "thumbnail": None,
+                        "description": obj.description,
+                        "xpi_url": "",
+                        "details": [],
+                        "contributors": []
+                    } for (slug, obj) in self.experiments.items()),
+                    key=lambda x: x['id'])
+            }
+        )
+
+    def test_contributors(self):
+        """Experiment detail API resource should list contributor profiles"""
+        user_1 = self.users['experimenttest-1']
+        user_2 = self.users['experimenttest-2']
+
+        profile_1 = UserProfile.objects.get_profile(user_1)
+        profile_1.title = 'chief cat wrangler'
+        profile_1.display_name = 'jane doe'
+        profile_1.save()
+
+        profile_2 = UserProfile.objects.get_profile(user_2)
+        profile_2.title = 'assistant cat wrangler'
+        profile_2.display_name = 'john doe'
+        profile_2.save()
+
+        experiment = self.experiments['test-1']
+        experiment.contributors.add(user_1)
+        experiment.contributors.add(user_2)
+
+        url = reverse('experiment-detail', args=(experiment.pk,))
+        resp = self.client.get(url)
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                "id": experiment.pk,
+                "url": "http://testserver/api/experiments/%s" %
+                       experiment.pk,
+                "title": experiment.title,
+                "slug": experiment.slug,
+                "thumbnail": None,
+                "description": experiment.description,
+                "xpi_url": "",
+                "details": [],
+                "contributors": [
+                    {
+                        "username": user_1.username,
+                        "display_name": profile_1.display_name,
+                        "title": profile_1.title,
+                        "avatar": None
+                    },
+                    {
+                        "username": user_2.username,
+                        "display_name": profile_2.display_name,
+                        "title": profile_2.title,
+                        "avatar": None
+                    }
+                ]
+            }
+        )

--- a/idea_town/frontend/static-src/app/templates/experiment-page.js
+++ b/idea_town/frontend/static-src/app/templates/experiment-page.js
@@ -34,27 +34,24 @@ export default `
           <section>
             <h3>Brought to you by</h3>
             <ul class="contributors">
+              {{#model.contributors}}
               <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
+                <img src="{{avatar}}" width="56" height="56">
                 <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
+                  <p class="name">{{display_name}}</span>
+                  <p class="title">{{title}}</span>
                 </div>
               </li>
-              <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
-                <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
-                </div>
-              </li>
-              <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
-                <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
-                </div>
-              </li>
+              {{/model.contributors}}
+              {{^model.contributors}}
+                <!-- TODO: need a blank slate case for no contributors? -->
+                <li>
+                  <img src="images/default-avatar@2x.png" width="56" height="56">
+                  <div class="contributor">
+                    <p class="name">To be announced</span>
+                  </div>
+                </li>
+              {{/model.contributors}}
             </ul>
           </section>
           <section>

--- a/idea_town/settings.py
+++ b/idea_town/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'idea_town.base',
     'idea_town.frontend',
     'idea_town.accounts',
+    'idea_town.users',
     'idea_town.experiments',
 
     # Third party apps

--- a/idea_town/users/admin.py
+++ b/idea_town/users/admin.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+from .models import UserProfile
+from ..utils import show_image, parent_link
+
+
+class UserProfileAdmin(admin.ModelAdmin):
+    list_display = ('id', parent_link('user'), show_image('avatar'),
+                    'display_name', 'title', 'created', 'modified',)
+    raw_id_fields = ('user',)
+
+
+for x in ((UserProfile, UserProfileAdmin),):
+    admin.site.register(*x)

--- a/idea_town/users/migrations/0001_initial.py
+++ b/idea_town/users/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import idea_town.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserProfile',
+            fields=[
+                ('id', models.AutoField(primary_key=True, verbose_name='ID', serialize=False, auto_created=True)),
+                ('display_name', models.CharField(max_length=256, blank=True)),
+                ('title', models.CharField(max_length=256, blank=True)),
+                ('avatar', models.ImageField(blank=True, upload_to=idea_town.utils.HashedUploadTo('avatar'))),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, related_name='profile')),
+            ],
+        ),
+    ]

--- a/idea_town/users/models.py
+++ b/idea_town/users/models.py
@@ -1,0 +1,27 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+from ..utils import HashedUploadTo
+
+
+avatar_upload_to = HashedUploadTo('avatar')
+
+
+class UserProfileManager(models.Manager):
+
+    def get_profile(self, user):
+        """Get a profile for a user, creating a blank one if necessary"""
+        (profile, created) = self.get_or_create(user=user)
+        return profile
+
+
+class UserProfile(models.Model):
+    """Profile model for additional user details"""
+    objects = UserProfileManager()
+
+    user = models.OneToOneField(User, related_name='profile')
+    display_name = models.CharField(max_length=256, blank=True)
+    title = models.CharField(max_length=256, blank=True)
+    avatar = models.ImageField(upload_to=avatar_upload_to, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)

--- a/idea_town/users/serializers.py
+++ b/idea_town/users/serializers.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+
+from .models import UserProfile
+
+
+class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
+    username = serializers.SerializerMethodField()
+    display_name = serializers.SerializerMethodField()
+    avatar = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserProfile
+        fields = ('username', 'display_name', 'title', 'avatar',)
+
+    def get_username(self, obj):
+        return obj.user.username
+
+    def get_display_name(self, obj):
+        user = obj.user
+        # Could also use first/last name here, but it's a bad l10n assumption
+        if obj.display_name:
+            return obj.display_name
+        else:
+            return user.username
+
+    def get_avatar(self, obj):
+        if obj.avatar:
+            request = self.context['request']
+            return request.build_absolute_uri(obj.avatar.url)
+        else:
+            return None

--- a/idea_town/users/tests.py
+++ b/idea_town/users/tests.py
@@ -4,12 +4,55 @@ from django.test import TestCase
 from django.test import Client
 from django.contrib.auth.models import User
 
+from .models import UserProfile
 from ..experiments.models import (Experiment, UserInstallation)
 
 import json
 
 import logging
 logger = logging.getLogger(__name__)
+
+
+class UserProfileTests(TestCase):
+
+    maxDiff = None
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.username = 'johndoe2'
+        cls.password = 'trustno1'
+        cls.email = '%s@example.com' % cls.username
+
+        cls.user = User.objects.create_user(
+            username=cls.username,
+            email=cls.email,
+            password=cls.password)
+
+        UserProfile.objects.filter(user=cls.user).delete()
+
+    def test_get_profile_nonexistent(self):
+        """Profile should be created on first attempt to get"""
+
+        profiles_count = UserProfile.objects.filter(user=self.user).count()
+        self.assertEqual(0, profiles_count)
+
+        profile = UserProfile.objects.get_profile(self.user)
+        self.assertIsNotNone(profile)
+        self.assertEqual(self.user, profile.user)
+
+        profiles_count = UserProfile.objects.filter(user=self.user).count()
+        self.assertEqual(1, profiles_count)
+
+    def test_get_profile_exists(self):
+        """Existing profile should be returned on get"""
+        expected_title = 'chief cat wrangler'
+
+        expected_profile = UserProfile(user=self.user, title=expected_title)
+        expected_profile.save()
+
+        result_profile = UserProfile.objects.get_profile(user=self.user)
+        self.assertIsNotNone(result_profile)
+        self.assertEqual(expected_title, result_profile.title)
 
 
 class MeViewSetTests(TestCase):
@@ -26,12 +69,12 @@ class MeViewSetTests(TestCase):
             email=cls.email,
             password=cls.password)
 
-        cls.experiments = dict((obj.slug, obj) for obj in (
-            Experiment.objects.create(**kwargs) for kwargs in (
-                dict(title='Test 1', slug='test-1', description='This is a test'),
-                dict(title='Test 2', slug='test-2', description='This is a test'),
-                dict(title='Test 3', slug='test-3', description='This is a test'),
-            )))
+        cls.experiments = dict((obj.slug, obj) for (obj, created) in (
+            Experiment.objects.get_or_create(
+                slug="test-%s" % idx, defaults=dict(
+                    title="Test %s" % idx,
+                    description="This is a test"
+                )) for idx in range(1, 4)))
 
         cls.addonData = {
             'name': 'Idea Town',
@@ -76,13 +119,15 @@ class MeViewSetTests(TestCase):
                 'addon': self.addonData,
                 'installed': [
                     {
-                        'id': 4,
+                        'id': self.experiments['test-1'].pk,
                         'description': 'This is a test',
                         'details': [],
+                        'contributors': [],
                         'slug': 'test-1',
                         'thumbnail': None,
                         'title': 'Test 1',
-                        'url': 'http://testserver/api/experiments/4',
+                        'url': 'http://testserver/api/experiments/%s' %
+                                self.experiments['test-1'].pk,
                         'xpi_url': ''
                     }
                 ]


### PR DESCRIPTION
- Add UserProfile model, admin, and serializer
- Add `contributors` field to Experiment model, admin, and serializer
- Display user profile data for contributors on experiment detail page
- Migrations & tests

Closes #150
