### PR TITLE
Fix for FxA dev client credentials

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -29,7 +29,7 @@ server:
     - FXA_ACCESS_TOKEN_URL=https://oauth-stable.dev.lcip.org/v1/token
     - FXA_AUTHORIZE_URL=https://oauth-stable.dev.lcip.org/v1/authorization
     - FXA_PROFILE_URL=https://stable.dev.lcip.org/profile/v1/profile
-    - FXA_CLIENT_ID=a6cbfd1c48c97307
-    - FXA_SECRET_KEY=57a02718ead7e7186cb22ce329dddc1abf01ad63bdedd85868a4836da4b8204c
+    - FXA_CLIENT_ID=2e13dbd92f77f7df
+    - FXA_SECRET_KEY=a93644d71fa684da464fd2dba4d687c14cb21e1dd740af83895e70ede82f54cc
     - DATADOG_API_KEY=4f3b967bbf13c7769ac4fa89efda0fae
     - DATADOG_APP_KEY=ddd45a7b3a3cb90ff1baf20ae8cfab04d1937038


### PR DESCRIPTION
So, in PR #143, I accidentally changed the dev credentials for FxA to the ones I was using for my throwaway Elastic Beanstalk instance. But, you wouldn't notice until a complete rebuild of the Docker setup, when FxA gives you the wrong redirect on oauth login. This changes them back.
