### PR TITLE
Calculate addon panel height on button click

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -10,17 +10,40 @@ The addon where ideas come to idea
 prod: check the `CONFIG` property in `package.json`
 dev: [dev-prefs.json](dev-prefs.json)
 
-## running
+## development
 
-* `npm start`
+A relatively easy path for working on this addon involves the following steps:
 
-You may need to set both `xpinstall.signatures.required` and
-`xpinstall.whitelist.required` flags to false in `about:config`
-if the addon has not yet been signed.
+1. Install [Firefox Developer Edition][devedition].
 
-If you want to install the xpi locally for dev, you will need to
-set your preferences in `about:addons`. You'll want to use the preferences
-from [dev-prefs.json](./dev-prefs.json).
+2. [Disable add-on signature checks.][sigchecks] TL;DR: Enter `about:config` in
+   the URL bar. Set `xpinstall.signatures.required` and
+   `xpinstall.whitelist.required` flags to false.
+
+3. Install the [Extension Auto-Installer][autoinstaller] Add-on in Firefox
+   Developer Edition.
+
+4. Run `npm start` to fire up a watcher that will build the Test Pilot add-on
+   whenever files change and auto-update the installed version in Firefox.
+
+5. Read all about [setting up an extension development
+   environment][extensiondev] on MDN.
+
+[devedition]: https://www.mozilla.org/en-US/firefox/developer/
+[sigchecks]: https://wiki.mozilla.org/Add-ons/Extension_Signing#FAQ
+[autoinstaller]: https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
+[extensiondev]: https://developer.mozilla.org/en-US/Add-ons/Setting_up_extension_development_environment
+
+## running once for testing
+
+* Install [Firefox Beta][fxbeta]
+
+* `npm run once`
+
+This should package the add-on and fire up Firefox Beta using a fresh profile
+with the add-on installed.
+
+[fxbeta]: https://www.mozilla.org/en-US/firefox/channel/#beta
 
 ## packaging
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -36,9 +36,6 @@ Mustache.parse(templates.experimentList);
 const PANEL_WIDTH = 400;
 const EXPERIMENT_HEIGHT = 95;
 const FOOTER_HEIGHT = 60;
-const PANEL_HEIGHT = (Object.keys(store.availableExperiments).length
-  * EXPERIMENT_HEIGHT)
-  + FOOTER_HEIGHT;
 
 // Generate a UUID for this client, if we don't have one yet.
 if (!store.clientUUID) {
@@ -133,8 +130,6 @@ Prefs.observe('devtools.theme', pref => {
 });
 
 const panel = Panel({ // eslint-disable-line new-cap
-  width: PANEL_WIDTH,
-  height: PANEL_HEIGHT,
   contentURL: './feedback.html',
   contentScriptFile: './panel.js',
   onHide: () => {
@@ -196,21 +191,23 @@ function setToggleButton(dark) {
       '32': iconPrefix + '-32.png',
       '64': iconPrefix + '-64.png'
     },
-    onChange: handleChange
+    onChange: handleToolbarButtonChange
   });
 }
 
-const EVENT_SEND_METRIC = 'testpilot::send-metric';
-
-function handleChange(state) {
-  if (state.checked) {
-    panel.show({
-      position: button
-    });
-  }
+function handleToolbarButtonChange(state) {
+  if (!state.checked) { return; }
+  const experimentCount = ('availableExperiments' in store) ?
+    Object.keys(store.availableExperiments).length : 0;
+  panel.show({
+    width: PANEL_WIDTH,
+    height: (experimentCount * EXPERIMENT_HEIGHT) + FOOTER_HEIGHT,
+    position: button
+  });
 }
 
 // Listen for metrics events from experiments.
+const EVENT_SEND_METRIC = 'testpilot::send-metric';
 const metrics = {
   isInitialized: false,
   init: function() {

--- a/addon/package.json
+++ b/addon/package.json
@@ -18,10 +18,12 @@
   "updateURL": "https://testpilot.firefox.com/static/addon/update.rdf",
   "updateLink": "https://testpilot.firefox.com/static/addon/addon.xpi",
   "scripts": {
+    "start": "npm run watch",
+    "once": "jpm run -b beta --prefs dev-prefs.json",
+    "package": "jpm xpi",
+    "watch": "jpm watchpost --post-url http://localhost:8888",
     "lint": "eslint .",
-    "sign": "./sign",
-    "start": "jpm run -b /usr/bin/firefox --prefs dev-prefs.json",
-    "watch": "jpm watchpost --post-url http://localhost:8888"
+    "sign": "./sign"
   },
   "license": "MPL-2.0",
   "devDependencies": {


### PR DESCRIPTION
- Move height calculation based on available experiments to on-demand
  when the toolbar button is clicked
- Safely default to a count of zero experiments if we haven't loaded the
  list yet.
- Some `package.json` tweaks:
  - `npm run once` launches Firefox Beta in a new profile, using `jpm run`
  - `npm run package` generates an unsigned .xpi
  - `npm start` runs `jpm watchpost`
  - `npm run watch` runs `jpm watchpost`

Fixes #467
