### PR TITLE
Faking querystring for marionette

### DIFF
--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -21,7 +21,7 @@ export default PageView.extend({
   render() {
     const isLoggedIn = !!app.me.user.id;
     const query = queryString.parse(location.search);
-    this.isMoz = query.hasOwnProperty('butimspecial');
+    this.isMoz = query.hasOwnProperty('butimspecial') || query.hasOwnProperty('butimspecial/');
     this.loggedIn = isLoggedIn;
     this.addonInstalled = app.me.hasAddon;
     this.isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;


### PR DESCRIPTION
@silne30 was saying that marionette was appending a "/" onto the end of the query string arg so we were having some automation issues.
This is a hacky fix to bypass a hacky marionette thing, all of which will be moot once we open the flood gates.
