### PR TITLE
Experiment detail page sidebar content management

### DIFF
--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -10,13 +10,15 @@ class ExperimentDetailInline(admin.TabularInline):
 
 class ExperimentAdmin(admin.ModelAdmin):
 
-    list_display = ('id', 'title', 'xpi_url',
+    list_display = ('id', 'title', 'version', 'xpi_url',
                     show_image('thumbnail'),
                     related_changelist_link('details'),
                     related_changelist_link('users'),
                     'created', 'modified',)
 
     prepopulated_fields = {"slug": ("title",)}
+
+    raw_id_fields = ('contributors',)
 
     inlines = (ExperimentDetailInline,)
 

--- a/idea_town/experiments/migrations/0003_auto_20151021_2102.py
+++ b/idea_town/experiments/migrations/0003_auto_20151021_2102.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import markupfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0002_auto_20150831_1658'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='contributors',
+            field=models.ManyToManyField(related_name='contributor', to=settings.AUTH_USER_MODEL),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='changelog_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='contribute_url',
+            field=models.URLField(blank=True),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='version',
+            field=models.CharField(blank=True, max_length=128),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='_measurements_rendered',
+            field=models.TextField(editable=False, default=''),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='measurements',
+            field=markupfield.fields.MarkupField(rendered_field=True, default='', default_markup_type='plain', blank=True),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='measurements_markup_type',
+            field=models.CharField(choices=[('', '--'), ('html', 'HTML'), ('plain', 'Plain'), ('markdown', 'Markdown'), ('restructuredtext', 'Restructured Text')], max_length=30, default='plain', blank=True),
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 
+from markupfield.fields import MarkupField
+
 from ..utils import HashedUploadTo
 
 
@@ -14,9 +16,14 @@ class Experiment(models.Model):
     slug = models.SlugField(max_length=128, unique=True, db_index=True)
     thumbnail = models.ImageField(upload_to=experiment_thumbnail_upload_to)
     description = models.TextField()
+    measurements = MarkupField(blank=True, default='', default_markup_type='plain')
     xpi_url = models.URLField()
+    version = models.CharField(blank=True, max_length=128)
+    changelog_url = models.URLField(blank=True)
+    contribute_url = models.URLField(blank=True)
 
     users = models.ManyToManyField(User, through='UserInstallation')
+    contributors = models.ManyToManyField(User, related_name='contributor')
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)

--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -1,7 +1,12 @@
+import json
+
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from django.test import Client
+from django.contrib.auth.models import User
+from rest_framework import fields
 
+from ..users.models import UserProfile
 from .models import (Experiment)  # , ExperimentDetail, UserInstallation)
 
 import logging
@@ -10,20 +15,101 @@ logger = logging.getLogger(__name__)
 
 class ExperimentViewTests(TestCase):
 
+    maxDiff = None
+
     @classmethod
     def setUpTestData(cls):
+        cls.experiments = dict((obj.slug, obj) for (obj, created) in (
+            Experiment.objects.get_or_create(
+                slug="test-%s" % idx, defaults=dict(
+                    title="Test %s" % idx,
+                    description="This is a test"
+                )) for idx in range(1, 4)))
 
-        cls.experiments = dict((obj.slug, obj) for obj in (
-            Experiment.objects.create(**kwargs) for kwargs in (
-                dict(title="Test 1", slug="test-1", description="This is a test"),
-                dict(title="Test 2", slug="test-2", description="This is a test"),
-                dict(title="Test 3", slug="test-3", description="This is a test"),
-            )))
+        cls.users = dict((obj.username, obj) for obj in (
+            User.objects.create_user(
+                username='experimenttest-%s' % idx,
+                email='experimenttest-%s@example.com' % idx,
+                password='trustno%s' % idx
+            ) for idx in range(0, 5)))
 
     def setUp(self):
         self.client = Client()
 
     def test_index(self):
+        """Experiment list API resource should include all experiments"""
         url = reverse('experiment-list')
         resp = self.client.get(url)
-        logger.debug(resp.content)
+        # HACK: Use a rest framework field to format dates as expected
+        date_field = fields.DateTimeField()
+        self.assertJSONEqual(
+            str(resp.content, encoding='utf8'),
+            {
+                "count": 3,
+                "next": None,
+                "previous": None,
+                "results": sorted(
+                    ({
+                        "id": experiment.pk,
+                        "url": "http://testserver/api/experiments/%s" %
+                               experiment.pk,
+                        "title": experiment.title,
+                        "slug": experiment.slug,
+                        "thumbnail": None,
+                        "description": experiment.description,
+                        "measurements": experiment.measurements.rendered,
+                        "version": experiment.version,
+                        "changelog_url": experiment.changelog_url,
+                        "contribute_url": experiment.contribute_url,
+                        "created": date_field.to_representation(
+                            experiment.created),
+                        "modified": date_field.to_representation(
+                            experiment.modified),
+                        "xpi_url": "",
+                        "details": [],
+                        "contributors": []
+                    } for (slug, experiment) in self.experiments.items()),
+                    key=lambda x: x['id'])
+            }
+        )
+
+    def test_contributors(self):
+        """Experiment detail API resource should list contributor profiles"""
+        users = [
+            self.users['experimenttest-1'],
+            self.users['experimenttest-2']
+        ]
+
+        profiles = [
+            UserProfile.objects.get_profile(users[0]),
+            UserProfile.objects.get_profile(users[1])
+        ]
+
+        profiles[0].title = 'chief cat wrangler'
+        profiles[0].display_name = 'jane doe'
+        profiles[0].save()
+
+        profiles[1].title = 'assistant cat wrangler'
+        profiles[1].display_name = 'john doe'
+        profiles[1].save()
+
+        experiment = self.experiments['test-1']
+        experiment.contributors.add(users[0])
+        experiment.contributors.add(users[1])
+
+        url = reverse('experiment-detail', args=(experiment.pk,))
+        resp = self.client.get(url)
+        result = json.loads(str(resp.content, encoding='utf8'))
+
+        contributors = result.get('contributors', None)
+        self.assertIsNotNone(contributors)
+
+        for idx in range(0, 2):
+            profile = profiles[idx]
+            user = users[idx]
+            contributor = contributors[idx]
+
+            self.assertEqual(contributor['username'], user.username)
+            self.assertEqual(contributor['display_name'], profile.display_name)
+            self.assertEqual(contributor['title'], profile.title)
+            self.assertEqual(contributor['avatar'], None)

--- a/idea_town/frontend/static-src/app/templates/experiment-page.js
+++ b/idea_town/frontend/static-src/app/templates/experiment-page.js
@@ -6,13 +6,13 @@ export default `
 
       <div class="details-header-wrapper">
         <div class="details-header">
-          <h1>{{title}}</h1>
+          <h1>{{model.title}}</h1>
           <div class="idea-controls">
             {{#isInstalled}}
-              <button data-hook="install" class="button primary">Enable {{title}}</button>
+              <button data-hook="install" class="button primary">Enable {{model.title}}</button>
             {{/isInstalled}}
             {{^isInstalled}}
-              <button data-hook="uninstall" class="button primary">Disable {{title}}</button>
+              <button data-hook="uninstall" class="button primary">Disable {{model.title}}</button>
             {{/isInstalled}}
             <div class="user-count">7,654,321</div>
           </div>
@@ -21,69 +21,66 @@ export default `
 
       <div class="details-content">
         <div class="details-overview">
-          <img src="{{thumbnail}}" width="260">
-          <section>
+          <img src="{{model.thumbnail}}" width="260">
+          {{#model.measurements}}
+          <section class="measurement">
             <h3>Measurements</h3>
-            <p class="disclaimer">All data is collected anonymously and used only to help us improve this test. <a href="">Learn more.</a></p>
-            <ul class="measurement">
-              <li>Usage per session</li>
-              <li>Index of selected results</li>
-              <li>Time spent searching</li>
-            </ul>
+            <p class="disclaimer">All data is collected anonymously and used only to help us improve this test.</p>
+            {{{model.measurements}}}
           </section>
+          {{/model.measurements}}
           <section>
             <h3>Brought to you by</h3>
             <ul class="contributors">
+              {{#model.contributors}}
               <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
+                <img src="{{avatar}}" width="56" height="56">
                 <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
+                  <p class="name">{{display_name}}</span>
+                  <p class="title">{{title}}</span>
                 </div>
               </li>
-              <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
-                <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
-                </div>
-              </li>
-              <li>
-                <img src="images/default-avatar@2x.png" width="56" height="56">
-                <div class="contributor">
-                  <p class="name">Chris P. Bacon</span>
-                  <p class="title">Senior Strategy Dingus</span>
-                </div>
-              </li>
+              {{/model.contributors}}
+              {{^model.contributors}}
+                <!-- TODO: need a blank slate case for no contributors? -->
+                <li>
+                  <img src="images/default-avatar@2x.png" width="56" height="56">
+                  <div class="contributor">
+                    <p class="name">To be announced</span>
+                  </div>
+                </li>
+              {{/model.contributors}}
             </ul>
           </section>
           <section>
             <h3>Details</h3>
             <table class="stats">
+              {{#model.version}}
               <tr>
                 <td>Version</td>
-                <td>0.4.5 <a href="">changelog</a></td>
+                <td>{{model.version}}{{#model.changelog_url}} <a href="{{model.changelog_url}}">changelog</a>{{/model.changelog_url}}</td>
               </tr>
+              {{/model.version}}
               <tr>
                 <td>Last Update</td>
-                <td>10/22/15</td>
+                <td>{{modified_date}}</td>
               </tr>
               <tr>
-                <td>Repo</td>
-                <td><a href="">https://github.com/mozilla/snooze-tabs<a></td>
+                <td>Contribute</td>
+                <td><a href="{{model.contribute_url}}">{{model.contribute_url}}<a></td>
               </tr>
             </table>
           </section>
         </div>
 
         <div class="details-description">
-          <p class="copy">{{description}}
-          {{#details}}
+          <p class="copy">{{model.description}}
+          {{#model.details}}
             <div class="details-image">
               <img src="{{image}}" width="680">
               <p class="caption"><strong>{{headline}}</strong> {{copy}}</p>
             </div>
-          {{/details}}
+          {{/model.details}}
         </div>
       </div>
     </div>

--- a/idea_town/frontend/static-src/app/views/experiment-page.js
+++ b/idea_town/frontend/static-src/app/views/experiment-page.js
@@ -18,11 +18,9 @@ export default PageView.extend({
   },
 
   render() {
-    this.title = this.model.title;
     this.isInstalled = !!this.model.isInstalled;
-    this.details = this.model.details;
-    this.thumbnail = this.model.thumbnail;
-    this.description = this.model.description;
+    this.modified_date = new Date(this.model.modified);
+    this.created_date = new Date(this.model.created);
 
     // TODO: let's not mess with body, if possible
     if (this.isInstalled) {

--- a/idea_town/frontend/static-src/styles/modules/_idea-view.scss
+++ b/idea_town/frontend/static-src/styles/modules/_idea-view.scss
@@ -98,11 +98,11 @@
 }
 
 .disclaimer {
-  font-size: 12px; 
+  font-size: 12px;
   margin-bottom: 18px;
 }
 
-.measurement {
+.measurement ul {
   list-style: none;
   margin: 0;
   padding: 0;
@@ -119,7 +119,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
-   
+
   li {
     @include flex-container(default, left, center, nowrap, false);
     padding-bottom: 10px;

--- a/idea_town/settings.py
+++ b/idea_town/settings.py
@@ -46,6 +46,7 @@ INSTALLED_APPS = [
     'idea_town.base',
     'idea_town.frontend',
     'idea_town.accounts',
+    'idea_town.users',
     'idea_town.experiments',
 
     # Third party apps
@@ -54,6 +55,7 @@ INSTALLED_APPS = [
 
     'rest_framework',
     'storages',
+    'markupfield',
 
     # FxA auth handling
     'allauth',

--- a/idea_town/users/admin.py
+++ b/idea_town/users/admin.py
@@ -1,0 +1,14 @@
+from django.contrib import admin
+
+from .models import UserProfile
+from ..utils import show_image, parent_link
+
+
+class UserProfileAdmin(admin.ModelAdmin):
+    list_display = ('id', parent_link('user'), show_image('avatar'),
+                    'display_name', 'title', 'created', 'modified',)
+    raw_id_fields = ('user',)
+
+
+for x in ((UserProfile, UserProfileAdmin),):
+    admin.site.register(*x)

--- a/idea_town/users/migrations/0001_initial.py
+++ b/idea_town/users/migrations/0001_initial.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+import idea_town.utils
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserProfile',
+            fields=[
+                ('id', models.AutoField(primary_key=True, verbose_name='ID', serialize=False, auto_created=True)),
+                ('display_name', models.CharField(max_length=256, blank=True)),
+                ('title', models.CharField(max_length=256, blank=True)),
+                ('avatar', models.ImageField(blank=True, upload_to=idea_town.utils.HashedUploadTo('avatar'))),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('user', models.OneToOneField(to=settings.AUTH_USER_MODEL, related_name='profile')),
+            ],
+        ),
+    ]

--- a/idea_town/users/models.py
+++ b/idea_town/users/models.py
@@ -1,0 +1,27 @@
+from django.db import models
+from django.contrib.auth.models import User
+
+from ..utils import HashedUploadTo
+
+
+avatar_upload_to = HashedUploadTo('avatar')
+
+
+class UserProfileManager(models.Manager):
+
+    def get_profile(self, user):
+        """Get a profile for a user, creating a blank one if necessary"""
+        (profile, created) = self.get_or_create(user=user)
+        return profile
+
+
+class UserProfile(models.Model):
+    """Profile model for additional user details"""
+    objects = UserProfileManager()
+
+    user = models.OneToOneField(User, related_name='profile')
+    display_name = models.CharField(max_length=256, blank=True)
+    title = models.CharField(max_length=256, blank=True)
+    avatar = models.ImageField(upload_to=avatar_upload_to, blank=True)
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)

--- a/idea_town/users/serializers.py
+++ b/idea_town/users/serializers.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+
+from .models import UserProfile
+
+
+class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
+    username = serializers.SerializerMethodField()
+    display_name = serializers.SerializerMethodField()
+    avatar = serializers.SerializerMethodField()
+
+    class Meta:
+        model = UserProfile
+        fields = ('username', 'display_name', 'title', 'avatar',)
+
+    def get_username(self, obj):
+        return obj.user.username
+
+    def get_display_name(self, obj):
+        user = obj.user
+        # Could also use first/last name here, but it's a bad l10n assumption
+        if obj.display_name:
+            return obj.display_name
+        else:
+            return user.username
+
+    def get_avatar(self, obj):
+        if obj.avatar:
+            request = self.context['request']
+            return request.build_absolute_uri(obj.avatar.url)
+        else:
+            return None

--- a/idea_town/utils.py
+++ b/idea_town/utils.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.utils.deconstruct import deconstructible
 from django.core.urlresolvers import reverse
 
+from rest_framework import serializers
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -14,6 +16,18 @@ logger = logging.getLogger(__name__)
 MK_UPLOAD_TMPL = getattr(
     settings, 'MK_UPLOAD_TMPL',
     '%(base)s/%(h1)s/%(h2)s/%(hash)s_%(field_fn)s_%(now)s_%(rand)04d%(ext)s')
+
+
+class MarkupField(serializers.Field):
+    """Serializer for django-markupfield MarkupField"""
+
+    def to_internal_value(self, value):
+        # TODO: This needs implementation if we do a writeable API that accepts
+        # measurement field changes
+        pass
+
+    def to_representation(self, value):
+        return value.rendered
 
 
 @deconstructible

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,3 +155,6 @@ boto==2.38.0
 
 # sha256: 3gT6WE26Z7tSel6olB0v9HEoXLD5d8hjRP8oJ8OZgeI
 django-storages-redux==1.3
+
+# sha256: Wce1-qdV928OJHIHUNTPCheKWQoZ-NhRLTW7Pmtbhkc
+django-markupfield==1.3.5


### PR DESCRIPTION
- Add measurements sidebar module as editable content field on experiments
- Display user profile data for contributors on experiment detail page
- Display Experiment model content on detail page sidebar
- Add UserProfile model, admin, and serializer
- Add `contributors` field to Experiment model, admin, and serializer
- Add version, changelog_url, and contribute_url fields to Experiment
  model, admin, and serializer
- Migrations & tests

Closes #150, #151, #152
