### PR TITLE
Handle manual enabling/disabling by the user

### DIFF
--- a/addon/README.md
+++ b/addon/README.md
@@ -97,6 +97,8 @@ Emitted:
 * `addon-install:download-failed`
 * `addon-uninstall:uninstall-started`
 * `addon-uninstall:uninstall-ended`
+* `addon-manage:enabled`
+* `addon-manage:disabled`
 * `addon-self:installed`
 * `addon-self:enabled`
 * `addon-self:upgraded`

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.1",
+  "version": "0.5.3",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- fixes #670
- adds `addon-manage:enabled` and `addon-manage:disabled` messages so we can handle these edge
  cases on the front end as well.
