### PR TITLE
Add short_title field to experiments

### DIFF
--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -13,7 +13,7 @@ class ExperimentAdmin(admin.ModelAdmin):
 
     list_display = ('id',
                     show_image('thumbnail'),
-                    'title', 'version', 'addon_id',
+                    'title', 'short_title', 'version', 'addon_id',
                     related_changelist_link('details'),
                     related_changelist_link('users'),
                     related_changelist_link('feedbacks'),

--- a/idea_town/experiments/migrations/0009_experiment_short_title.py
+++ b/idea_town/experiments/migrations/0009_experiment_short_title.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0008_auto_20160111_1702'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='short_title',
+            field=models.CharField(max_length=60, default='', blank=True),
+        ),
+    ]

--- a/idea_town/experiments/models.py
+++ b/idea_town/experiments/models.py
@@ -24,6 +24,7 @@ class Experiment(models.Model):
         ordering = ['order']
 
     title = models.CharField(max_length=128)
+    short_title = models.CharField(max_length=60, blank=True, default='')
     slug = models.SlugField(max_length=128, unique=True, db_index=True)
     thumbnail = models.ImageField(upload_to=experiment_thumbnail_upload_to)
     description = models.TextField()

--- a/idea_town/experiments/serializers.py
+++ b/idea_town/experiments/serializers.py
@@ -31,7 +31,8 @@ class ExperimentSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = Experiment
-        fields = ('id', 'url', 'title', 'slug', 'thumbnail', 'description',
+        fields = ('id', 'url', 'title', 'short_title', 'slug',
+                  'thumbnail', 'description',
                   'version', 'changelog_url', 'contribute_url',
                   'privacy_notice_url', 'measurements',
                   'xpi_url', 'addon_id', 'details', 'contributors',

--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -39,7 +39,8 @@ class BaseTestCase(TestCase):
         self.experiments = dict((obj.slug, obj) for (obj, created) in (
             Experiment.objects.get_or_create(
                 slug="test-%s" % idx, defaults=dict(
-                    title="Test %s" % idx,
+                    title="Longer Test Title %s" % idx,
+                    short_title="Test %s" % idx,
                     description="This is a test",
                     addon_id="addon-%s@example.com" % idx
                 )) for idx in range(1, 4)))
@@ -65,6 +66,7 @@ class ExperimentViewTests(BaseTestCase):
                         "url": "http://testserver/api/experiments/%s" %
                                experiment.pk,
                         "title": experiment.title,
+                        "short_title": experiment.short_title,
                         "order": experiment.order,
                         "slug": experiment.slug,
                         "thumbnail": None,

--- a/idea_town/frontend/static-src/app/views/experiment-row-view.js
+++ b/idea_town/frontend/static-src/app/views/experiment-row-view.js
@@ -15,8 +15,11 @@ export default BaseView.extend({
              </li>`,
 
   bindings: {
-    'model.title': {
-      hook: 'title'
+    'model': {
+      hook: 'title',
+      type: function shortTitleWithFallback(el, model) {
+        el.innerHTML = model.short_title || model.title;
+      }
     },
     'model.description': {
       hook: 'description'

--- a/idea_town/frontend/static-src/test/views/experiment-row-view.js
+++ b/idea_town/frontend/static-src/test/views/experiment-row-view.js
@@ -1,10 +1,39 @@
 import test from 'tape-catch';
+import Experiment from '../../app/models/experiment';
 import View from '../../app/views/experiment-row-view';
 
 test(`Running Tests for ${__filename}`, a => a.end());
 
 test('Experiment row view renders', t => {
   t.plan(1);
-  const view = new View().render();
+  const model = new Experiment({
+    slug: 'test',
+    title: 'test'
+  });
+  const view = new View({model: model}).render();
   t.ok(view.query('.idea-card'));
+});
+
+test('Experiment row displays title when short_title is blank', t => {
+  t.plan(1);
+  const expectedTitle = 'long title';
+  const model = new Experiment({
+    slug: 'test',
+    short_title: '',
+    title: expectedTitle
+  });
+  const view = new View({model: model}).render();
+  t.equal(view.query('.idea-card h2').innerHTML, expectedTitle);
+});
+
+test('Experiment row displays short_title', t => {
+  t.plan(1);
+  const expectedTitle = 'short title';
+  const model = new Experiment({
+    slug: 'test',
+    short_title: expectedTitle,
+    title: 'long long long title'
+  });
+  const view = new View({model: model}).render();
+  t.equal(view.query('.idea-card h2').innerHTML, expectedTitle);
 });


### PR DESCRIPTION
- Add short_title to model, admin, and serializer
- Display short_title in experiment-row-view when it has content,
  otherwise fall back to title

Fixes #301, fixes #262
