### PR TITLE
Use a Gravatar for user avatar by default

### DIFF
--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -6,6 +6,7 @@ from django.test import Client
 from django.contrib.auth.models import User
 from rest_framework import fields
 
+from ..utils import gravatar_url
 from ..users.models import UserProfile
 from .models import (Experiment)  # , ExperimentDetail, UserInstallation)
 
@@ -114,4 +115,5 @@ class ExperimentViewTests(TestCase):
             self.assertEqual(contributor['username'], user.username)
             self.assertEqual(contributor['display_name'], profile.display_name)
             self.assertEqual(contributor['title'], profile.title)
-            self.assertEqual(contributor['avatar'], None)
+
+            self.assertEqual(contributor['avatar'], gravatar_url(user.email))

--- a/idea_town/frontend/static-src/app/templates/experiment-page.js
+++ b/idea_town/frontend/static-src/app/templates/experiment-page.js
@@ -35,7 +35,7 @@ export default `
               <ul class="contributors">
                 {{#model.contributors}}
                 <li>
-                  <img src="{{avatar}}" width="56" height="56">
+                  <img class="avatar" src="{{avatar}}" width="56" height="56">
                   <div class="contributor">
                     <p class="name">{{display_name}}</span>
                     <p class="title">{{title}}</span>

--- a/idea_town/frontend/static-src/app/templates/header-view.js
+++ b/idea_town/frontend/static-src/app/templates/header-view.js
@@ -10,7 +10,12 @@ export default `
           </header>
           <div class="town-background"></div>
           <div id="avatar-wrapper">
-            <span class="default-avatar" data-hook="logout"></span>
+            {{#avatar}}
+              <img class="avatar" src="{{avatar}}" width="41" height="41" data-hook="logout">
+            {{/avatar}}
+            {{^avatar}}
+              <span class="default-avatar" data-hook="logout"></span>
+            {{/avatar}}
           </div>
         </div>
       </div>

--- a/idea_town/frontend/static-src/app/templates/scroll-header-view.js
+++ b/idea_town/frontend/static-src/app/templates/scroll-header-view.js
@@ -8,7 +8,12 @@ export default `
         </header>
         {{^scrolled}}
           <div id="avatar-wrapper">
-            <span class="default-avatar" data-hook="logout"></span>
+            {{#avatar}}
+              <img class="avatar" src="{{avatar}}" width="41" height="41" data-hook="logout">
+            {{/avatar}}
+            {{^avatar}}
+              <span class="default-avatar" data-hook="logout"></span>
+            {{/avatar}}
           </div>
         {{/scrolled}}
         {{#scrolled}}

--- a/idea_town/frontend/static-src/app/views/header-view.js
+++ b/idea_town/frontend/static-src/app/views/header-view.js
@@ -41,6 +41,7 @@ export default BaseView.extend({
 
     // an active user has an addon and a session
     this.activeUser = !!this.session && app.me.hasAddon;
+    this.avatar = !!this.session && app.me.user.profile.avatar;
 
     if (this.model) {
       this.title = this.model.title;

--- a/idea_town/frontend/static-src/styles/modules/_avatar.scss
+++ b/idea_town/frontend/static-src/styles/modules/_avatar.scss
@@ -5,10 +5,14 @@
   flex: 0 0 48px;
   height: 48px;
   z-index: 2;
-  
+
   .default-avatar {
     @include hidpi-background-image('default-avatar', 41px 41px);
     flex: 0 0 41px;
     height: 41px;
   }
+}
+
+img.avatar {
+  border-radius: 50%;
 }

--- a/idea_town/users/admin.py
+++ b/idea_town/users/admin.py
@@ -1,11 +1,11 @@
 from django.contrib import admin
 
 from .models import UserProfile
-from ..utils import show_image, parent_link
+from ..utils import show_avatar, parent_link
 
 
 class UserProfileAdmin(admin.ModelAdmin):
-    list_display = ('id', parent_link('user'), show_image('avatar'),
+    list_display = ('id', parent_link('user'), show_avatar('avatar'),
                     'display_name', 'title', 'invite_pending',
                     'created', 'modified',)
     list_filter = ('invite_pending',)

--- a/idea_town/users/serializers.py
+++ b/idea_town/users/serializers.py
@@ -1,5 +1,7 @@
 from rest_framework import serializers
 
+from ..utils import gravatar_url
+
 from .models import UserProfile
 
 
@@ -27,5 +29,7 @@ class UserProfileSerializer(serializers.HyperlinkedModelSerializer):
         if obj.avatar:
             request = self.context['request']
             return request.build_absolute_uri(obj.avatar.url)
+        elif obj.user.email:
+            return gravatar_url(obj.user.email)
         else:
             return None

--- a/idea_town/users/views.py
+++ b/idea_town/users/views.py
@@ -5,6 +5,8 @@ from rest_framework.response import Response
 
 from ..experiments.models import (UserInstallation)
 from ..experiments.serializers import ExperimentSerializer
+from .models import UserProfile
+from .serializers import UserProfileSerializer
 
 import logging
 logger = logging.getLogger(__name__)
@@ -19,9 +21,12 @@ class MeViewSet(ViewSet):
             return Response({})
 
         user = request.user
+        profile = UserProfile.objects.get_profile(user)
 
         return Response({
             "id": user.email,
+            "profile": UserProfileSerializer(profile,
+                                             context={'request': request}).data,
             "addon": {
                 "name": "Idea Town",
                 "url": settings.ADDON_URL

--- a/idea_town/utils.py
+++ b/idea_town/utils.py
@@ -66,6 +66,31 @@ def show_image(field_name, height="50"):
     return show_image_display
 
 
+def gravatar_url(email, size="64"):
+    email_hash = hashlib.md5(bytes(email, 'utf-8')).hexdigest()
+    return '//www.gravatar.com/avatar/%s?s=%s' % (email_hash, size)
+
+
+def show_avatar(field_name, height="50"):
+    """Helper to show images in admin changelist views"""
+
+    def show_avatar_display(obj):
+        if not hasattr(obj, field_name):
+            return 'None'
+        avatar_path = getattr(obj, field_name)
+        if avatar_path:
+            img_url = "%s%s" % (settings.MEDIA_URL, avatar_path)
+        elif hasattr(obj, 'user'):
+            img_url = gravatar_url(obj.user.email)
+        return ('<a href="%s" target="_new"><img src="%s" height="%s" /></a>' %
+                (img_url, img_url, height))
+
+    show_avatar_display.allow_tags = True
+    show_avatar_display.short_description = field_name
+
+    return show_avatar_display
+
+
 def parent_link(field_name):
     """Helper to link to parent model in admin changelists"""
 


### PR DESCRIPTION
- Use profile avatar in header view
- Add UserProfile data to /api/me resource
- Add Gravatar URL as fallback for avatar in UserProfile serializer
- Add avatar to admin
- Add gravatar_url() utility function
- Tweaks to tests
