### PR TITLE
Addon install message follow up

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -41,7 +41,7 @@ const survey = require('./lib/survey');
 const PANEL_WIDTH = 300;
 const FOOTER_HEIGHT = 50;
 const EXPERIMENT_HEIGHT = 80;
-const INSTALLED_PANEL_HEIGHT = 370;
+const INSTALLED_PANEL_HEIGHT = 300;
 
 // Canned selectable server environment configs
 const SERVER_ENVIRONMENTS = {
@@ -172,11 +172,7 @@ function setupApp() {
       const installMsgPanel = Panel({ // eslint-disable-line new-cap
         contentURL: './base.html',
         contentScriptFile: './panel.js',
-        onShow: () => {
-          installMsgPanel.port.emit('show', Mustache.render(templates.installed, {
-            base_url: settings.BASE_URL
-          }));
-        }
+        onShow: () => installMsgPanel.port.emit('show', templates.installed)
       });
 
       installMsgPanel.on('hide', () => {

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -26,5 +26,4 @@ module.exports.installed = `
     <div class="copter fly-down"></div>
   </div>
   <p>Test Pilot lets you test out experimental features in Firefox. Ready for takeoff?</p>
-  <a href="{{base_url}}/home" class="button default quick-pop">Let's go</a>
 </div>`;

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- fixes #659
- remove "Let's go" site link from installed message panel
- adjust installed message panel height
- bump `addon/package.json` version to `0.5.4`
- remove call to `Mustache.render` for installed template,
  since we no longer have data passed to it.
