### PR TITLE
Issue #130: Localize page titles with L20n

### DIFF
--- a/idea_town/frontend/static-src/app/lib/page-manager.js
+++ b/idea_town/frontend/static-src/app/lib/page-manager.js
@@ -29,8 +29,12 @@ export default class PageManager {
 
     this._viewSwitcher = new AmpersandViewSwitcher(opts.pageContainer, {
       show: (view) => {
-        document.title = 'Idea Town - ' + view.pageTitle || 'Idea Town';
+        document.title = view.pageTitle;
         document.body.scrollTop = 0;
+        const title = document.querySelector('head title');
+        const args = JSON.stringify(view.getL10nArgs());
+        title.setAttribute('data-l10n-args', args);
+        title.setAttribute('data-l10n-id', view.pageTitleL10nID);
       }
     });
 

--- a/idea_town/frontend/static-src/app/views/experiment-list-page.js
+++ b/idea_town/frontend/static-src/app/views/experiment-list-page.js
@@ -4,7 +4,8 @@ import ExperimentRowView from './experiment-row-view';
 import PageView from './page-view';
 
 export default PageView.extend({
-  pageTitle: 'Experiments',
+  pageTitle: 'Idea Town - Experiments',
+  pageTitleL10nID: 'pageTitleExperimentListPage',
   template: `<div class="page" >
                <section data-hook="experiment-list-page">
                  <header data-hook="main-header"></header>

--- a/idea_town/frontend/static-src/app/views/experiment-page.js
+++ b/idea_town/frontend/static-src/app/views/experiment-page.js
@@ -135,7 +135,8 @@ export default PageView.extend({
       }
     }.bind(this));
 
-    this.pageTitle = this.model.title;
+    this.pageTitle = 'Idea Town - ' + this.model.title;
+    this.pageTitleL10nID = 'pageTitleExperiment';
   },
 
   render() {

--- a/idea_town/frontend/static-src/app/views/landing-page.js
+++ b/idea_town/frontend/static-src/app/views/landing-page.js
@@ -6,7 +6,8 @@ import template from '../templates/landing-page';
 export default PageView.extend({
   _template: template,
 
-  pageTitle: 'Help build Firefox',
+  pageTitle: 'Idea Town - Help build Firefox',
+  pageTitleL10nID: 'pageTitleLandingPage',
 
   events: {
     'click [data-hook=show-beta-notice]': '_showBetaNotice'

--- a/idea_town/frontend/static-src/app/views/page-view.js
+++ b/idea_town/frontend/static-src/app/views/page-view.js
@@ -3,6 +3,9 @@ import HeaderView from './header-view';
 import FooterView from './footer-view';
 
 export default BaseView.extend({
+  pageTitle: 'Idea Town',
+  pageTitleL10nID: 'pageTitleDefault',
+
   afterRender() {
     this.renderSubview(new HeaderView({
       headerScroll: this.headerScroll

--- a/locales/en-US/app.l20n
+++ b/locales/en-US/app.l20n
@@ -1,5 +1,10 @@
 <siteName "Idea Town">
 
+<pageTitleDefault "Test Pilot">
+<pageTitleLandingPage "Test Pilot - Help build Firefox">
+<pageTitleExperimentListPage "Test Pilot - Experiments">
+<pageTitleExperiment "Test Pilot - {{title}}">
+
 <headerSubtitle "The innovative community where new Ideas for Firefox are tested.">
 
 <footerLinkContribute "Contribute">


### PR DESCRIPTION
- Tweak page title handling in page-manager to use data-l10n-{args,id}
- Add l10n IDs for each page title string in major views
- Drop string concatenation for page title handling
- Add page title strings to en-US locale
