### PR TITLE
Control the order of experiments

### DIFF
--- a/idea_town/experiments/migrations/0008_auto_20160111_1702.py
+++ b/idea_town/experiments/migrations/0008_auto_20160111_1702.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0007_experiment_privacy_notice_url'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='experiment',
+            options={'ordering': ['order']},
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='order',
+            field=models.IntegerField(default=0),
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -12,6 +12,9 @@ experimentdetail_image_upload_to = HashedUploadTo('image')
 
 class Experiment(models.Model):
 
+    class Meta:
+        ordering = ['order']
+
     title = models.CharField(max_length=128)
     slug = models.SlugField(max_length=128, unique=True, db_index=True)
     thumbnail = models.ImageField(upload_to=experiment_thumbnail_upload_to)
@@ -20,6 +23,7 @@ class Experiment(models.Model):
                                default_markup_type='plain')
     xpi_url = models.URLField()
     version = models.CharField(blank=True, max_length=128)
+    order = models.IntegerField(default=0)
     changelog_url = models.URLField(blank=True)
     contribute_url = models.URLField(blank=True)
     privacy_notice_url = models.URLField(blank=True)

--- a/idea_town/experiments/serializers.py
+++ b/idea_town/experiments/serializers.py
@@ -35,7 +35,7 @@ class ExperimentSerializer(serializers.HyperlinkedModelSerializer):
                   'privacy_notice_url', 'measurements',
                   'xpi_url', 'addon_id', 'details', 'contributors',
                   'installations_url',
-                  'created', 'modified',)
+                  'created', 'modified', 'order',)
 
     def get_contributors(self, obj):
         request = self.context['request']

--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -65,6 +65,7 @@ class ExperimentViewTests(BaseTestCase):
                         "url": "http://testserver/api/experiments/%s" %
                                experiment.pk,
                         "title": experiment.title,
+                        "order": experiment.order,
                         "slug": experiment.slug,
                         "thumbnail": None,
                         "description": experiment.description,

--- a/idea_town/frontend/static-src/app/collections/experiments.js
+++ b/idea_town/frontend/static-src/app/collections/experiments.js
@@ -7,6 +7,7 @@ export default Collection.extend({
   model: Experiment,
   indexes: ['slug'],
   url: '/api/experiments',
+  comparator: 'order',
 
   // Ampersand.sync doesn't seem to pass correct Accept headers by default.
   // This supposedly is fixed by https://github.com/AmpersandJS/ampersand-sync/pull/24


### PR DESCRIPTION
SHOULD BE MERGED AFTER #346 

fixes #333 

You can now set the `order` field in django admin to reorder experiments on the home page.
