### PR TITLE
476-home-page-link

### DIFF
--- a/testpilot/frontend/static-src/app/templates/header-view.js
+++ b/testpilot/frontend/static-src/app/templates/header-view.js
@@ -2,7 +2,9 @@ export default `
   <header id="main-header" class="content-wrapper" data-hook="active-user">
     <h1>
       <span class="firefox-logo"></span>
-      <span data-hook="title"></span>
+      <a href="/">
+        <span data-hook="title"></span>
+      </a>
     </h1>
     <div data-hook="settings"></div>
   </header>

--- a/testpilot/frontend/static-src/app/templates/landing-page.js
+++ b/testpilot/frontend/static-src/app/templates/landing-page.js
@@ -5,7 +5,9 @@ export default `
       <header id="main-header" class="content-wrapper">
         <h1>
           <span class="firefox-logo"></span>
-          <span data-l10n-id="siteName">Firefox Test Pilot</span>
+          <a href="/accounts/login/?next=/">
+            <span data-l10n-id="siteName">Firefox Test Pilot</span>
+          </a>
         </h1>
         <a data-l10n-id="landingFxaAlternateButton" href="/accounts/login/?next=/" class="button outline">Sign in</a>
       </header>


### PR DESCRIPTION
Adds homepage or sign up link to title h1 text depending on whether the user is signed in or not. This is a solution for [issue 476](https://github.com/mozilla/testpilot/issues/476)
