### PR TITLE
Disable npm spinner to clean up Travis logs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ whitelist_externals =
 commands =
     npm config set spin false 
     npm install
-    npm run lint
+    node ./node_modules/gulp/bin/gulp.js lint

--- a/tox.ini
+++ b/tox.ini
@@ -34,5 +34,6 @@ whitelist_externals =
     node
     npm
 commands =
+    npm config set spin false 
     npm install
-    node ./node_modules/gulp/bin/gulp.js lint
+    npm run lint


### PR DESCRIPTION
Noticed a bunch of stray "\" and "|" type characters in the npm install log. Hopefully this fixes that.

Copied "npm run lint" shortcut from https://github.com/mozilla/idea-town/pull/183/files
