### PR TITLE
Remove reference to dead splash site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,6 @@ Test Pilot is an opt-in platform that allows us to perform controlled tests of n
 
 Test Pilot is not intended to replace trains for most features, nor is it a test bed for concepts we do not believe have a strong chance of shipping in general release. Rather, it is reserved for features that require user feedback, testing, and tuning before they ship with the browser.
 
-## Repositories
-
-* **testpilot** - Test Pilot server and front-end
-* [testpilot-splash](https://github.com/mozilla/testpilot-splash/) - Teaser site for collecting emails
 
 ## More Information
 


### PR DESCRIPTION
The link to **mozilla/testpilot-splash** is broken.
Plus I don't think a link to a splash site we [probably] won't ever release is irrelevant, but removing that link only leaves a mention of the current repo, which isn't useful to anybody since they're already looking at this repo.

Long story longer, I killed the **Repositories** section since IMO it doesn't provide any useful information.
