### PR TITLE
Foundations for feature flipping

### DIFF
--- a/testpilot/experiments/admin.py
+++ b/testpilot/experiments/admin.py
@@ -3,13 +3,30 @@ from django.contrib import admin
 from hvad.admin import TranslatableAdmin, TranslatableTabularInline
 
 from .models import (Experiment, ExperimentDetail, UserInstallation,
-                     UserFeedback)
+                     UserFeedback, Feature, FeatureCondition)
 from ..utils import (show_image, parent_link, related_changelist_link,
                      translated)
 
 
 class ExperimentDetailInline(TranslatableTabularInline):
     model = ExperimentDetail
+    extra = 1
+
+
+class FeatureInline(admin.TabularInline):
+    model = Feature
+    extra = 1
+
+
+class FeatureConditionInline(admin.TabularInline):
+    model = FeatureCondition
+    extra = 1
+
+    def formfield_for_choice_field(self, db_field, request, **kwargs):
+        if db_field.name == 'operator':
+            kwargs['choices'] = FeatureCondition.objects.get_operator_choices()
+        return (super(FeatureConditionInline, self)
+                .formfield_for_choice_field(db_field, request, **kwargs))
 
 
 class ExperimentAdmin(TranslatableAdmin):
@@ -25,7 +42,7 @@ class ExperimentAdmin(TranslatableAdmin):
 
     raw_id_fields = ('contributors',)
 
-    inlines = (ExperimentDetailInline,)
+    inlines = (ExperimentDetailInline, FeatureInline, FeatureConditionInline, )
 
     # Workaround for prepopulated_fields and fieldsets from here:
     # https://github.com/KristianOellegaard/django-hvad/issues/10#issuecomment-5572524

--- a/testpilot/experiments/migrations/0011_feature_featurecondition_featurestate.py
+++ b/testpilot/experiments/migrations/0011_feature_featurecondition_featurestate.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0010_auto_20160202_2211'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Feature',
+            fields=[
+                ('id', models.AutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
+                ('slug', models.SlugField(max_length=128, unique=True)),
+                ('title', models.CharField(max_length=128)),
+                ('default_active', models.BooleanField(default=False)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('experiment', models.ForeignKey(to='experiments.Experiment', related_name='features')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='FeatureCondition',
+            fields=[
+                ('id', models.AutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
+                ('operator', models.CharField(max_length=256)),
+                ('argument', models.TextField()),
+                ('comment', models.TextField()),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('experiment', models.ForeignKey(to='experiments.Experiment', related_name='conditions')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='FeatureState',
+            fields=[
+                ('id', models.AutoField(auto_created=True, serialize=False, verbose_name='ID', primary_key=True)),
+                ('active', models.BooleanField(default=False)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('modified', models.DateTimeField(auto_now=True)),
+                ('feature', models.ForeignKey(to='experiments.Feature', related_name='states')),
+                ('installation', models.ForeignKey(to='experiments.UserInstallation', blank=True, null=True)),
+            ],
+        ),
+    ]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -1,3 +1,6 @@
+import json
+import random
+
 from django.db import models
 from django.contrib.auth.models import User
 from django.utils.functional import cached_property
@@ -94,6 +97,10 @@ class UserInstallation(models.Model):
     class Meta:
         unique_together = ('experiment', 'user', 'client_id',)
 
+    @cached_property
+    def features(self):
+        return FeatureState.objects.get_for_installation(self)
+
 
 class UserFeedback(models.Model):
 
@@ -110,3 +117,113 @@ class UserFeedback(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
+
+
+class Feature(models.Model):
+    experiment = models.ForeignKey(Experiment, related_name='features',
+                                   db_index=True)
+    slug = models.SlugField(max_length=128, unique=True, db_index=True)
+    title = models.CharField(max_length=128)
+    default_active = models.BooleanField(default=False)
+
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
+
+
+class FeatureConditionManager(models.Manager):
+
+    operator_registry = {}
+
+    def register_operator(self, name, description=''):
+        """Decorator to register a condition operator function"""
+        def decorator(func):
+            self.operator_registry[name] = dict(
+                func=func, description=description)
+            return func
+        return decorator
+
+    def get_operator_choices(self):
+        """Assemble list of operator choices for form fields"""
+        return [
+            (name, '%s: %s' % (name, operator['description']))
+            for name, operator in self.operator_registry.items()
+        ]
+
+    def apply_conditions_for_installation(self, installation):
+        conditions = FeatureCondition.objects.filter(
+            experiment=installation.experiment)
+        for condition in conditions:
+            operator = self.operator_registry.get(condition.operator, None)
+            if operator is not None:
+                # TODO: Report some error on an unknown operator?
+                operator['func'](condition, installation)
+
+
+class FeatureCondition(models.Model):
+    objects = FeatureConditionManager()
+
+    experiment = models.ForeignKey(Experiment, related_name='conditions',
+                                   db_index=True)
+    operator = models.CharField(max_length=256, choices=[('', 'None'), ])
+    argument = models.TextField()
+    comment = models.TextField()
+
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
+
+
+class FeatureStateManager(models.Manager):
+
+    def get_for_installation(self, installation):
+        experiment = installation.experiment
+
+        out = dict()
+
+        # Gather default active values for defined features
+        features = Feature.objects.filter(experiment=experiment)
+        out.update((f.slug, f.default_active) for f in features)
+
+        # Apply conditions, which will set some states if necessary
+        FeatureCondition.objects.apply_conditions_for_installation(installation)
+
+        # Update with installation-specific feature FeatureState
+        states = FeatureState.objects.filter(installation=installation)
+        out.update((s.feature.slug, s.active) for s in states)
+
+        return out
+
+
+class FeatureState(models.Model):
+    objects = FeatureStateManager()
+
+    installation = models.ForeignKey(UserInstallation, blank=True, null=True)
+    feature = models.ForeignKey('Feature', related_name='states',
+                                db_index=True)
+    active = models.BooleanField(default=False)
+
+    created = models.DateTimeField(auto_now_add=True)
+    modified = models.DateTimeField(auto_now=True)
+
+
+@FeatureCondition.objects.register_operator(
+    'random_bucket',
+    'Pick a random feature from a list')
+def operator_random_bucket(condition, installation):
+    buckets = json.loads(condition.argument)
+    states = dict((s.feature.slug, s.active) for s in
+                  FeatureState.objects.filter(installation=installation))
+
+    # Check if the user is already in a bucket - bail out if so.
+    for bucket in buckets:
+        if states.get(bucket, False):
+            return
+
+    # Attempt to activate state for a random bucket
+    bucket = random.choice(buckets)
+    try:
+        feature = Feature.objects.get(slug=bucket)
+        FeatureState.objects.get_or_create(installation=installation,
+                                           feature=feature, active=True)
+    except Feature.DoesNotExist:
+        # TODO: Report an error on a bucket name not matching a feature?
+        pass

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -69,7 +69,7 @@ class UserInstallationSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = UserInstallation
-        fields = ('url', 'experiment', 'client_id', 'addon_id',
+        fields = ('url', 'experiment', 'client_id', 'addon_id', 'features',
                   'created', 'modified')
 
     def get_url(self, obj):

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import json
 
 from django.core.urlresolvers import reverse
@@ -7,7 +9,8 @@ from rest_framework import fields
 
 from ..utils import gravatar_url, TestCase
 from ..users.models import UserProfile
-from .models import (Experiment, UserFeedback, UserInstallation)
+from .models import (Experiment, UserFeedback, UserInstallation, Feature,
+                     FeatureState, FeatureCondition)
 
 import logging
 logger = logging.getLogger(__name__)
@@ -333,3 +336,129 @@ class UserFeedbackTests(BaseTestCase):
                           password='trustno2')
         resp = self.client.get(feedback_url)
         self.assertEqual(404, resp.status_code)
+
+
+class FeaturesBasicTests(BaseTestCase):
+
+    def setUp(self):
+        super(FeaturesBasicTests, self).setUp()
+
+        self.client.login(username=self.username,
+                          password=self.password)
+
+        self.experiment = self.experiments['test-1']
+        self.client_id = '8675309'
+
+        self.installation = UserInstallation.objects.create(
+            user=self.user, experiment=self.experiment,
+            client_id=self.client_id)
+
+        self.feature1_title = 'frobulation'
+        feature1 = Feature.objects.create(
+            experiment=self.experiment, slug=self.feature1_title,
+            title=self.feature1_title, default_active=False)
+
+        FeatureState.objects.create(
+            installation=self.installation, feature=feature1, active=True)
+
+        self.feature2_title = 'reticulation'
+        Feature.objects.create(
+            experiment=self.experiment, slug=self.feature2_title,
+            title=self.feature2_title, default_active=True)
+
+    def test_get_features_utility(self):
+        """get_features_for_installation utility should yield feature flags"""
+        result = self.installation.features
+        self.assertEqual(result, {
+            self.feature1_title: True,
+            self.feature2_title: True
+        })
+
+    def test_features_list(self):
+        """Features list for installation should be an accessible resource"""
+        result = self.jsonGet('features-list',
+                              experiment_pk=self.experiment.pk,
+                              client_id=self.client_id)
+        self.assertEqual(result, {
+            self.feature1_title: True,
+            self.feature2_title: True
+        })
+
+    def test_me_list(self):
+        """/api/me installation listing should include feature flags"""
+        result = self.jsonGet('me-list')
+        self.assertEqual(result['installed'][0]['features'], {
+            self.feature1_title: True,
+            self.feature2_title: True
+        })
+
+
+class FeatureConditionTests(BaseTestCase):
+
+    def setUp(self):
+        super(FeatureConditionTests, self).setUp()
+
+        self.experiment = self.experiments['test-1']
+
+        self.user1 = self.users['experimenttest-0']
+        self.user2 = self.users['experimenttest-1']
+        self.user3 = self.users['experimenttest-2']
+
+        self.installation1 = UserInstallation.objects.create(
+            experiment=self.experiment, user=self.user1,
+            client_id='8675309-0')
+
+        self.installation2 = UserInstallation.objects.create(
+            experiment=self.experiment, user=self.user2,
+            client_id='8675309-1')
+
+        self.installation3 = UserInstallation.objects.create(
+            experiment=self.experiment, user=self.user3,
+            client_id='8675309-2')
+
+        self.feature1 = Feature.objects.create(
+            experiment=self.experiment, slug='frobulation',
+            title='frobulation', default_active=False)
+
+        self.feature2 = Feature.objects.create(
+            experiment=self.experiment, slug='reticulation',
+            title='reticulation', default_active=False)
+
+        self.feature3 = Feature.objects.create(
+            experiment=self.experiment, slug='encabulation',
+            title='encabulation', default_active=False)
+
+    def test_random_bucket(self):
+
+        FeatureCondition.objects.create(
+            experiment=self.experiment,
+            operator='random_bucket',
+            argument=json.dumps([
+                self.feature1.slug,
+                self.feature2.slug,
+                self.feature3.slug
+            ])
+        )
+
+        with patch('random.choice') as mock_choice:
+
+            mock_choice.return_value = self.feature1.slug
+            self.assertEqual(self.installation1.features, {
+                self.feature1.slug: True,
+                self.feature2.slug: False,
+                self.feature3.slug: False,
+            })
+
+            mock_choice.return_value = self.feature2.slug
+            self.assertEqual(self.installation2.features, {
+                self.feature1.slug: False,
+                self.feature2.slug: True,
+                self.feature3.slug: False,
+            })
+
+            mock_choice.return_value = self.feature3.slug
+            self.assertEqual(self.installation3.features, {
+                self.feature1.slug: False,
+                self.feature2.slug: False,
+                self.feature3.slug: True,
+            })

--- a/testpilot/experiments/urls.py
+++ b/testpilot/experiments/urls.py
@@ -4,6 +4,8 @@ from . import views
 
 urlpatterns = patterns(
     '',
+    url(r'^(?P<experiment_pk>[\w-]+)/installations/(?P<client_id>[\w-]+)/features',
+        views.features_list, name='features-list'),
     url(r'^(?P<experiment_pk>[\w-]+)/installations/(?P<client_id>[\w-]+)',
         views.installation_detail, name='experiment-installation-detail'),
     url(r'^(?P<experiment_pk>[\w-]+)/installations/',

--- a/testpilot/experiments/views.py
+++ b/testpilot/experiments/views.py
@@ -78,6 +78,16 @@ def installation_detail(request, experiment_pk, client_id):
         installation, context={'request': request}).data)
 
 
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def features_list(request, experiment_pk, client_id):
+    experiment = get_object_or_404(Experiment, pk=experiment_pk)
+    installation = get_object_or_404(
+        UserInstallation,
+        user=request.user, experiment=experiment, client_id=client_id)
+    return Response(installation.features)
+
+
 class ExperimentDetailViewSet(viewsets.ModelViewSet):
     serializer_class = ExperimentDetailSerializer
     permission_classes = (IsAccountAdminOrReadOnly,)

--- a/testpilot/users/tests.py
+++ b/testpilot/users/tests.py
@@ -145,6 +145,7 @@ class MeViewSetTests(TestCase):
                 'experiment': 'http://testserver/api/experiments/%s' % experiment.pk,
                 'addon_id': 'addon-1@example.com',
                 'client_id': client_id,
+                'features': {},
                 'url':
                     'http://testserver/api/experiments/%s/installations/%s' %
                     (experiment.pk, client_id),


### PR DESCRIPTION
- Models for features, conditions, and per-installation state
- New feature flag state API resource at
  /experiments/{experiment_id}/installations/{client_id}/features
- Per-installation feature state added to UserInstallation serializer
- Extensible registry of condition operators
- Admin for features and conditions
- Migrations and tests

Closes #366
