### PR TITLE
Include origin as Referer header in API requests from addon

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -415,7 +415,11 @@ function syncAddonInstallation(addonID) {
 }
 
 function requestAPI(opts) {
+  const reqUrl = new URL(opts.url);
+
   const headers = {
+    // HACK: Use the API origin as Referer to make CSRF checking happy on SSL
+    'Referer': reqUrl.origin,
     'Accept': 'application/json',
     'Cookie': ''
   };


### PR DESCRIPTION
Using API origin in Referer header makes Django CSRF protection happier
for SSL requests. Kind of a hack, but necessary since we're piggybacking
on cookie session auth from the addon for API requests.

Fixes #652
