### PR TITLE
[fixes #463] Create mechanism to allow for content detection

### DIFF
--- a/addon/data/message-bridge.js
+++ b/addon/data/message-bridge.js
@@ -8,9 +8,6 @@
 
 // Page script acts as messaging bridge between addon and web content.
 
-// Let the client know that the addon is installed.
-unsafeWindow.navigator.testpilotAddon = true;
-
 window.addEventListener('from-web-to-addon', function(event) {
   self.port.emit('from-web-to-addon', event.detail);
 }, false);

--- a/addon/data/set-installed-flag.js
+++ b/addon/data/set-installed-flag.js
@@ -1,0 +1,11 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the "License"). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+/* global cloneInto unsafeWindow */
+
+// Allow friendly clients to know that Test Pilot is installed.
+
+unsafeWindow.navigator.testpilotAddon = true;


### PR DESCRIPTION
Just tried to do what @lmorchard suggested in the issue. Works locally using `npm run once`.

fixes #463
