### PR TITLE
Add operations endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ testpilot/frontend/static-src/vendor/
 testpilot/frontend/static-src/styles/vendor/
 docker-compose-s3.yml
 debug-config.json
+version.json

--- a/testpilot/base/tests.py
+++ b/testpilot/base/tests.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+
+import io
+import json
+
+from django.core.urlresolvers import reverse
+from django.db import OperationalError
+
+from ..utils import TestCase
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class OpsEndpointTests(TestCase):
+
+    def test_ops_heartbeat_ok(self):
+        """/__heartbeat__ should respond with 200 OK"""
+        url = reverse('ops-heartbeat')
+        self.assertEqual('/__heartbeat__', url)
+        resp = self.client.get(url)
+        self.assertEqual(200, resp.status_code)
+
+    def test_ops_heartbeat_db_failure(self):
+        """/__heartbeat__ should respond with 500 when there is a database problem"""
+        url = reverse('ops-heartbeat')
+        to_mock = 'django.db.backends.base.base.BaseDatabaseWrapper.ensure_connection'
+        with patch(to_mock) as mock_ensure_connection:
+            mock_ensure_connection.side_effect = OperationalError(
+                'FATAL:  the database system is shutting down')
+            resp = self.client.get(url)
+            self.assertEqual(500, resp.status_code)
+
+    def test_ops_lbheartbeat(self):
+        """/__lbheartbeat__ should respond with 200 OK"""
+        url = reverse('ops-lbheartbeat')
+        self.assertEqual('/__lbheartbeat__', url)
+        resp = self.client.get(url)
+        self.assertEqual(200, resp.status_code)
+
+    def test_ops_version_url(self):
+        """/__version__ should be the ops endpoint URL"""
+        self.assertEqual('/__version__', reverse('ops-version'))
+
+    def test_ops_version_default(self):
+        """/__version__ should respond with canned data if file not available"""
+        with patch('os.path.exists') as mock_exists:
+            mock_exists.return_value = False
+            result = self.jsonGet('ops-version')
+            expected = {
+                "source": "https://github.com/mozilla/testpilot.git",
+                "version": "dev",
+                "commit": "dev"
+            }
+            self.assertEqual(expected, result)
+
+    def test_ops_version_file(self):
+        """/__version__ should respond with version.json file, if available"""
+        with patch('os.path.exists') as mock_exists:
+            mock_exists.return_value = True
+            with patch('builtins.open') as mock_open:
+                expected = {
+                    "source": "test",
+                    "version": "test",
+                    "commit": "test"
+                }
+                mock_open.return_value = io.StringIO(json.dumps(expected))
+                result = self.jsonGet('ops-version')
+                self.assertEqual(expected, result)

--- a/testpilot/base/urls.py
+++ b/testpilot/base/urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url, patterns
+
+from . import views
+
+urlpatterns = patterns(
+    '',
+    url(r'^__version__', views.ops_version, name='ops-version'),
+    url(r'^__heartbeat__', views.ops_heartbeat, name='ops-heartbeat'),
+    url(r'^__lbheartbeat__', views.ops_lbheartbeat, name='ops-lbheartbeat'),
+)

--- a/testpilot/base/views.py
+++ b/testpilot/base/views.py
@@ -1,0 +1,34 @@
+import os.path
+import json
+
+from django.conf import settings
+from django.http import HttpResponse, JsonResponse, HttpResponseServerError
+
+from ..experiments.models import Experiment
+
+
+def ops_lbheartbeat(request):
+    return HttpResponse('ok')
+
+
+def ops_heartbeat(request):
+    try:
+        # Check the database by counting Experiments
+        Experiment.objects.count()
+        # TODO: Add checks for other dependencies as we add them
+        return HttpResponse('ok')
+    except:
+        return HttpResponseServerError('database failure')
+
+
+def ops_version(request):
+    VERSION_FN = '%s/version.json' % settings.ROOT
+    if os.path.exists(VERSION_FN):
+        data = json.load(open(VERSION_FN, 'r'))
+    else:
+        data = {
+            "source": "https://github.com/mozilla/testpilot.git",
+            "version": "dev",
+            "commit": "dev"
+        }
+    return JsonResponse(data)

--- a/testpilot/urls.py
+++ b/testpilot/urls.py
@@ -15,6 +15,7 @@ users_views.register_views(router)
 urlpatterns = patterns(
     '',
     # users app is special, because it handles /accounts and /users
+    url(r'', include('testpilot.base.urls')),
     url(r'', include('testpilot.users.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api-auth/', include('rest_framework.urls',


### PR DESCRIPTION
Add operations endpoints
- /__version__ endpoint
  - Responds with contents of version.json when available - i.e. when
    generated by circle.yml on Docker container build
  - Responds with canned fallback data when version.json is missing -
    i.e. in development
- /__lbheartbeat__ endpoint
  - responds with 200 OK when the Django app is available
- /__lbheartbeat__ endpoint
  - checks for database availability, responds with 500 Internal Server
    Error if there's a problem
  - responds with 200 OK otherwise
- Tests

Fixes #394
