### PR TITLE
update add-on name

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -1,5 +1,5 @@
 # Test Pilot
-The addon where ideas come to idea
+The add-on where ideas come to idea
 
 ## installation
 
@@ -51,8 +51,8 @@ with the add-on installed.
 
 ## distributing
 
-We serve the addon from the `/static/addon/` directory. We will need
-to get the addon signed via [AMO](http://addons.mozilla.org/) and move
+We serve the add-on from the `/static/addon/` directory. We will need
+to get the add-on signed via [AMO](http://addons.mozilla.org/) and move
 it into the correct directory. This is all packaged into a script,
 `npm run sign` in the [package.json](./package.json).
 
@@ -117,9 +117,9 @@ The event `addon-install:install-ended` will include some extra properties:
 }
 ```
 
-#### Talking to the addon
+#### Talking to the add-on
 
-You will need to setup the following function (or an equivalent) to send messages to the addon.
+You will need to setup the following function (or an equivalent) to send messages to the add-on.
 
 ``` javascript
 function sendToAddon (data) {

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,11 +1,11 @@
 {
-  "title": "Test Pilot Addon",
+  "title": "Test Pilot",
   "name": "testpilot-addon",
   "version": "0.4.9",
   "private": true,
-  "description": "The addon where ideas come to idea",
+  "description": "Test Pilot is a privacy sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",
-  "homepage": "https://github.com/mozilla/testpilot/tree/master/addon",
+  "homepage": "https://testpilot.firefox.com/",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot/issues"
   },

--- a/addon/sign
+++ b/addon/sign
@@ -6,7 +6,7 @@
  */
 /*
  * This script is for signing, packaging, and distributing the testpilot
- * addon. If the current package version has already been signed, we generate
+ * add-on. If the current package version has already been signed, we generate
  * an update.rdf, download the signed xpi from amo, and move the files into
  * the testpilot project.
  * If the package version has not been signed, we build the xpi and update.rdf,
@@ -49,13 +49,13 @@ function signCb(err, resp, body) {
   } else distAddon();
 }
 
-// if we need to sign and distribute our addon, we want to use this method
+// if we need to sign and distribute our add-on, we want to use this method
 function distAddon() {
   // generate our xpi and update.rdf
   packageAddon(function(err) {
     if (err) return console.error(err);
 
-    // sign our addon
+    // sign our add-on
     var generatedXpi = '@testpilot-addon-' + version + '.xpi';
 
     signAddon(generatedXpi, function(err, signedXpiPath) {
@@ -80,17 +80,17 @@ function distAddon() {
   });
 }
 
-// if we download our signed addon we want to use this method of distribution
+// if we download our signed add-on we want to use this method of distribution
 function distAddonSigned() {
   // generate our xpi and update.rdf
   packageAddon(function(err) {
     if (err) return console.error(err);
-    console.log('addon packaged.');
+    console.log('add-on packaged.');
 
     // move generated files into /dist directory
     var updateFile = '@testpilot-addon-' + version + '.update.rdf';
 
-    // remove generated addon file, since we already downloaded a
+    // remove generated add-on file, since we already downloaded a
     // signed version
     removeGeneratedXpi();
 


### PR DESCRIPTION
This is low priority but:

1) Changes name from "Test Pilot Addon" to "Test Pilot"
2) Updates description
3) Updates the home page now that we have one
4) Changes visible references to "addon" to "add-on" which is technically correct.  The best kind of correct.
