### PR TITLE
Add ability to easily hack on addon ui

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -51,6 +51,8 @@ A relatively easy path for working on this addon involves the following steps:
 [autoinstaller]: https://addons.mozilla.org/en-US/firefox/addon/autoinstaller/
 [extensiondev]: https://developer.mozilla.org/en-US/Add-ons/Setting_up_extension_development_environment
 
+For UI hacking you can run `npm run watch-ui` to easily debug `lib/templates.js` and `data/panel.css`
+
 ## running once for testing
 
 * Install [Firefox Beta][fxbeta]

--- a/addon/experiment-data.json
+++ b/addon/experiment-data.json
@@ -1,0 +1,186 @@
+[
+  {
+    "id": 1,
+    "url": "http:\/\/testpilot.dev:8000\/api\/experiments\/1",
+    "title": "Universal Search",
+    "short_title": "",
+    "slug": "universal-search",
+    "thumbnail": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experiment\/a\/8\/a8182b008f6434ba702ab177232625e2_thumbnail_1449675941_0564.png",
+    "description": "Search your bookmarks, history and the web from a single place",
+    "introduction": "",
+    "version": "5.1.4",
+    "changelog_url": "https:\/\/github.com\/mozilla\/universal-search-addon\/commits\/master",
+    "contribute_url": "https:\/\/github.com\/mozilla\/universal-search-addon\/blob\/master\/CONTRIBUTING.md",
+    "privacy_notice_url": "",
+    "measurements": "<p>- Uses per session<br \/>- Index selected<br \/>- Percentage of searches<br \/><\/p>",
+    "xpi_url": "https:\/\/people.mozilla.org\/~jhirsch\/universal-search-addon\/addon.xpi",
+    "addon_id": "universal-search-addon@mozilla.com",
+    "gradient_start": "#e07634",
+    "gradient_stop": "#4cffa8",
+    "details": [
+      {
+        "url": "http:\/\/testpilot.dev:8000\/api\/details\/1",
+        "order": 0,
+        "headline": "Discover",
+        "image": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experimentdetail\/c\/f\/cf8ec31677b2e3a198cc7550242b7b35_image_1449783090_0930.png",
+        "copy": "Universal Search puts all of the best search features of Firefox in one easy place.",
+        "experiment_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/1"
+      },
+      {
+        "url": "http:\/\/testpilot.dev:8000\/api\/details\/4",
+        "order": 0,
+        "headline": "History and Bookmarks",
+        "image": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experimentdetail\/d\/f\/dfed7362e904f7f4da22918e19ae95f6_image_1449783172_0008.png",
+        "copy": "We've added some smarts to help you sort through everything you've ever found before. Looking for that old recipe? Just search.",
+        "experiment_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/1"
+      },
+      {
+        "url": "http:\/\/testpilot.dev:8000\/api\/details\/5",
+        "order": 0,
+        "headline": "Search The World",
+        "image": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experimentdetail\/1\/7\/17105f0bb1546d756e4b02b13a566e73_image_1449783173_0422.png",
+        "copy": "Search with whatever engine you like. We'll find what you're looking for.",
+        "experiment_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/1"
+      }
+    ],
+    "contributors": [
+      {
+        "username": "lorchard-demo",
+        "display_name": "Les Orchard",
+        "title": "{web,mad,computer} scientist",
+        "avatar": "http:\/\/testpilot.dev:8000\/media\/demo\/users_userprofile\/3\/4\/34d9e0344ef6a177f0767cd7fc707153_avatar_1446220382_0957.png"
+      },
+      {
+        "username": "jgruen-demo",
+        "display_name": "John Gruen",
+        "title": "Designer",
+        "avatar": "\/\/www.gravatar.com\/avatar\/9cd19bb38c89e25ad23bd973a6bd224b?s=64"
+      },
+      {
+        "username": "charmston-demo",
+        "display_name": "Chuck Harmston",
+        "title": "Engineer",
+        "avatar": "\/\/www.gravatar.com\/avatar\/c569400fd10c6ed0e7e0194155273d1e?s=64"
+      },
+      {
+        "username": "jhirsch-demo",
+        "display_name": "Jared HIrsch",
+        "title": "Engineer",
+        "avatar": "\/\/www.gravatar.com\/avatar\/abe193c513e181a8a3ee40980928af39?s=64"
+      }
+    ],
+    "installations_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/1\/installations\/",
+    "installation_count": 1,
+    "created": "2015-12-09T15:45:42.395000Z",
+    "modified": "2015-12-10T22:10:11.640000Z",
+    "order": 0
+  },
+  {
+    "id": 2,
+    "url": "http:\/\/testpilot.dev:8000\/api\/experiments\/2",
+    "title": "Tab Cinema",
+    "short_title": "",
+    "slug": "mozvr",
+    "thumbnail": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experiment\/7\/f\/7fb027cc91d81bfe14d0c7daf2ada413_thumbnail_1449676075_0620.png",
+    "description": "A visual history of your tabs in slideshow form",
+    "introduction": "",
+    "version": "",
+    "changelog_url": "",
+    "contribute_url": "",
+    "privacy_notice_url": "",
+    "measurements": "<p><\/p>",
+    "xpi_url": "http:\/\/example.com",
+    "addon_id": "tab-cinema-addon@example.com",
+    "gradient_start": "#e07634",
+    "gradient_stop": "#4cffa8",
+    "details": [
+      {
+        "url": "http:\/\/testpilot.dev:8000\/api\/details\/2",
+        "order": 0,
+        "headline": "Explore",
+        "image": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experimentdetail\/6\/a\/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449676076_0047.jpg",
+        "copy": "Do the dishes in a virtual world",
+        "experiment_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/2"
+      }
+    ],
+    "contributors": [
+      {
+        "username": "torgeir-demo",
+        "display_name": "torgeir-demo",
+        "title": "",
+        "avatar": "\/\/www.gravatar.com\/avatar\/131985e6cb4bf9e7d26fda0e7b6f46da?s=64"
+      },
+      {
+        "username": "nchapman-demo",
+        "display_name": "nchapman-demo",
+        "title": "",
+        "avatar": "\/\/www.gravatar.com\/avatar\/ea746ee95136a9a98aff32026954edb0?s=64"
+      }
+    ],
+    "installations_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/2\/installations\/",
+    "installation_count": 0,
+    "created": "2015-12-09T15:47:56.050000Z",
+    "modified": "2015-12-10T22:00:31.398000Z",
+    "order": 0
+  },
+  {
+    "id": 3,
+    "url": "http:\/\/testpilot.dev:8000\/api\/experiments\/3",
+    "title": "Activity Stream",
+    "short_title": "",
+    "slug": "activity-stream",
+    "thumbnail": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experiment\/e\/1\/e19739ea25188c866b654d3aa2616b27_thumbnail_1449778314_0632.png",
+    "description": "Find everything you've ever found, no matter what",
+    "introduction": "",
+    "version": "",
+    "changelog_url": "",
+    "contribute_url": "",
+    "privacy_notice_url": "",
+    "measurements": "<p><\/p>",
+    "xpi_url": "http:\/\/example.com",
+    "addon_id": "activity-stream-addon@mozilla.com",
+    "gradient_start": "#e07634",
+    "gradient_stop": "#4cffa8",
+    "details": [
+      {
+        "url": "http:\/\/testpilot.dev:8000\/api\/details\/3",
+        "order": 0,
+        "headline": "Stream",
+        "image": "http:\/\/testpilot.dev:8000\/media\/demo\/experiments_experimentdetail\/6\/a\/6a99c575ab87f8c7d1ed1e52e7e349ce_image_1449778315_0766.jpg",
+        "copy": "Stream your dreams",
+        "experiment_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/3"
+      }
+    ],
+    "contributors": [
+      {
+        "username": "lorchard-demo",
+        "display_name": "Les Orchard",
+        "title": "{web,mad,computer} scientist",
+        "avatar": "http:\/\/testpilot.dev:8000\/media\/demo\/users_userprofile\/3\/4\/34d9e0344ef6a177f0767cd7fc707153_avatar_1446220382_0957.png"
+      },
+      {
+        "username": "nchapman-demo",
+        "display_name": "nchapman-demo",
+        "title": "",
+        "avatar": "\/\/www.gravatar.com\/avatar\/ea746ee95136a9a98aff32026954edb0?s=64"
+      },
+      {
+        "username": "pdehaan-demo",
+        "display_name": "pdehaan-demo",
+        "title": "QA type person",
+        "avatar": "http:\/\/testpilot.dev:8000\/media\/demo\/users_userprofile\/7\/2\/72b302bf297a228a75730123efef7c41_avatar_1447803448_0037.gif"
+      },
+      {
+        "username": "charmston-demo",
+        "display_name": "Chuck Harmston",
+        "title": "Engineer",
+        "avatar": "\/\/www.gravatar.com\/avatar\/c569400fd10c6ed0e7e0194155273d1e?s=64"
+      }
+    ],
+    "installations_url": "http:\/\/testpilot.dev:8000\/api\/experiments\/3\/installations\/",
+    "installation_count": 0,
+    "created": "2015-12-10T20:11:55.207000Z",
+    "modified": "2015-12-10T22:00:58.944000Z",
+    "order": 0
+  }
+]

--- a/addon/package.json
+++ b/addon/package.json
@@ -22,6 +22,7 @@
     "start": "npm run watch",
     "once": "jpm run -b beta --prefs dev-prefs.json",
     "watch": "jpm watchpost --post-url http://localhost:8888",
+    "watch-ui": "watchify-server ui-test.js --index ui-test.html",
     "lint": "eslint .",
     "sign": "./bin/update-version && ./bin/sign",
     "package": "jpm xpi && mv @testpilot-addon-$npm_package_version.xpi ../testpilot/frontend/static-src/addon/addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf ../testpilot/frontend/static-src/addon/update.rdf"
@@ -33,7 +34,8 @@
     "eslint-config-airbnb": "^0.0.8",
     "jpm": "1.0.6",
     "jsonwebtoken": "5.7.0",
-    "request": "2.69.0"
+    "request": "2.69.0",
+    "watchify-server": "1.0.2"
   },
   "preferences": [
     {

--- a/addon/ui-test.html
+++ b/addon/ui-test.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+      body {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        font-family: 'Fira Sans', sans-serif;
+        font-size: 1.6rem;
+
+        background: #fff;
+        color: #000;
+      }
+
+     #browser-doorhanger-wrapper {
+       bottom: 0;
+       left: 0;
+       position: absolute;
+       right: 0;
+       top: 0;
+     }
+
+     #full-page-wrapper.space-between {
+       display: flex;
+       align-items: center;
+       flex-direction: column;
+       justify-content: space-between;
+     }
+
+     #full-page-wrapper {
+       -webkit-flex: 1;
+       -ms-flex: 1;
+       flex: 1;
+       min-height: 100vh;
+       width: 100%;
+     }
+
+     .blue {
+       background-image: radial-gradient(circle, #0996f8 70%, #0675d3 100%, #0568ba 110%);
+       color: #fff;
+     }
+
+     .help-button {
+       display: flex;
+       align-items: center;
+       justify-content: flex-end;
+       z-index: 9999999;
+       position: fixed !important;
+       bottom: 0;
+       padding: 20px;
+       width: 100%;
+       background: rgba(255, 255, 255, 0.9);
+       border-top: 1px solid rgba(0, 0, 0, 0.5);
+     }
+
+     .help-button > * {
+       margin-left: 20px;
+     }
+
+     #browser-doorhanger {
+       display: flex;
+       flex-direction: column;
+       justify-content: center;
+       background: #fff;
+       border-radius: 5px;
+       box-shadow: 0 0 1px rgba(0, 0, 0, 0.5), 0 4px 10px rgba(0, 0, 0, 0.3);
+       position: absolute;
+       right: 2px;
+       text-align: center;
+       top: 2px;
+       width: 300px;
+       z-index: 2;
+     }
+    </style>
+    <link rel="stylesheet" href="data/panel.css" type="text/css" media="screen" />
+  </head>
+  <body>
+    <div id="browser-doorhanger-wrapper" class="main">
+      <div id="browser-doorhanger"></div>
+    </div>
+    <div id="full-page-wrapper" class="space-between blue"></div>
+    <div class="help-button"><span>Helpers: </span>
+      <button class="button default" id="render-experiment-list">Render Experiment List</button>
+      <button class="button default" id="render-installed">Render Installed Message</button>
+      <button class="button default" id="toggle-active">Show/Hide Active</button>
+    </div>
+
+    <script src="ui-test.js"></script>
+  </body>
+</html>

--- a/addon/ui-test.js
+++ b/addon/ui-test.js
@@ -1,0 +1,45 @@
+const Mustache = require('mustache');
+const templates = require('./lib/templates');
+Mustache.parse(templates.installed);
+Mustache.parse(templates.experimentList);
+
+const baseUrl = 'http://testpilot.dev:8000';
+const experiments = require('./experiment-data.json');
+
+const wrapEl = document.getElementById('browser-doorhanger');
+
+document.getElementById('render-installed').onclick = renderInstalledMsg;
+document.getElementById('render-experiment-list').onclick = renderExperimentList;
+document.getElementById('toggle-active').onclick = toggleActive;
+
+renderExperimentList();
+
+function renderExperimentList() {
+  wrapEl.innerHTML = Mustache.render(templates.experimentList, {
+    base_url: baseUrl,
+    experiments: experiments
+  });
+}
+
+function renderInstalledMsg() {
+  wrapEl.innerHTML = Mustache.render(templates.installed, {
+    base_url: baseUrl
+  });
+}
+
+function toggleActive() {
+  if (!document.querySelector('.experiment-list')) {
+    renderExperimentList();
+    document.querySelector('.experiment-item').classList.add('active');
+    return;
+  }
+
+  const items = Array.from(document.querySelectorAll('.experiment-item'));
+
+  const isActive = items.filter(function(el) {
+    return el.classList.contains('active');
+  }).length;
+
+  if (isActive) renderExperimentList();
+  else items[0].classList.add('active');
+}


### PR DESCRIPTION
- add watchify-server dependency for watching and serving our ui-test
- add `watch-ui` script to package.json
- add `addon/ui-test.html` and `addon/ui-test.js` for tweaking ui changes
- add `addon/experiment-data.json` to simplify ui testing

![2016-04-06_1920x1080_scrot](https://cloud.githubusercontent.com/assets/1844554/14332761/e55ca18e-fbff-11e5-9c74-5f28c92bbd54.png)

To run this pr you will need to:
`cd addon/ && npm install && npm run watch-ui`
