### PR TITLE
Run app as non-root user in Docker container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ LICENSE
 README.md
 .git
 .gitignore
+testpilot/frontend/static-src

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ CMD ["./bin/run-prod.sh"]
 
 WORKDIR /app
 
+RUN groupadd --gid 10001 app && \
+    useradd --uid 10001 --gid 10001 --shell /usr/sbin/nologin app
+
 # Install & cache dependencies for Django/Python using peep with a supported
 # pinned version of pip
 COPY requirements.txt /app/requirements.txt
@@ -12,5 +15,13 @@ COPY bin/peep.py /app/bin/peep.py
 RUN pip install pip==6.0.0 && \
     ./bin/peep.py install -r requirements.txt
 
-# Finally, copy in the whole app after dependencies have been installed & cached
+# Copy in the whole app after dependencies have been installed & cached
 COPY . /app
+
+# Collect the static assets together, with placeholder env vars
+RUN SECRET_KEY=foo DEBUG=False ALLOWED_HOSTS=localhost \
+    DATABASE_URL=postgres://postgres@db/postgres \
+    ./manage.py collectstatic --noinput
+
+# De-escalate from root privileges with app user
+USER app

--- a/bin/run-common.sh
+++ b/bin/run-common.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
 ./manage.py migrate
-./manage.py collectstatic --noinput
 ./manage.py createinitialsuperuser
 ./manage.py updatefxaprovider

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -14,6 +14,9 @@ server:
   dockerfile: Dockerfile
   ports:
     - "8000:8000"
+  # HACK: escalate to root user in dev, because we need to be able to write
+  # file uploads to /app/media. Production will use Amazon S3
+  user: root
   volumes:
     - .:/app
   command:

--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -408,41 +408,28 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'verbose'
         },
-        'mail_admins': {
-            'level': 'ERROR',
-            'filters': ['require_debug_false'],
-            'class': 'django.utils.log.AdminEmailHandler'
-        },
-        'logfile': {
-            'class': 'logging.handlers.RotatingFileHandler',
-            'level': 'DEBUG',
-            'maxBytes': config('DJANGO_LOG_MAXBYTES', default=16 * 1024 * 1024, cast=int),
-            'backupCount': config('DJANGO_LOG_BACKUP_COUNT', default=2, cast=int),
-            'filename': config('DJANGO_LOG_FILENAME', default='./django.log'),
-            'formatter': config('DJANGO_LOG_FORMATTER', default='verbose')
-        },
     },
     'loggers': {
         'testpilot': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
             'level': config('DJANGO_LOG_LEVEL', default='INFO'),
             'propagate': True,
         },
         'django': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
         },
         'django.request': {
-            'handlers': ['mail_admins', 'console', 'logfile'],
+            'handlers': ['console'],
             'level': 'ERROR',
             'propagate': False,
         },
         'django.security': {
-            'handlers': ['mail_admins', 'console', 'logfile'],
+            'handlers': ['console'],
             'level': 'ERROR',
             'propagate': False,
         },
         'py.warnings': {
-            'handlers': ['console', 'logfile'],
+            'handlers': ['console'],
         },
     }
 }


### PR DESCRIPTION
- Create "app" user with uid 10001, gid 10001
- Run app in docker container as USER app
- Move `collectstatic` command from `run-common.sh` to Dockerfile, so
  file modifications run as root and not lower-privilege app user
- Remove all file-based logging, because app user will not have
  permission to write files
- Escalate to root user in docker-compose for local dev server instance,
  so we can write uploads to the /app/media directory

Closes #398
