### PR TITLE
Add missing socialaccount templates

### DIFF
--- a/idea_town/settings.py
+++ b/idea_town/settings.py
@@ -211,7 +211,7 @@ TEMPLATES = [
         'BACKEND': 'django_jinja.backend.Jinja2',
         'APP_DIRS': True,
         'OPTIONS': {
-            'match_regex': r'^(?!(admin|rest_framework)/.*)',
+            'match_regex': r'^(?!(admin|registration|rest_framework)/.*)',
             'match_extension': '.html',
             'newstyle_gettext': True,
             'context_processors': [

--- a/idea_town/users/templates/socialaccount/authentication_error.html
+++ b/idea_town/users/templates/socialaccount/authentication_error.html
@@ -1,0 +1,12 @@
+{% extends "idea_town/base.html" %}
+
+{% block page_title %}{{ _('Social Network Login Failure') }}{% endblock %}
+
+{% block content %}
+<h1>{{ _('Social Network Login Failure') }}</h1>
+
+<p>{% trans %}
+An error occurred while attempting to login via your social network account.
+Please try again later.
+{% endtrans %}</p>
+{% endblock %}

--- a/idea_town/users/templates/socialaccount/login_cancelled.html
+++ b/idea_town/users/templates/socialaccount/login_cancelled.html
@@ -1,0 +1,11 @@
+{% extends "idea_town/base.html" %}
+
+{% block page_title %}{{ _('Login Cancelled') }}{% endblock %}
+
+{% block content %}
+
+<h1>{{ _("Login Cancelled") }}</h1>
+
+<p>{% trans %}You decided to cancel logging in to our site using one of your existing accounts. If this was a mistake, please proceed to <a href="{{url('account_login')}}">sign in</a>.{% endtrans %}</p>
+
+{% endblock %}


### PR DESCRIPTION
What should be a user readable error message became a blank page with a 500 error when we hit a transient FxA issue. This should help a little
