### PR TITLE
New FxA credentials for testpilot.dev redirect URL

### DIFF
--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -31,8 +31,8 @@ server:
     - FXA_ACCESS_TOKEN_URL=https://oauth-stable.dev.lcip.org/v1/token
     - FXA_AUTHORIZE_URL=https://oauth-stable.dev.lcip.org/v1/authorization
     - FXA_PROFILE_URL=https://stable.dev.lcip.org/profile/v1/profile
-    - FXA_CLIENT_ID=2e13dbd92f77f7df
-    - FXA_SECRET_KEY=a93644d71fa684da464fd2dba4d687c14cb21e1dd740af83895e70ede82f54cc
+    - FXA_CLIENT_ID=4636d485f6f0c761
+    - FXA_SECRET_KEY=c19cca573b94fc195377c577d29f460ab638bec9c8e2b42b1296bd6b22319778
     - DATADOG_API_KEY=4f3b967bbf13c7769ac4fa89efda0fae
     - DATADOG_APP_KEY=ddd45a7b3a3cb90ff1baf20ae8cfab04d1937038
     - ACCOUNT_INVITE_ONLY_MODE=True


### PR DESCRIPTION
closes #408 

We renamed the project hostname to testpilot.dev. But, the client id/secret on the FxA test service still pointed at ideatown.dev. I created a new set of credentials on the [FxA OAuth Credentials Management](https://oauth-stable.dev.lcip.org/console/) test server that points at testpilot.dev and put them into the docker-compose env vars.

To test, you'll need to stop the docker containers, do a `docker kill` if necessary, then a `docker up` to reboot. Django should pick up the new env vars and there should be a message something like this in the stdout log to indicate config has changed:

```
server_1           | Updating existing Firefox Accounts provider (pk=1)
```
