### PR TITLE
Use a Gravatar for user avatar by default

### DIFF
--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -6,6 +6,7 @@ from django.test import Client
 from django.contrib.auth.models import User
 from rest_framework import fields
 
+from ..utils import gravatar_url
 from ..users.models import UserProfile
 from .models import (Experiment)  # , ExperimentDetail, UserInstallation)
 
@@ -114,4 +115,5 @@ class ExperimentViewTests(TestCase):
             self.assertEqual(contributor['username'], user.username)
             self.assertEqual(contributor['display_name'], profile.display_name)
             self.assertEqual(contributor['title'], profile.title)
-            self.assertEqual(contributor['avatar'], None)
+
+            self.assertEqual(contributor['avatar'], gravatar_url(user.email))

--- a/idea_town/users/admin.py
+++ b/idea_town/users/admin.py
@@ -1,11 +1,11 @@
 from django.contrib import admin
 
 from .models import UserProfile
-from ..utils import show_image, parent_link
+from ..utils import show_avatar, parent_link
 
 
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ('id', parent_link('user'), show_image('avatar'),
+    list_display = ('id', parent_link('user'), show_avatar('avatar'),
                     'display_name', 'title', 'created', 'modified',)
     raw_id_fields = ('user',)
 

--- a/idea_town/users/serializers.py
+++ b/idea_town/users/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from ..utils import gravatar_url
+
 from .models import UserProfile
 
 
@@ -27,5 +29,7 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
         if obj.avatar:
             request = self.context['request']
             return request.build_absolute_uri(obj.avatar.url)
+        elif obj.user.email:
+            return gravatar_url(obj.user.email)
         else:
             return None

--- a/idea_town/users/views.py
+++ b/idea_town/users/views.py
@@ -5,6 +5,8 @@ from rest_framework.response import Response
 
 from ..experiments.models import (UserInstallation)
 from ..experiments.serializers import ExperimentSerializer
+from .models import UserProfile
+from .serializers import UserProfileSerializer
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,9 +21,12 @@ class MeViewSet(ViewSet):
             return Response({})
 
         user = request.user
+        profile = UserProfile.objects.get_profile(user)
 
         return Response({
             "id": user.email,
+            "profile": UserProfileSerializer(profile,
+                                             context={'request': request}).data,
             "addon": {
                 "name": "Idea Town",
                 "url": settings.ADDON_URL

--- a/idea_town/utils.py
+++ b/idea_town/utils.py
@@ -66,6 +66,31 @@ def show_image(field_name, height="50"):
     return show_image_display
 
 
+def gravatar_url(email, size="64"):
+    email_hash = hashlib.md5(bytes(email, 'utf-8')).hexdigest()
+    return '//www.gravatar.com/avatar/%s?s=%s' % (email_hash, size)
+
+
+def show_avatar(field_name, height="50"):
+    """Helper to show images in admin changelist views"""
+
+    def show_avatar_display(obj):
+        if not hasattr(obj, field_name):
+            return 'None'
+        avatar_path = getattr(obj, field_name)
+        if avatar_path:
+            img_url = "%s%s" % (settings.MEDIA_URL, avatar_path)
+        elif hasattr(obj, 'user'):
+            img_url = gravatar_url(obj.user.email)
+        return ('<a href="%s" target="_new"><img src="%s" height="%s" /></a>' %
+                (img_url, img_url, height))
+
+    show_avatar_display.allow_tags = True
+    show_avatar_display.short_description = field_name
+
+    return show_avatar_display
+
+
 def parent_link(field_name):
     """Helper to link to parent model in admin changelists"""
 


### PR DESCRIPTION
- Add Gravatar URL as fallback for avatar in UserProfile serializer
- Add UserProfile data to /api/me resource
- Add avatar to admin
- Add gravatar_url() utility function
- Tweaks to tests
