### PR TITLE
Experiment metadata in sidebar

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -29,7 +29,7 @@ server:
     - FXA_ACCESS_TOKEN_URL=https://oauth-stable.dev.lcip.org/v1/token
     - FXA_AUTHORIZE_URL=https://oauth-stable.dev.lcip.org/v1/authorization
     - FXA_PROFILE_URL=https://stable.dev.lcip.org/profile/v1/profile
-    - FXA_CLIENT_ID=a6cbfd1c48c97307
-    - FXA_SECRET_KEY=57a02718ead7e7186cb22ce329dddc1abf01ad63bdedd85868a4836da4b8204c
+    - FXA_CLIENT_ID=2e13dbd92f77f7df
+    - FXA_SECRET_KEY=a93644d71fa684da464fd2dba4d687c14cb21e1dd740af83895e70ede82f54cc
     - DATADOG_API_KEY=4f3b967bbf13c7769ac4fa89efda0fae
     - DATADOG_APP_KEY=ddd45a7b3a3cb90ff1baf20ae8cfab04d1937038

--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -10,7 +10,7 @@ class ExperimentDetailInline(admin.TabularInline):
 
 class ExperimentAdmin(admin.ModelAdmin):
 
-    list_display = ('id', 'title', 'xpi_url',
+    list_display = ('id', 'title', 'version', 'xpi_url',
                     show_image('thumbnail'),
                     related_changelist_link('details'),
                     related_changelist_link('users'),

--- a/idea_town/experiments/migrations/0003_auto_20151021_1902.py
+++ b/idea_town/experiments/migrations/0003_auto_20151021_1902.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0002_auto_20150831_1658'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='changelog_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='contribute_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='version',
+            field=models.CharField(blank=True, max_length=128),
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -15,6 +15,9 @@ class Experiment(models.Model):
     thumbnail = models.ImageField(upload_to=experiment_thumbnail_upload_to)
     description = models.TextField()
     xpi_url = models.URLField()
+    version = models.CharField(blank=True, max_length=128)
+    changelog_url = models.URLField(blank=True)
+    contribute_url = models.URLField(blank=True)
 
     users = models.ManyToManyField(User, through='UserInstallation')
 

--- a/idea_town/experiments/serializers.py
+++ b/idea_town/experiments/serializers.py
@@ -24,4 +24,6 @@ class ExperimentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Experiment
         fields = ('id', 'url', 'title', 'slug', 'thumbnail', 'description',
+                  'version', 'changelog_url', 'contribute_url',
+                  'created', 'modified',
                   'xpi_url', 'details')

--- a/idea_town/frontend/static-src/app/templates/experiment-page.js
+++ b/idea_town/frontend/static-src/app/templates/experiment-page.js
@@ -60,17 +60,19 @@ export default `
           <section>
             <h3>Details</h3>
             <table class="stats">
+              {{#model.version}}
               <tr>
                 <td>Version</td>
-                <td>0.4.5 <a href="">changelog</a></td>
+                <td>{{model.version}}{{#model.changelog_url}} <a href="{{model.changelog_url}}">changelog</a>{{/model.changelog_url}}</td>
               </tr>
+              {{/model.version}}
               <tr>
                 <td>Last Update</td>
-                <td>10/22/15</td>
+                <td>{{modified_date}}</td>
               </tr>
               <tr>
-                <td>Repo</td>
-                <td><a href="">https://github.com/mozilla/snooze-tabs<a></td>
+                <td>Contribute</td>
+                <td><a href="{{model.contribute_url}}">{{model.contribute_url}}<a></td>
               </tr>
             </table>
           </section>

--- a/idea_town/frontend/static-src/app/views/experiment-page.js
+++ b/idea_town/frontend/static-src/app/views/experiment-page.js
@@ -24,6 +24,9 @@ export default PageView.extend({
     this.thumbnail = this.model.thumbnail;
     this.description = this.model.description;
 
+    this.modified_date = new Date(this.model.modified);
+    this.created_date = new Date(this.model.created);
+
     // TODO: let's not mess with body, if possible
     if (this.isInstalled) {
       document.body.classList.add('active');


### PR DESCRIPTION
- Add version, changelog_url, and contribute_url fields to Experiment
  model, admin, and serializer
- Display Experiment model content on detail page sidebar
- Test tweaks & migration

Closes #151
