### PR TITLE
Track per-client experiment installations

### DIFF
--- a/addon-api/ping-server.js
+++ b/addon-api/ping-server.js
@@ -10,6 +10,7 @@ const getCookiesFromHost = require('./cookie-manager');
 function pingServer(config, title, data, addon) {
   getCookiesFromHost(config.HOSTNAME, function(cookies) {
     const headers = {'Cookie': '',
+                     'Accept': 'application/json',
                      'Content-Type': 'application/json'};
     cookies.forEach(function(c) {
       headers.Cookie += c.name + '=' + c.value + ';';
@@ -29,7 +30,7 @@ function pingServer(config, title, data, addon) {
         content: JSON.stringify(formatEvent(config.IDEATOWN_PREFIX, title, id, data, addon)),
         headers: headers,
         onComplete: function(resp) {
-          console.error(resp);
+          // console.error(resp);
         }
       }).post();
     });

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,8 +5,9 @@
  */
 
 let app;
+
 const store = require('sdk/simple-storage').storage;
-const {Cu} = require('chrome');
+const {Cc, Ci, Cu} = require('chrome');
 const self = require('sdk/self');
 const tabs = require('sdk/tabs');
 const {PageMod} = require('sdk/page-mod');
@@ -14,7 +15,10 @@ const {ActionButton} = require('sdk/ui/button/action');
 const request = require('sdk/request').Request;
 const AddonManager = Cu.import('resource://gre/modules/AddonManager.jsm').AddonManager;
 const prefs = require('sdk/simple-prefs').prefs;
+const URL = require('sdk/url').URL;
 const Router = require('./route');
+const cookieManager2 = Cc['@mozilla.org/cookiemanager;1']
+                       .getService(Ci.nsICookieManager2);
 
 const mod = new PageMod({
   include: prefs.ALLOWED_ORIGINS.split(','),
@@ -24,26 +28,19 @@ const mod = new PageMod({
   onAttach: setupApp
 });
 
-if (!store.experiments) {
-  store.experiments = {};
-}
-
-if (!store.availableExperiments) {
-  store.availableExperiments = [];
+if (!store.clientUUID) {
+  store.clientUUID = generateUUID();
 }
 
 require('sdk/system/unload').when(function(reason) {
   if (reason === 'uninstall') {
     app.send('addon-self:uninstalled');
-    if (store.experiments) {
-      for (let ex in store.experiments) { // eslint-disable-line prefer-const
-        if (store.experiments.hasOwnProperty(ex)) {
-          uninstall({addon_id: ex});
-        }
+    if (store.installedAddons) {
+      for (let id of store.installedAddons) { // eslint-disable-line prefer-const
+        uninstallExperiment({addon_id: id});
       }
-      delete store.experiments;
+      delete store.installedAddons;
     }
-
     delete store.availableExperiments;
   }
 });
@@ -61,86 +58,88 @@ ActionButton({ // eslint-disable-line new-cap
   }
 });
 
-function getInstalledAddons(cb) {
-  request({
-    url: prefs.BASE_URL + '/api/experiments?format=json',
-    onComplete: res => {
-      if (!res.json.results.length || res.error) {
-        console.error('No experiments:: ', res);
-      }
-
-      store.availableExperiments = res.json.results.map(exp => {
-        return exp.addon_id;
-      });
-
-      AddonManager.getAllAddons(addons => {
-        addons.forEach(ex => {
-          if (isIdeatownAddon(ex.id)) {
-            store.experiments[ex.id] = ex.version;
-          }
-        });
-
-        // send back to client as an array
-        const installed = [];
-        for (let ex in store.experiments) { // eslint-disable-line prefer-const
-          if (store.experiments.hasOwnProperty(ex)) {
-            installed.push({
-              id: ex,
-              version: store.experiments[ex]
-            });
-          }
-        }
-
-        cb(installed);
-      });
-    }
-  }).get();
-}
-
 function setupApp() {
-  app = new Router(mod);
+  updateExperiments().then(() => {
+    app = new Router(mod);
 
-  if (self.loadReason === 'install') {
-    app.send('addon-self:installed');
-  } else if (self.loadReason === 'enable') {
-    app.send('addon-self:enabled');
-  } else if (self.loadReason === 'upgrade') {
-    app.send('addon-self:upgraded');
-  }
+    app.on('install-experiment', installExperiment);
 
-  app.on('install-experiment', function(msg) {
-    installExperiment(msg);
-  });
+    app.on('uninstall-experiment', uninstallExperiment);
 
-  app.on('uninstall-experiment', function(msg) {
-    uninstall(msg);
-  });
-
-  app.on('uninstall-all', function() {
-    for (let ex in store.experiments) { // eslint-disable-line prefer-const
-      if (store.experiments.hasOwnProperty(ex)) {
-        uninstall({addon_id: ex});
+    app.on('uninstall-all', function() {
+      for (let id of store.installedAddons) { // eslint-disable-line prefer-const
+        uninstallExperiment({addon_id: id});
       }
-    }
-  });
+    });
 
-  app.on('loaded', function() {
-    getInstalledAddons(addons => {
-      app.send('addon-available', {
-        installed: addons
+    app.on('sync-installed', serverInstalled => {
+      syncAllAddonInstallations(serverInstalled).then(() => {
+        app.send('sync-installed-result', {
+          clientUUID: store.clientUUID,
+          installed: store.installedAddons
+        });
       });
     });
+
+    if (self.loadReason === 'install') {
+      app.send('addon-self:installed');
+    } else if (self.loadReason === 'enable') {
+      app.send('addon-self:enabled');
+    } else if (self.loadReason === 'upgrade') {
+      app.send('addon-self:upgraded');
+    }
   });
 }
 
-function uninstall(experiment) {
-  if (isIdeatownAddon(experiment.addon_id)) {
+function updateExperiments() {
+  // Fetch the list of available experiments
+  return requestAPI({
+    url: prefs.BASE_URL + '/api/experiments'
+  }).then(res => {
+    // Index the available experiments by addon ID
+    store.availableExperiments = {};
+    res.json.results.forEach(exp => {
+      store.availableExperiments[exp.addon_id] = exp;
+    });
+
+    // Query all installed addons
+    return new Promise(resolve => AddonManager.getAllAddons(resolve));
+  }).then(addons => {
+    // Filter addons by known experiments, index by ID
+    store.installedAddons = {};
+    addons.filter(addon => isIdeatownAddonID(addon.id))
+          .forEach(addon => store.installedAddons[addon.id] = addon);
+    return store.installedAddons;
+  });
+}
+
+function syncAllAddonInstallations(serverInstalled) {
+  const availableIDs = Object.keys(store.availableExperiments);
+  const clientIDs = Object.keys(store.installedAddons);
+  const serverIDs = serverInstalled
+    .filter(item => item.client_id === store.clientUUID)
+    .map(item => item.addon_id);
+
+  return Promise.all(availableIDs.filter(id => {
+    const cidx = clientIDs.indexOf(id);
+    const sidx = serverIDs.indexOf(id);
+    // Both missing? Okay.
+    if (cidx === -1 && sidx === -1) { return false; }
+    // Both found? Okay.
+    if (cidx !== -1 && sidx !== -1) { return false; }
+    // One found, one not? Better sync.
+    return true;
+  }).map(syncAddonInstallation));
+}
+
+function uninstallExperiment(experiment) {
+  if (isIdeatownAddonID(experiment.addon_id)) {
     AddonManager.getAddonByID(experiment.addon_id, a => a.uninstall());
   }
 }
 
 function installExperiment(experiment) {
-  if (isIdeatownAddon(experiment.addon_id)) {
+  if (isIdeatownAddonID(experiment.addon_id)) {
     AddonManager.getInstallForURL(experiment.xpi_url, install => {
       install.install();
     }, 'application/x-xpinstall');
@@ -148,7 +147,7 @@ function installExperiment(experiment) {
 }
 
 function formatInstallData(install, addon) {
-  let formatted = {
+  const formatted = {
     'name': install.name || '',
     'error': install.error,
     'state': install.state,
@@ -158,7 +157,7 @@ function formatInstallData(install, addon) {
   };
 
   if (addon) {
-    formatted = require('xtend')(formatted, {
+    Object.assign(formatted, {
       'id': addon.id,
       'description': addon.description,
       'homepageURL': addon.homepageURL,
@@ -172,9 +171,61 @@ function formatInstallData(install, addon) {
   return formatted;
 }
 
+function isIdeatownAddonID(id) {
+  return id in store.availableExperiments;
+}
+
+function syncAddonInstallation(addonID) {
+  const experiment = store.availableExperiments[addonID];
+  const method = (addonID in store.installedAddons) ? 'put' : 'delete';
+  // HACK: Use the same "done" handler for 2xx & 4xx responses -
+  // 200 = PUT success, 410 = DELETE success, 404 = DELETE redundant
+  const done = (res) => [addonID, method, res.status];
+  return requestAPI({
+    method: method,
+    url: experiment.installations_url + store.clientUUID
+  }).then(done, done);
+}
+
+function requestAPI(opts) {
+  const headers = {
+    'Accept': 'application/json',
+    'Cookie': ''
+  };
+
+  const hostname = URL(prefs.BASE_URL).hostname; // eslint-disable-line new-cap
+  const cookieEnumerator = cookieManager2.getCookiesFromHost(hostname);
+  while (cookieEnumerator.hasMoreElements()) {
+    const c = cookieEnumerator.getNext().QueryInterface(Ci.nsICookie); // eslint-disable-line new-cap
+    headers.Cookie += c.name + '=' + c.value + ';';
+    if (c.name === 'csrftoken') {
+      headers['X-CSRFToken'] = c.value;
+    }
+  }
+
+  return new Promise((resolve, reject) => {
+    request({
+      url: opts.url,
+      headers: Object.assign(headers, opts.headers || {}),
+      contentType: 'application/json',
+      onComplete: res => (res.status < 400) ? resolve(res) : reject(res)
+    })[opts.method || 'get']();
+  });
+}
+
+// source: http://jsfiddle.net/briguy37/2mvfd/
+function generateUUID() {
+  let d = new Date().getTime();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = (d + Math.random() * 16) % 16 | 0;
+    d = Math.floor(d / 16);
+    return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+  });
+}
+
 AddonManager.addAddonListener({
   onUninstalling: function(addon) {
-    if (isIdeatownAddon(addon.id)) {
+    if (isIdeatownAddonID(addon.id)) {
       app.send('addon-uninstall:uninstall-started', {
         id: addon.id,
         name: addon.name,
@@ -183,30 +234,29 @@ AddonManager.addAddonListener({
     }
   },
   onUninstalled: function(addon) {
-    if (isIdeatownAddon(addon.id)) {
+    if (isIdeatownAddonID(addon.id)) {
       app.send('addon-uninstall:uninstall-ended', {
         id: addon.id,
         name: addon.name,
         version: addon.version
       }, addon);
 
-      if (store.experiments[addon.id]) {
-        delete store.experiments[addon.id];
+      if (store.installedAddons[addon.id]) {
+        delete store.installedAddons[addon.id];
+        syncAddonInstallation(addon.id);
       }
     }
   }
 });
 
-function isIdeatownAddon(id) {
-  return store.availableExperiments.indexOf(id) > -1;
-}
-
 AddonManager.addInstallListener({
   onInstallEnded: function(install, addon) {
-    if (isIdeatownAddon(addon.id)) {
-      store.experiments[addon.id] = addon.version;
-      app.send('addon-install:install-ended', formatInstallData(install, addon), addon);
-    }
+    if (!isIdeatownAddonID(addon.id)) { return; }
+    store.installedAddons[addon.id] = addon;
+    syncAddonInstallation(addon.id).then(() => {
+      app.send('addon-install:install-ended',
+               formatInstallData(install, addon), addon);
+    });
   },
   onInstallFailed: function(install) {
     app.send('addon-install:install-failed', formatInstallData(install));

--- a/addon/route.js
+++ b/addon/route.js
@@ -4,9 +4,11 @@
  * http://mozilla.org/MPL/2.0/.
  */
 const prefs = require('sdk/simple-prefs').prefs;
+const URL = require('sdk/url').URL;
 const IdeaTown = require('idea-town');
 const ideaTown = new IdeaTown({
   'BASE_URL': prefs['BASE_URL'], // eslint-disable-line dot-notation
+  'HOSTNAME': URL(prefs['BASE_URL']).hostname, // eslint-disable-line dot-notation, new-cap
   'IDEATOWN_PREFIX': prefs['IDEATOWN_PREFIX'] // eslint-disable-line dot-notation
 });
 

--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -35,7 +35,10 @@ class ExperimentDetailAdmin(admin.ModelAdmin):
 class UserInstallationAdmin(admin.ModelAdmin):
 
     list_display = ('id', parent_link('experiment'), parent_link('user'),
+                    'client_id',
                     'created', 'modified',)
+
+    list_filter = ('experiment',)
 
 
 class UserFeedbackAdmin(admin.ModelAdmin):

--- a/idea_town/experiments/migrations/0006_auto_20151119_1849.py
+++ b/idea_town/experiments/migrations/0006_auto_20151119_1849.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0005_auto_20151111_1758'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='userinstallation',
+            name='client_id',
+            field=models.CharField(blank=True, max_length=128),
+        ),
+        migrations.AlterUniqueTogether(
+            name='userinstallation',
+            unique_together=set([('experiment', 'user', 'client_id')]),
+        ),
+        migrations.RemoveField(
+            model_name='userinstallation',
+            name='rating',
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -55,11 +55,13 @@ class UserInstallation(models.Model):
 
     experiment = models.ForeignKey(Experiment)
     user = models.ForeignKey(User)
-
-    rating = models.FloatField(null=True, blank=True)
+    client_id = models.CharField(blank=True, max_length=128)
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        unique_together = ('experiment', 'user', 'client_id',)
 
 
 class UserFeedback(models.Model):

--- a/idea_town/experiments/urls.py
+++ b/idea_town/experiments/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url, patterns
+
+from . import views
+
+urlpatterns = patterns(
+    '',
+    url(r'^(?P<experiment_pk>[\w-]+)/installations/(?P<client_id>[\w-]+)',
+        views.installation_detail, name='experiment-installation-detail'),
+    url(r'^(?P<experiment_pk>[\w-]+)/installations/',
+        views.installation_list, name='experiment-installation-list'),
+)

--- a/idea_town/frontend/static-src/app/collections/experiments.js
+++ b/idea_town/frontend/static-src/app/collections/experiments.js
@@ -28,6 +28,15 @@ export default Collection.extend({
     });
   },
 
+  fetch(optionsIn) {
+    return new Promise((resolve, reject) => {
+      const options = optionsIn || {};
+      options.success = resolve;
+      options.error = reject;
+      Collection.prototype.fetch.call(this, options);
+    });
+  },
+
   // django-rest-framework returns the actual models under 'results'
   parse(response) {
     return response.results;

--- a/idea_town/urls.py
+++ b/idea_town/urls.py
@@ -20,6 +20,7 @@ urlpatterns = patterns(
     url(r'^api-auth/', include('rest_framework.urls',
                                namespace='rest_framework')),
     url(r'^api/metrics/', metrics_view.MetricsView.as_view(), name='metrics'),
+    url(r'^api/experiments/', include('idea_town.experiments.urls')),
     url(r'^api/', include(router.urls)),
     # Catch-all fallback to frontend client view
     url(r'', include('idea_town.frontend.urls')),

--- a/idea_town/users/tests.py
+++ b/idea_town/users/tests.py
@@ -84,7 +84,8 @@ class MeViewSetTests(TestCase):
             Experiment.objects.get_or_create(
                 slug="test-%s" % idx, defaults=dict(
                     title="Test %s" % idx,
-                    description="This is a test"
+                    description="This is a test",
+                    addon_id="addon-%s@example.com" % idx
                 )) for idx in range(1, 4)))
 
         cls.addonData = {
@@ -126,11 +127,10 @@ class MeViewSetTests(TestCase):
         )
 
         experiment = self.experiments['test-1']
+        client_id = '8675309'
 
-        UserInstallation.objects.create(
-            experiment=experiment,
-            user=self.user
-        )
+        installation = UserInstallation.objects.create(
+            experiment=experiment, user=self.user, client_id=client_id)
 
         # HACK: Use a rest framework field to format dates as expected
         date_field = fields.DateTimeField()
@@ -142,22 +142,14 @@ class MeViewSetTests(TestCase):
         self.assertDictEqual(
             result_data['installed'][0],
             {
-                'id': experiment.pk,
-                'url': 'http://testserver/api/experiments/%s' % experiment.pk,
-                'slug': experiment.slug,
-                'title': experiment.title,
-                'description': experiment.description,
-                'measurements': experiment.measurements.rendered,
-                'version': experiment.version,
-                'changelog_url': experiment.changelog_url,
-                'contribute_url': experiment.contribute_url,
-                'thumbnail': None,
-                'xpi_url': experiment.xpi_url,
-                'addon_id': experiment.addon_id,
-                'details': [],
-                'contributors': [],
-                'created': date_field.to_representation(experiment.created),
-                'modified': date_field.to_representation(experiment.modified),
+                'experiment': 'http://testserver/api/experiments/%s' % experiment.pk,
+                'addon_id': 'addon-1@example.com',
+                'client_id': client_id,
+                'url':
+                    'http://testserver/api/experiments/%s/installations/%s' %
+                    (experiment.pk, client_id),
+                'created': date_field.to_representation(installation.created),
+                'modified': date_field.to_representation(installation.modified),
             }
         )
 

--- a/idea_town/users/views.py
+++ b/idea_town/users/views.py
@@ -3,8 +3,8 @@ from django.conf import settings
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 
-from ..experiments.models import (UserInstallation)
-from ..experiments.serializers import ExperimentSerializer
+from ..experiments.models import UserInstallation
+from ..experiments.serializers import UserInstallationSerializer
 from .models import UserProfile
 from .serializers import UserProfileSerializer
 
@@ -25,17 +25,16 @@ class MeViewSet(ViewSet):
 
         return Response({
             "id": user.email,
-            "profile": UserProfileSerializer(profile,
-                                             context={'request': request}).data,
+            "profile": UserProfileSerializer(
+                profile,
+                context={'request': request}).data,
             "addon": {
                 "name": "Idea Town",
                 "url": settings.ADDON_URL
             },
-            "installed": [
-                ExperimentSerializer(x.experiment,
-                                     context={'request': request}).data
-                for x in UserInstallation.objects.filter(user=user)
-            ]
+            "installed": UserInstallationSerializer(
+                UserInstallation.objects.filter(user=user), many=True,
+                context={'request': request}).data
         })
 
 


### PR DESCRIPTION
- (addon, frontend) Sync installation state of experiments to server on
  initial page load
- (addon) Generate random UUID for Idea Town addon
- (addon) Refactor tracking of available & installed experiments
- (server) Rework UserInstallation model, admin, and tests
- (server) UserInstallation PUT / DELETE API
- (addon, frontend) Misc refactorings & promisifications & cleanup
- (addon-api) Use `Accept: application/json` header to get JSON data
  from metrics API and quiet XML errors in console.

Closes #195
