### PR TITLE
Model content localization

### DIFF
--- a/fixtures/demo_data.json
+++ b/fixtures/demo_data.json
@@ -119,129 +119,6 @@
   }
 },
 {
-  "model": "experiments.experiment",
-  "fields": {
-    "measurements": "- Uses per session\r\n- Index selected\r\n- Percentage of searches\r\n",
-    "version": "5.1.4",
-    "privacy_notice_url": "",
-    "contribute_url": "https://github.com/mozilla/universal-search-addon/blob/master/CONTRIBUTING.md",
-    "title": "Universal Search",
-    "measurements_markup_type": "markdown",
-    "_measurements_rendered": "<ul>\n<li>Uses per session</li>\n<li>Index selected</li>\n<li>Percentage of searches</li>\n</ul>",
-    "thumbnail": "demo/experiments_experiment/a/8/a8182b008f6434ba702ab177232625e2_thumbnail_1449675941_0564.png",
-    "description": "Search your bookmarks, history and the web from a single place",
-    "addon_id": "universal-search-addon@mozilla.com",
-    "created": "2015-12-09T15:45:42.395Z",
-    "contributors": [ [ "jhirsch-demo" ], [ "charmston-demo" ], [ "jgruen-demo" ], [ "lorchard-demo" ] ],
-    "slug": "universal-search",
-    "xpi_url": "https://people.mozilla.org/~jhirsch/universal-search-addon/addon.xpi",
-    "modified": "2015-12-10T22:10:11.640Z",
-    "changelog_url": "https://github.com/mozilla/universal-search-addon/commits/master"
-  }
-},
-{
-  "model": "experiments.experiment",
-  "fields": {
-    "measurements": "",
-    "version": "",
-    "privacy_notice_url": "",
-    "contribute_url": "",
-    "title": "Tab Cinema",
-    "measurements_markup_type": "plain",
-    "_measurements_rendered": "<p></p>",
-    "thumbnail": "demo/experiments_experiment/7/f/7fb027cc91d81bfe14d0c7daf2ada413_thumbnail_1449676075_0620.png",
-    "description": "A visual history of your tabs in slideshow form",
-    "addon_id": "tab-cinema-addon@example.com",
-    "created": "2015-12-09T15:47:56.050Z",
-    "contributors": [ [ "nchapman-demo" ], [ "torgeir-demo" ] ],
-    "slug": "mozvr",
-    "xpi_url": "http://example.com",
-    "modified": "2015-12-10T22:00:31.398Z",
-    "changelog_url": ""
-  }
-},
-{
-  "model": "experiments.experiment",
-  "fields": {
-    "measurements": "",
-    "version": "",
-    "privacy_notice_url": "",
-    "contribute_url": "",
-    "title": "Activity Stream",
-    "measurements_markup_type": "plain",
-    "_measurements_rendered": "<p></p>",
-    "thumbnail": "demo/experiments_experiment/e/1/e19739ea25188c866b654d3aa2616b27_thumbnail_1449778314_0632.png",
-    "description": "Find everything you've ever found, no matter what",
-    "addon_id": "activity-stream-addon@mozilla.com",
-    "created": "2015-12-10T20:11:55.207Z",
-    "contributors": [ [ "charmston-demo" ], [ "nchapman-demo" ], [ "lorchard-demo" ], [ "pdehaan-demo" ] ],
-    "slug": "activity-stream",
-    "xpi_url": "http://example.com",
-    "modified": "2015-12-10T22:00:58.944Z",
-    "changelog_url": ""
-  }
-},
-{
-  "model": "experiments.experimentdetail",
-  "fields": {
-    "experiment": [ "universal-search" ],
-    "headline": "Discover",
-    "image": "demo/experiments_experimentdetail/c/f/cf8ec31677b2e3a198cc7550242b7b35_image_1449783090_0930.png",
-    "copy": "Universal Search puts all of the best search features of Firefox in one easy place.",
-    "order": 0,
-    "created": "2015-12-09T15:45:42.678Z",
-    "modified": "2015-12-10T21:55:50.899Z"
-  }
-},
-{
-  "model": "experiments.experimentdetail",
-  "fields": {
-    "experiment": [ "mozvr" ],
-    "headline": "Explore",
-    "image": "demo/experiments_experimentdetail/6/a/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449676076_0047.jpg",
-    "copy": "Do the dishes in a virtual world",
-    "order": 0,
-    "created": "2015-12-09T15:47:56.275Z",
-    "modified": "2015-12-09T15:47:56.275Z"
-  }
-},
-{
-  "model": "experiments.experimentdetail",
-  "fields": {
-    "experiment": [ "activity-stream" ],
-    "headline": "Stream",
-    "image": "demo/experiments_experimentdetail/6/a/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449778315_0766.jpg",
-    "copy": "Stream your dreams",
-    "order": 0,
-    "created": "2015-12-10T20:11:55.456Z",
-    "modified": "2015-12-10T20:11:55.456Z"
-  }
-},
-{
-  "model": "experiments.experimentdetail",
-  "fields": {
-    "experiment": [ "universal-search" ],
-    "headline": "History and Bookmarks",
-    "image": "demo/experiments_experimentdetail/d/f/dfed7362e904f7f4da22918e19ae95f6_image_1449783172_0008.png",
-    "copy": "We've added some smarts to help you sort through everything you've ever found before. Looking for that old recipe? Just search.",
-    "order": 0,
-    "created": "2015-12-10T21:32:53.244Z",
-    "modified": "2015-12-10T21:55:50.903Z"
-  }
-},
-{
-  "model": "experiments.experimentdetail",
-  "fields": {
-    "experiment": [ "universal-search" ],
-    "headline": "Search The World",
-    "image": "demo/experiments_experimentdetail/1/7/17105f0bb1546d756e4b02b13a566e73_image_1449783173_0422.png",
-    "copy": "Search with whatever engine you like. We'll find what you're looking for.",
-    "order": 0,
-    "created": "2015-12-10T21:32:53.872Z",
-    "modified": "2015-12-10T21:55:50.907Z"
-  }
-},
-{
   "model": "users.userprofile",
   "fields": {
     "avatar": "demo/users_userprofile/3/4/34d9e0344ef6a177f0767cd7fc707153_avatar_1446220382_0957.png",
@@ -299,6 +176,204 @@
     "title": "Engineer",
     "created": "2015-12-10T21:59:39.278Z",
     "modified": "2015-12-10T22:07:29.017Z"
+  }
+},
+{
+  "model": "experiments.experiment",
+  "fields": {
+    "addon_id": "universal-search-addon@mozilla.com",
+    "version": "5.1.4",
+    "changelog_url": "https://github.com/mozilla/universal-search-addon/commits/master",
+    "privacy_notice_url": "",
+    "contributors": [ [ "lorchard-demo" ], [ "jgruen-demo" ], [ "charmston-demo" ], [ "jhirsch-demo" ] ],
+    "order": 0,
+    "modified": "2015-12-10T22:10:11.640Z",
+    "thumbnail": "demo/experiments_experiment/a/8/a8182b008f6434ba702ab177232625e2_thumbnail_1449675941_0564.png",
+    "created": "2015-12-09T15:45:42.395Z",
+    "slug": "universal-search",
+    "xpi_url": "https://people.mozilla.org/~jhirsch/universal-search-addon/addon.xpi",
+    "contribute_url": "https://github.com/mozilla/universal-search-addon/blob/master/CONTRIBUTING.md"
+  }
+},
+{
+  "model": "experiments.experiment",
+  "fields": {
+    "addon_id": "tab-cinema-addon@example.com",
+    "version": "",
+    "changelog_url": "",
+    "privacy_notice_url": "",
+    "contributors": [ [ "torgeir-demo" ], [ "nchapman-demo" ] ],
+    "order": 0,
+    "modified": "2015-12-10T22:00:31.398Z",
+    "thumbnail": "demo/experiments_experiment/7/f/7fb027cc91d81bfe14d0c7daf2ada413_thumbnail_1449676075_0620.png",
+    "created": "2015-12-09T15:47:56.050Z",
+    "slug": "mozvr",
+    "xpi_url": "http://example.com",
+    "contribute_url": ""
+  }
+},
+{
+  "model": "experiments.experiment",
+  "fields": {
+    "addon_id": "activity-stream-addon@mozilla.com",
+    "version": "",
+    "changelog_url": "",
+    "privacy_notice_url": "",
+    "contributors": [ [ "lorchard-demo" ], [ "nchapman-demo" ], [ "pdehaan-demo" ], [ "charmston-demo" ] ],
+    "order": 0,
+    "modified": "2015-12-10T22:00:58.944Z",
+    "thumbnail": "demo/experiments_experiment/e/1/e19739ea25188c866b654d3aa2616b27_thumbnail_1449778314_0632.png",
+    "created": "2015-12-10T20:11:55.207Z",
+    "slug": "activity-stream",
+    "xpi_url": "http://example.com",
+    "contribute_url": ""
+  }
+},
+{
+  "model": "experiments.experimenttranslation",
+  "pk": 1,
+  "fields": {
+    "language_code": "en-us",
+    "title": "Universal Search",
+    "master": [ "universal-search" ],
+    "_measurements_rendered": "<p>- Uses per session<br />- Index selected<br />- Percentage of searches<br /></p>",
+    "short_title": "",
+    "description": "Search your bookmarks, history and the web from a single place",
+    "measurements_markup_type": "plain",
+    "measurements": "- Uses per session\r\n- Index selected\r\n- Percentage of searches\r\n"
+  }
+},
+{
+  "model": "experiments.experimenttranslation",
+  "pk": 2,
+  "fields": {
+    "language_code": "en-us",
+    "title": "Tab Cinema",
+    "master": [ "mozvr" ],
+    "_measurements_rendered": "<p></p>",
+    "short_title": "",
+    "description": "A visual history of your tabs in slideshow form",
+    "measurements_markup_type": "plain",
+    "measurements": ""
+  }
+},
+{
+  "model": "experiments.experimenttranslation",
+  "pk": 3,
+  "fields": {
+    "language_code": "en-us",
+    "title": "Activity Stream",
+    "master": [ "activity-stream" ],
+    "_measurements_rendered": "<p></p>",
+    "short_title": "",
+    "description": "Find everything you've ever found, no matter what",
+    "measurements_markup_type": "plain",
+    "measurements": ""
+  }
+},
+{
+  "model": "experiments.experimentdetail",
+  "pk": 1,
+  "fields": {
+    "order": 0,
+    "created": "2015-12-09T15:45:42.678Z",
+    "experiment": [ "universal-search" ],
+    "modified": "2015-12-10T21:55:50.899Z",
+    "image": "demo/experiments_experimentdetail/c/f/cf8ec31677b2e3a198cc7550242b7b35_image_1449783090_0930.png"
+  }
+},
+{
+  "model": "experiments.experimentdetail",
+  "pk": 2,
+  "fields": {
+    "order": 0,
+    "created": "2015-12-09T15:47:56.275Z",
+    "experiment": [ "mozvr" ],
+    "modified": "2015-12-09T15:47:56.275Z",
+    "image": "demo/experiments_experimentdetail/6/a/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449676076_0047.jpg"
+  }
+},
+{
+  "model": "experiments.experimentdetail",
+  "pk": 3,
+  "fields": {
+    "order": 0,
+    "created": "2015-12-10T20:11:55.456Z",
+    "experiment": [ "activity-stream" ],
+    "modified": "2015-12-10T20:11:55.456Z",
+    "image": "demo/experiments_experimentdetail/6/a/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449778315_0766.jpg"
+  }
+},
+{
+  "model": "experiments.experimentdetail",
+  "pk": 4,
+  "fields": {
+    "order": 0,
+    "created": "2015-12-10T21:32:53.244Z",
+    "experiment": [ "universal-search" ],
+    "modified": "2015-12-10T21:55:50.903Z",
+    "image": "demo/experiments_experimentdetail/d/f/dfed7362e904f7f4da22918e19ae95f6_image_1449783172_0008.png"
+  }
+},
+{
+  "model": "experiments.experimentdetail",
+  "pk": 5,
+  "fields": {
+    "order": 0,
+    "created": "2015-12-10T21:32:53.872Z",
+    "experiment": [ "universal-search" ],
+    "modified": "2015-12-10T21:55:50.907Z",
+    "image": "demo/experiments_experimentdetail/1/7/17105f0bb1546d756e4b02b13a566e73_image_1449783173_0422.png"
+  }
+},
+{
+  "model": "experiments.experimentdetailtranslation",
+  "pk": 1,
+  "fields": {
+    "copy": "Do the dishes in a virtual world",
+    "master": 2,
+    "headline": "Explore",
+    "language_code": "en-us"
+  }
+},
+{
+  "model": "experiments.experimentdetailtranslation",
+  "pk": 2,
+  "fields": {
+    "copy": "Stream your dreams",
+    "master": 3,
+    "headline": "Stream",
+    "language_code": "en-us"
+  }
+},
+{
+  "model": "experiments.experimentdetailtranslation",
+  "pk": 3,
+  "fields": {
+    "copy": "Universal Search puts all of the best search features of Firefox in one easy place.",
+    "master": 1,
+    "headline": "Discover",
+    "language_code": "en-us"
+  }
+},
+{
+  "model": "experiments.experimentdetailtranslation",
+  "pk": 4,
+  "fields": {
+    "copy": "We've added some smarts to help you sort through everything you've ever found before. Looking for that old recipe? Just search.",
+    "master": 4,
+    "headline": "History and Bookmarks",
+    "language_code": "en-us"
+  }
+},
+{
+  "model": "experiments.experimentdetailtranslation",
+  "pk": 5,
+  "fields": {
+    "copy": "Search with whatever engine you like. We'll find what you're looking for.",
+    "master": 5,
+    "headline": "Search The World",
+    "language_code": "en-us"
   }
 }
 ]

--- a/idea_town/experiments/admin.py
+++ b/idea_town/experiments/admin.py
@@ -1,34 +1,42 @@
 from django.contrib import admin
 
+from hvad.admin import TranslatableAdmin, TranslatableTabularInline
+
 from .models import (Experiment, ExperimentDetail, UserInstallation,
                      UserFeedback)
-from ..utils import (show_image, parent_link, related_changelist_link)
+from ..utils import (show_image, parent_link, related_changelist_link,
+                     translated)
 
 
-class ExperimentDetailInline(admin.TabularInline):
+class ExperimentDetailInline(TranslatableTabularInline):
     model = ExperimentDetail
 
 
-class ExperimentAdmin(admin.ModelAdmin):
+class ExperimentAdmin(TranslatableAdmin):
 
     list_display = ('id',
                     show_image('thumbnail'),
-                    'title', 'short_title', 'version', 'addon_id',
+                    translated('title'), translated('short_title'),
+                    'version', 'addon_id',
                     related_changelist_link('details'),
                     related_changelist_link('users'),
                     related_changelist_link('feedbacks'),
                     'created', 'modified',)
 
-    prepopulated_fields = {"slug": ("title",)}
-
     raw_id_fields = ('contributors',)
 
     inlines = (ExperimentDetailInline,)
 
+    # Workaround for prepopulated_fields and fieldsets from here:
+    # https://github.com/KristianOellegaard/django-hvad/issues/10#issuecomment-5572524
+    def __init__(self, *args, **kwargs):
+        super(ExperimentAdmin, self).__init__(*args, **kwargs)
+        self.prepopulated_fields = {"slug": ("title",)}
 
-class ExperimentDetailAdmin(admin.ModelAdmin):
 
-    list_display = ('id', parent_link('experiment'), 'order', 'headline',
+class ExperimentDetailAdmin(TranslatableAdmin):
+    list_display = ('id', parent_link('experiment'), 'order',
+                    translated('headline'),
                     show_image('image'), 'created', 'modified',)
 
 

--- a/idea_town/experiments/migrations/0010_auto_20160202_2211.py
+++ b/idea_town/experiments/migrations/0010_auto_20160202_2211.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import markupfield.fields
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def copy_fields_to_translation(model, translation_model, field_names):
+    for obj in model.objects.all():
+        fields = dict(master=obj, language_code='en-us')
+        for name in field_names:
+            fields['%s_tmp' % name] = getattr(obj, name)
+        translation_model.objects.create(**fields)
+
+
+def migrate_translations(apps, schema_editor):
+
+    copy_fields_to_translation(
+        apps.get_model("experiments", "Experiment"),
+        apps.get_model("experiments", "ExperimentTranslation"),
+        ('title', 'short_title', 'description', 'measurements'))
+
+    copy_fields_to_translation(
+        apps.get_model("experiments", "ExperimentDetail"),
+        apps.get_model("experiments", "ExperimentDetailTranslation"),
+        ('headline', 'copy'))
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0009_experiment_short_title'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExperimentDetailTranslation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('headline_tmp', models.CharField(max_length=256)),
+                ('copy_tmp', models.TextField()),
+                ('language_code', models.CharField(db_index=True, max_length=15)),
+                ('master', models.ForeignKey(null=True, related_name='translations', editable=False, to='experiments.ExperimentDetail')),
+            ],
+            options={
+                'db_tablespace': '',
+                'db_table': 'experiments_experimentdetail_translation',
+                'abstract': False,
+                'default_permissions': (),
+                'managed': True,
+            },
+        ),
+        migrations.CreateModel(
+            name='ExperimentTranslation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
+                ('title_tmp', models.CharField(max_length=128)),
+                ('short_title_tmp', models.CharField(blank=True, default='', max_length=60)),
+                ('description_tmp', models.TextField()),
+                ('measurements_tmp', markupfield.fields.MarkupField(rendered_field=True, blank=True, default='')),
+                ('measurements_tmp_markup_type', models.CharField(choices=[('', '--'), ('html', 'HTML'), ('plain', 'Plain'), ('markdown', 'Markdown'), ('restructuredtext', 'Restructured Text')], blank=True, default='plain', max_length=30)),
+                ('_measurements_tmp_rendered', models.TextField(editable=False)),
+                ('language_code', models.CharField(db_index=True, max_length=15)),
+                ('master', models.ForeignKey(null=True, related_name='translations', editable=False, to='experiments.Experiment')),
+            ],
+            options={
+                'db_tablespace': '',
+                'db_table': 'experiments_experiment_translation',
+                'abstract': False,
+                'default_permissions': (),
+                'managed': True,
+            },
+        ),
+        migrations.AlterUniqueTogether(
+            name='experimenttranslation',
+            unique_together=set([('language_code', 'master')]),
+        ),
+        migrations.AlterUniqueTogether(
+            name='experimentdetailtranslation',
+            unique_together=set([('language_code', 'master')]),
+        ),
+        migrations.RunPython(migrate_translations, migrations.RunPython.noop),
+        migrations.RenameField(
+            model_name='experimentdetailtranslation',
+            old_name='copy_tmp',
+            new_name='copy',
+        ),
+        migrations.RenameField(
+            model_name='experimentdetailtranslation',
+            old_name='headline_tmp',
+            new_name='headline',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='_measurements_tmp_rendered',
+            new_name='_measurements_rendered',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='description_tmp',
+            new_name='description',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='measurements_tmp',
+            new_name='measurements',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='measurements_tmp_markup_type',
+            new_name='measurements_markup_type',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='short_title_tmp',
+            new_name='short_title',
+        ),
+        migrations.RenameField(
+            model_name='experimenttranslation',
+            old_name='title_tmp',
+            new_name='title',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='_measurements_rendered',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='description',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='measurements',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='measurements_markup_type',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='short_title',
+        ),
+        migrations.RemoveField(
+            model_name='experiment',
+            name='title',
+        ),
+        migrations.RemoveField(
+            model_name='experimentdetail',
+            name='copy',
+        ),
+        migrations.RemoveField(
+            model_name='experimentdetail',
+            name='headline',
+        ),
+    ]

--- a/idea_town/experiments/serializers.py
+++ b/idea_town/experiments/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from hvad.contrib.restframework import HyperlinkedTranslatableModelSerializer
 from django.core.urlresolvers import reverse
 
 from ..users.models import UserProfile
@@ -8,7 +9,7 @@ from .models import (Experiment, ExperimentDetail, UserFeedback,
 from ..utils import MarkupField
 
 
-class ExperimentDetailSerializer(serializers.HyperlinkedModelSerializer):
+class ExperimentDetailSerializer(HyperlinkedTranslatableModelSerializer):
     experiment_url = serializers.SerializerMethodField()
 
     class Meta:
@@ -22,7 +23,7 @@ class ExperimentDetailSerializer(serializers.HyperlinkedModelSerializer):
         return request.build_absolute_uri(path)
 
 
-class ExperimentSerializer(serializers.HyperlinkedModelSerializer):
+class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
     """Experiment serializer that includes ExperimentDetails"""
     details = ExperimentDetailSerializer(many=True, read_only=True)
     contributors = serializers.SerializerMethodField()

--- a/idea_town/experiments/tests.py
+++ b/idea_town/experiments/tests.py
@@ -39,6 +39,7 @@ class BaseTestCase(TestCase):
         self.experiments = dict((obj.slug, obj) for (obj, created) in (
             Experiment.objects.get_or_create(
                 slug="test-%s" % idx, defaults=dict(
+                    order=idx,
                     title="Longer Test Title %s" % idx,
                     short_title="Test %s" % idx,
                     description="This is a test",

--- a/idea_town/experiments/views.py
+++ b/idea_town/experiments/views.py
@@ -12,7 +12,7 @@ from .serializers import (ExperimentSerializer,
                           ExperimentDetailSerializer,
                           UserFeedbackSerializer,
                           UserInstallationSerializer)
-from ..utils import IsRequestUserBackend
+from ..utils import IsRequestUserBackend, IsAccountAdminOrReadOnly
 
 import logging
 logger = logging.getLogger(__name__)
@@ -22,8 +22,11 @@ class ExperimentViewSet(viewsets.ModelViewSet):
     """
     Returns a list of all Experiments in the system.
     """
-    queryset = Experiment.objects.all()
     serializer_class = ExperimentSerializer
+    permission_classes = (IsAccountAdminOrReadOnly,)
+
+    def get_queryset(self):
+        return Experiment.objects.language().fallbacks('en')
 
     def retrieve(self, request, *args, **kwargs):
         """Use the deep serializer for individual retrieval, which includes
@@ -76,8 +79,11 @@ def installation_detail(request, experiment_pk, client_id):
 
 
 class ExperimentDetailViewSet(viewsets.ModelViewSet):
-    queryset = ExperimentDetail.objects.all()
     serializer_class = ExperimentDetailSerializer
+    permission_classes = (IsAccountAdminOrReadOnly,)
+
+    def get_queryset(self):
+        return ExperimentDetail.objects.language().fallbacks('en')
 
 
 class UserFeedbackViewSet(viewsets.ModelViewSet):
@@ -94,6 +100,6 @@ class UserFeedbackViewSet(viewsets.ModelViewSet):
 
 
 def register_views(router):
-    router.register(r'experiments', ExperimentViewSet)
-    router.register(r'details', ExperimentDetailViewSet)
+    router.register(r'experiments', ExperimentViewSet, base_name='experiment')
+    router.register(r'details', ExperimentDetailViewSet, base_name='experimentdetail')
     router.register(r'feedback', UserFeedbackViewSet, base_name='userfeedback')

--- a/requirements.txt
+++ b/requirements.txt
@@ -153,3 +153,9 @@ django-storages-redux==1.3
 
 # sha256: Wce1-qdV928OJHIHUNTPCheKWQoZ-NhRLTW7Pmtbhkc
 django-markupfield==1.3.5
+
+# sha256: mqltx0gWvpK1MlIcAI5NrBZ6M9uxOda_KyoURvebZDM
+django-hvad==1.4.0
+
+# sha256: M63XBGg6XX-f9JwD5ApNjFAIglia7pcNXtga0Rx651w
+django-mozilla-product-details==0.10.0


### PR DESCRIPTION
- Add django-hvad 1.4.0 dependency
- Migrate existing model data to en-US translations
- Tweaks to get admin & API working with hvad
- Use django-mozilla-product-details to get supported locales, with some
  settings boilerplate stolen from mozilla/bedrock
- Revise demo_data.json for translations
- Remove natural key from ExperimentDetail because it did not make much sense
- Define order for experiments created in test, because hvad mixes up
  the previously implicit order

Issue #130 
