### PR TITLE
add an icon so we're not the default puzzle piece

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -6,6 +6,7 @@
   "description": "Test Pilot is a privacy sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",
   "homepage": "https://testpilot.firefox.com/",
+  "icon": "resource://@testpilot-addon/data/icon-32.png",
   "bugs": {
     "url": "https://github.com/mozilla/testpilot/issues"
   },


### PR DESCRIPTION
When I run `npm run package` it says that it successfully made the add-on, but it doesn't actually make the add-on...  so, this is untested so far.

I used the 32px icon because [the docs](https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/package_json) say the limit is 48px.  This didn't seem important enough to increment the add-on version, but if we have a strict policy of any change increments I can adjust it.
