### PR TITLE
Revert "Disable pre-signed S3 URLs for default storage"

### DIFF
--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -306,7 +306,6 @@ if DEFAULT_FILE_STORAGE == 'storages.backends.s3boto.S3BotoStorage':
     AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default=None)
     AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default=None)
     AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME')
-    AWS_QUERYSTRING_AUTH = False
     MEDIA_URL = config('MEDIA_URL')
 else:
     MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))


### PR DESCRIPTION
Turns out this breaks images altogether on prod & stage. Revert for now
while we figure out how to do this properly.

This reverts commit 033999d7d0a021c50884f0b8f3a7b275eb77dc7d.
