### PR TITLE
Add "introduction" content experiment detail page

### DIFF
--- a/testpilot/experiments/migrations/0013_auto_20160329_1941.py
+++ b/testpilot/experiments/migrations/0013_auto_20160329_1941.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import markupfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0012_auto_20160317_1352'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experimenttranslation',
+            name='_introduction_rendered',
+            field=models.TextField(editable=False, default=''),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='experimenttranslation',
+            name='introduction',
+            field=markupfield.fields.MarkupField(blank=True, rendered_field=True, default=''),
+        ),
+        migrations.AddField(
+            model_name='experimenttranslation',
+            name='introduction_markup_type',
+            field=models.CharField(blank=True, default='markdown', choices=[('', '--'), ('html', 'HTML'), ('plain', 'Plain'), ('markdown', 'Markdown'), ('restructuredtext', 'Restructured Text')], max_length=30),
+        ),
+    ]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -36,6 +36,8 @@ class Experiment(TranslatableModel):
         description=models.TextField(),
         measurements=MarkupField(blank=True, default='',
                                  default_markup_type='plain'),
+        introduction=MarkupField(blank=True, default='',
+                                 default_markup_type='markdown'),
     )
 
     slug = models.SlugField(max_length=128, unique=True, db_index=True)

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -29,11 +29,12 @@ class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
     contributors = serializers.SerializerMethodField()
     installations_url = serializers.SerializerMethodField()
     measurements = MarkupField()
+    introduction = MarkupField()
 
     class Meta:
         model = Experiment
         fields = ('id', 'url', 'title', 'short_title', 'slug',
-                  'thumbnail', 'description',
+                  'thumbnail', 'description', 'introduction',
                   'version', 'changelog_url', 'contribute_url',
                   'privacy_notice_url', 'measurements',
                   'xpi_url', 'addon_id', 'gradient_start',

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -46,6 +46,7 @@ class BaseTestCase(TestCase):
                     title="Longer Test Title %s" % idx,
                     short_title="Test %s" % idx,
                     description="This is a test",
+                    introduction="<h1>Hello, Test!</h1>",
                     addon_id="addon-%s@example.com" % idx
                 )) for idx in range(1, 4)))
 
@@ -75,6 +76,7 @@ class ExperimentViewTests(BaseTestCase):
                         "slug": experiment.slug,
                         "thumbnail": None,
                         "description": experiment.description,
+                        "introduction": experiment.introduction.rendered,
                         "measurements": experiment.measurements.rendered,
                         "version": experiment.version,
                         "changelog_url": experiment.changelog_url,

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -57,7 +57,12 @@ export default `
             </div>
           </div>
 
-          <div class="details-description"></div>
+          <div class="details-description">
+            <section data-hook="introduction-container" class="introduction">
+              <div data-hook="introduction-html"></div>
+            </section>
+            <div class="details-list"></div>
+          </div>
         </div>
       </div>
       <footer id="main-footer" class="content-wrapper">

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -98,6 +98,16 @@ export default PageView.extend({
       hook: 'contribute-url'
     }],
 
+    'model.introduction': [{
+      type: 'innerHTML',
+      hook: 'introduction-html'
+    },
+    {
+      type: 'toggle',
+      hook: 'introduction-container',
+      mode: 'visibility'
+    }],
+
     'model.measurements': [{
       type: 'innerHTML',
       hook: 'measurements-html'
@@ -161,7 +171,7 @@ export default PageView.extend({
   afterRender() {
     this.renderCollection(new CollectionExtended(this.model.details),
                           DetailView,
-                          this.query('.details-description'));
+                          this.query('.details-list'));
 
     this.renderCollection(new CollectionExtended(this.model.contributors),
                           ContributorView,

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -24,6 +24,7 @@ const test = around(tape)
         xpi_url: 'http://goog1e.net/cybernetix.xpi',
         url: '/slsk',
         enabled: true,
+        introduction: '<h1>Hello introduction!</h1>',
         details: [{
           image: 'img/fail.png',
           copy: 'blah',
@@ -69,6 +70,29 @@ test('now active indicator shows when experiment is enabled', t => {
   const model = app.experiments.get('slsk', 'slug');
   model.enabled = false;
   t.equal(myView.query('.now-active').style.display, 'none');
+});
+
+test('introduction appears in view', t => {
+  t.plan(3);
+
+  const myView = new MyView({headerScroll: false, slug: 'slsk'});
+  const myModel = app.experiments.models[0];
+
+  myView.render();
+  const innerHTML = myView.query('[data-hook=introduction-html]').innerHTML;
+  const styleWhenNotEmpty = myView
+    .query('[data-hook=introduction-container]').style;
+  t.ok(innerHTML === myModel.introduction,
+       'innerHTML matches model');
+  t.ok(styleWhenNotEmpty.visibility !== 'hidden',
+       'introduction is visible when model has content');
+
+  myModel.introduction = '';
+  myView.render();
+  const styleWhenEmpty = myView
+    .query('[data-hook=introduction-container]').style;
+  t.ok(styleWhenEmpty.visibility === 'hidden',
+       'introduction is hidden when model has no content');
 });
 
 test('updateAddon tests', t => {


### PR DESCRIPTION
- Add new MarkupField `introduction` to Experiment model
- Expose `introduction` in ExperimentSerializer for API
- Display `introduction` markup content before ExperimentDetails in view
- Migrations
- Tests, frontend & backend

Fixes #504
