### PR TITLE
Expand frontend check to include full build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     - TOX_ENV=flake8
     - TOX_ENV=docs
     - TOX_ENV=tests
-    - TOX_ENV=eslint
+    - TOX_ENV=frontend
     - TOX_ENV=addon
 script:
   - tox -e $TOX_ENV

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = tests, flake8, docs, eslint, addon
+envlist = tests, flake8, docs, frontend, addon
 
 [testenv]
 basepython = python3
@@ -29,14 +29,14 @@ deps =
     sphinx-autobuild
 commands = make -C docs html
 
-[testenv:eslint]
+[testenv:frontend]
 whitelist_externals =
     node
     npm
 commands =
     npm config set spin false
     npm install
-    node ./node_modules/gulp/bin/gulp.js lint
+    node ./node_modules/gulp/bin/gulp.js build
 
 [testenv:addon]
 changedir = addon


### PR DESCRIPTION
Turns out that just linting the JS doesn't reveal some issues that arise
from a full build. So, let's do a throwaway build as a check in Travis.

Also, include JS linting as a required step before building.
