### PR TITLE
Experiment Gradients

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -154,3 +154,6 @@ testfixtures==4.9.1
 
 # sha256: ceezvPn8pAi8tlu2CJLzddOr3S5PKW7uuP4Lu_zeWY4
 jsonschema==2.5.1
+
+# sha256: 2jgtD0CR_QWvc0NNXdXZA1hnZB5sUMcEtTLes4JAf-M
+django-colorfield==0.1.10

--- a/testpilot/experiments/migrations/0012_auto_20160317_1352.py
+++ b/testpilot/experiments/migrations/0012_auto_20160317_1352.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import colorfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0011_feature_featurecondition_featurestate'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='gradient_start',
+            field=colorfield.fields.ColorField(default='#e07634', max_length=10),
+        ),
+        migrations.AddField(
+            model_name='experiment',
+            name='gradient_stop',
+            field=colorfield.fields.ColorField(default='#4cffa8', max_length=10),
+        ),
+    ]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.utils.functional import cached_property
 
+from colorfield.fields import ColorField
 from markupfield.fields import MarkupField
 
 from hvad.models import TranslatableModel, TranslatedFields
@@ -46,6 +47,8 @@ class Experiment(TranslatableModel):
     contribute_url = models.URLField(blank=True)
     privacy_notice_url = models.URLField(blank=True)
     addon_id = models.CharField(max_length=500, blank=False,)
+    gradient_start = ColorField(default='#e07634')
+    gradient_stop = ColorField(default='#4cffa8')
 
     users = models.ManyToManyField(User, through='UserInstallation')
     contributors = models.ManyToManyField(User, related_name='contributor')

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -36,7 +36,8 @@ class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
                   'thumbnail', 'description',
                   'version', 'changelog_url', 'contribute_url',
                   'privacy_notice_url', 'measurements',
-                  'xpi_url', 'addon_id', 'details', 'contributors',
+                  'xpi_url', 'addon_id', 'gradient_start',
+                  'gradient_stop', 'details', 'contributors',
                   'installations_url', 'installation_count',
                   'created', 'modified', 'order',)
 

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -81,6 +81,8 @@ class ExperimentViewTests(BaseTestCase):
                         "contribute_url": experiment.contribute_url,
                         "privacy_notice_url": experiment.privacy_notice_url,
                         "addon_id": experiment.addon_id,
+                        "gradient_start": experiment.gradient_start,
+                        "gradient_stop": experiment.gradient_stop,
 
                         "created": date_field.to_representation(
                             experiment.created),

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -20,7 +20,7 @@ export default `
     <div data-hook="details">
         <div class="details-content content-wrapper">
           <div class="details-overview">
-            <div class="experiment-icon-wrapper">
+            <div class="experiment-icon-wrapper" data-hook="bg">
               <img class="experiment-icon" data-hook="thumbnail"></img>
             </div>
             <div class="details-sections">

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -29,6 +29,15 @@ export default PageView.extend({
 
   bindings: {
 
+    'model': {
+      hook: 'bg',
+      type: function setGradientBg(el, model) {
+        el.setAttribute('style', `background: linear-gradient(135deg, ${model.gradient_start},
+                                                                     ${model.gradient_stop}`);
+        return el;
+      }
+    },
+
     'model.title': {
       type: 'text',
       hook: 'title'

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -4,7 +4,7 @@ import BaseView from './base-view';
 
 export default BaseView.extend({
   template: `<div data-hook="show-detail" class="experiment-summary">
-              <div class="experiment-icon-wrapper">
+              <div class="experiment-icon-wrapper" data-hook="bg">
                 <div class="experiment-icon" data-hook="thumbnail"></div>
               </div>
               <div class="experiment-information">
@@ -24,12 +24,20 @@ export default BaseView.extend({
   },
 
   bindings: {
-    'model': {
+    'model': [{
       hook: 'title',
       type: function shortTitleWithFallback(el, model) {
         el.innerHTML = model.short_title || model.title;
       }
     },
+    {
+      hook: 'bg',
+      type: function setGradientBg(el, model) {
+        el.setAttribute('style', `background: linear-gradient(135deg, ${model.gradient_start},
+                                                                     ${model.gradient_stop}`);
+        return el;
+      }
+    }],
     'model.description': {
       hook: 'description'
     },

--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
     'django_jinja',
     'django_cleanup',
 
+    'colorfield',
     'rest_framework',
     'storages',
     'markupfield',


### PR DESCRIPTION
- add django-colorfield dependency
- add gradient-start and gradient-stop fields to experiment model
- update experiment model test and serializer
- update experiment-row-view.js bindings to apply gradient
- update experiment-page-view.js and it's template to apply gradient
- add colorfield to INSTALLED_APPS in settings.py
- add migration for new experiment model fields
- fixes #461

cc @johngruen
