### PR TITLE
Sign addon with hashed version only on master or release

### DIFF
--- a/addon/bin/sign
+++ b/addon/bin/sign
@@ -17,7 +17,9 @@ var fs = require('fs');
 var path = require('path');
 var request = require('request');
 var jwt = require('jsonwebtoken');
-var manifest = require('./package.json');
+
+var manifestFilename = __dirname + '/../package.json';
+var manifest = require(manifestFilename);
 var version = manifest.version;
 var apiKey = process.env['AMO_USER'];
 var apiSecret = process.env['AMO_SECRET'];

--- a/addon/bin/update-version
+++ b/addon/bin/update-version
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var util = require('util');
+var childProcess = require('child_process');
+
+// Load the current manifest.json
+var manifestFilename = __dirname + '/../package.json';
+var manifest = require(manifestFilename);
+
+// Come up with a version tag suffix based on CIRCLE_TAG, or fall back to
+// looking up the current git commit hash.
+var tag;
+if (process.env['CIRCLE_TAG']) {
+  tag = 'tag-' + process.env['CIRCLE_TAG'];
+} else {
+  // Note: Must use short git hash, because AMO rejects versions > 32 chars
+  tag = 'dev-' + childProcess.execSync('git rev-parse --short HEAD')
+                             .toString('utf-8')
+                             .trim();
+}
+
+// Update the version tag suffix.
+var versionParts = manifest.version.split('-');
+manifest.version = versionParts[0] + '-' + tag;
+
+// Write the modified manifest.json
+var manifestJSON = JSON.stringify(manifest, null, '  ');
+fs.writeFileSync(manifestFilename, manifestJSON);

--- a/addon/package.json
+++ b/addon/package.json
@@ -20,10 +20,10 @@
   "scripts": {
     "start": "npm run watch",
     "once": "jpm run -b beta --prefs dev-prefs.json",
-    "package": "jpm xpi",
     "watch": "jpm watchpost --post-url http://localhost:8888",
     "lint": "eslint .",
-    "sign": "./sign"
+    "sign": "./bin/update-version && ./bin/sign",
+    "package": "jpm xpi && mv @testpilot-addon-$npm_package_version.xpi ../testpilot/frontend/static-src/addon/addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf ../testpilot/frontend/static-src/addon/update.rdf"
   },
   "license": "MPL-2.0",
   "devDependencies": {

--- a/circle.yml
+++ b/circle.yml
@@ -40,12 +40,16 @@ dependencies:
     # create a version.json
     - printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s"}\n' "$CIRCLE_SHA1" "$CIRCLE_TAG" "$CIRCLE_PROJECT_USERNAME" "$CIRCLE_PROJECT_REPONAME" > version.json
 
-    # build addon
+    # build addon - only sign when on master branch or a tag
     - cd addon/ &&
       npm config set spin false &&
       npm install &&
       npm run lint &&
-      npm run sign
+      if [[ $CIRCLE_BRANCH == 'master' || $CIRCLE_TAG != '' ]]; then
+        npm run sign;
+      else
+        npm run package;
+      fi
 
     # build static assets
     - npm install
@@ -63,10 +67,10 @@ test:
   override:
     - >
         docker run --net=host
-        -e 'DEBUG=False' 
-        -e 'SECRET_KEY=Foo' 
-        -e 'ALLOWED_HOSTS=localhost' 
-        -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test' 
+        -e 'DEBUG=False'
+        -e 'SECRET_KEY=Foo'
+        -e 'ALLOWED_HOSTS=localhost'
+        -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test'
         --user root app:build sh -c 'flake8 testpilot && ./manage.py test -v2 testpilot'
 
 # appropriately tag and push the container to dockerhub


### PR DESCRIPTION
- In Circle CI, only use `npm run sign` when we're on master branch or
  are building a release. Use `npm run package`, otherwise.
- As part of `npm run sign`, modify the addon version to include current
  git revision hash or current Circle CI release tag.

Fixes #484
