### PR TITLE
Use NODE_ENV=development as debug mode in gulpfile

### DIFF
--- a/bin/run-frontend-watch.sh
+++ b/bin/run-frontend-watch.sh
@@ -7,6 +7,6 @@ rm -rf /app/node_modules
 # Be very specific about starting up a gulp process that uses modules from
 # /root/node_modules and restarts whenever gulpfile.js is changed
 while [ 1 ]; do
-    NODE_PATH=/root/node_modules/ /root/node_modules/gulp/bin/gulp.js
+    NODE_PATH=/root/node_modules/ NODE_ENV=development /root/node_modules/gulp/bin/gulp.js
     sleep 3
 done

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,7 @@ const through = require('through2');
 const tabzilla = require('mozilla-tabzilla');
 const uglify = require('gulp-uglify');
 
-// TODO: ENV VAR to check prod/dev?
-const IS_DEBUG = true;
+const IS_DEBUG = (process.env.NODE_ENV === 'development');
 
 const SRC_PATH = './idea_town/frontend/static-src/';
 const DEST_PATH = './idea_town/frontend/static/';
@@ -77,11 +76,11 @@ gulp.task('scripts', ['lint'], function scriptsTask() {
   bundledStream
     .pipe(source('app.js'))
     .pipe(buffer())
-    .pipe(sourcemaps.init({loadMaps: true}))
+    .pipe(gulpif(IS_DEBUG, sourcemaps.init({loadMaps: true})))
      // don't uglify in development. eases build chain debugging
     .pipe(gulpif(!IS_DEBUG, uglify()))
     .on('error', gutil.log)
-    .pipe(sourcemaps.write('./'))
+    .pipe(gulpif(IS_DEBUG, sourcemaps.write('./')))
     .pipe(gulp.dest(DEST_PATH + 'app/'));
 
   // this part runs first, then pipes to bundledStream
@@ -89,6 +88,7 @@ gulp.task('scripts', ['lint'], function scriptsTask() {
     const b = browserify({
       entries: entries,
       debug: IS_DEBUG,
+      fullPaths: IS_DEBUG,
       transform: [babelify]
     });
     b.bundle()


### PR DESCRIPTION
With this PR, we need to set `NODE_ENV=development` to put the gulp build into debug mode. Also has a nice side effect of turning _off_ debug features when building the Docker image, which has been serving up giant debug JS until now.

Closes #297
