### PR TITLE
Fix cursor on download Firefox button

### DIFF
--- a/testpilot/frontend/static-src/styles/modules/_buttons.scss
+++ b/testpilot/frontend/static-src/styles/modules/_buttons.scss
@@ -113,7 +113,7 @@
 .download-firefox {
   @include flex-container(row, center, center);
   color: $white;
-  cursor: default;
+  cursor: auto;
   display: flex;
   flex-direction: row;
   font-weight: 500;


### PR DESCRIPTION
Sets the `cursor` style to "auto", which gives the correct hand cursor for the download button (when using non-Firefox browser).

![firefox_test_pilot](https://cloud.githubusercontent.com/assets/557895/14400242/0ffcc9b8-fdaa-11e5-9afe-6c8b451f52f4.png)

r? @johngruen @meandavejustice @lmorchard
