### PR TITLE
Audit events sent to GA before public launch

### DIFF
--- a/testpilot/frontend/static-src/app/views/disable-dialog-view.js
+++ b/testpilot/frontend/static-src/app/views/disable-dialog-view.js
@@ -1,3 +1,4 @@
+import app from 'ampersand-app';
 import BaseView from './base-view';
 
 export default BaseView.extend({
@@ -16,7 +17,7 @@ export default BaseView.extend({
           </p>
 
           <div class="modal-actions">
-            <a data-l10n-id="feedbackSubmitButton" target="_blank" href="{{surveyUrl}}" class="submit button default large quit">Take a quick survey</a>
+            <a data-l10n-id="feedbackSubmitButton" data-hook="submit-feedback" href="{{surveyUrl}}" class="submit button default large quit">Take a quick survey</a>
             <a data-l10n-id="feedbackCancelButton" class="cancel" href="">Close</a>
           </div>
         </div>
@@ -47,8 +48,16 @@ export default BaseView.extend({
     e.stopPropagation();
   },
 
-  submit() {
+  submit(ev) {
+    ev.preventDefault();
     this.animateRemove();
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'exit survey disabled',
+      newTab: true,
+      outboundURL: ev.target.getAttribute('href')
+    });
     if (this.parentOnSubmit) this.parentOnSubmit();
   }
 });

--- a/testpilot/frontend/static-src/app/views/experiment-tour-dialog-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-tour-dialog-view.js
@@ -1,3 +1,4 @@
+import app from 'ampersand-app';
 import BaseView from './base-view';
 
 export default BaseView.extend({
@@ -81,19 +82,41 @@ export default BaseView.extend({
 
   cancel() {
     this.animateRemove();
+
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'cancel tour'
+    });
   },
 
   takeTour() {
     this.currentStep = 0;
+
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'take tour'
+    });
   },
 
   tourBack() {
     this.currentStep = Math.max(this.currentStep - 1, 0);
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: `back to step ${this.currentStep}`
+    });
   },
 
   tourNext() {
     this.currentStep = Math.min(this.currentStep + 1,
                                 this.model.tour_steps.length - 1);
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: `forward to step ${this.currentStep}`
+    });
   }
 
 });

--- a/testpilot/frontend/static-src/app/views/header-view.js
+++ b/testpilot/frontend/static-src/app/views/header-view.js
@@ -34,10 +34,6 @@ export default BaseView.extend({
     }
   },
 
-  events: {
-    'click [data-hook=logout]': 'logout'
-  },
-
   initialize(opts) {
     if (opts.headerScroll) {
       const chunkedUrl = location.pathname.split('/');
@@ -64,20 +60,5 @@ export default BaseView.extend({
     if (this.experiment) {
       this.isInstalled = !!this.experiment.isInstalled;
     }
-  },
-
-  // TODO: actually manage state without refreshing the page. for now, just refresh
-  //       to pick up csrftoken cookie changes.
-  logout() {
-    fetch('/accounts/logout/', {
-      method: 'POST',
-      credentials: 'same-origin',
-      headers: { 'X-CSRFTOKEN': app.me.csrfToken }
-    }).then(() => {
-      window.location.reload();
-    }).catch((err) => {
-      // for now, log the error in the console & do nothing in the UI
-      console && console.error(err); // eslint-disable-line no-console
-    });
   }
 });

--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -37,7 +37,9 @@ export default PageView.extend({
     }
 
     app.sendToGA('pageview', {
-      'dimension1': this.loggedIn
+      'dimension1': this.loggedIn,
+      'dimension2': this.loggedIn ? Boolean(app.me.installed.length) : null,
+      'dimension3': this.loggedIn ? app.me.installed.length : null
     });
   },
 

--- a/testpilot/frontend/static-src/app/views/retire-page.js
+++ b/testpilot/frontend/static-src/app/views/retire-page.js
@@ -18,7 +18,10 @@ export default PageView.extend({
             <div class="modal-content">
               <p data-l10n-id="retirePageMessage">Before you go, we want to thank you for contributing to Test Pilot. <br> You're welcome back any time!</p>
             </div>
-            <div class="modal-actions"><a data-l10n-id="retirePageSurveyButton" href="external-survey.html" class="button default large">Take a quick survey</a><a data-l10n-id="home" href="/" class="modal-escape">Home</a></div>
+            <div class="modal-actions">
+              <a data-l10n-id="retirePageSurveyButton" data-hook="take-survey" href="external-survey.html" class="button default large">Take a quick survey</a>
+              <a data-l10n-id="home" href="/" class="modal-escape">Home</a>
+            </div>
           </div>
           <div class="copter-wrapper">
             <div class="copter no-display"></div>
@@ -32,6 +35,10 @@ export default PageView.extend({
     'retireUrl': { type: 'string', default: '/users/retire/' }
   },
 
+  events: {
+    'click [data-hook=take-survey]': 'takeSurvey'
+  },
+
   render() {
     PageView.prototype.render.apply(this, arguments);
 
@@ -40,7 +47,7 @@ export default PageView.extend({
     this.retireUserAccount()
       .then(() => app.me.fetch())
       .then(() => this.clearProgressMessage())
-      .catch(err => console.log(err));
+      .catch(err => console.log(err)); // eslint-disable-line no-console
   },
 
   uninstallAddon() {
@@ -68,6 +75,17 @@ export default PageView.extend({
       this.query('.modal').classList.remove('no-display');
       this.query('.modal').classList.add('fade-in');
     }, 500);
+  },
+
+  takeSurvey(ev) {
+    ev.preventDefault();
+    app.sendToGA('event', {
+      eventCategory: 'RetirePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'take survey',
+      newTab: true,
+      outboundURL: ev.target.getAttribute('href')
+    });
   },
 
   // override page afterRender() to skip rendering header & footer

--- a/testpilot/frontend/static-src/app/views/settings-menu-view.js
+++ b/testpilot/frontend/static-src/app/views/settings-menu-view.js
@@ -13,8 +13,8 @@ export default BaseView.extend({
 
                <div class="settings-menu no-display">
                  <ul>
-                   <li><a data-l10n-id="menuWiki" href="https://wiki.mozilla.org/Test_Pilot" target="_blank">Test Pilot Wiki</a></li>
-                   <li><a data-l10n-id="menuFileIssue" href="https://github.com/mozilla/testpilot/issues/new" target="_blank">File an Issue</a></li>
+                   <li><a data-l10n-id="menuWiki" data-hook="wiki" href="https://wiki.mozilla.org/Test_Pilot" target="_blank">Test Pilot Wiki</a></li>
+                   <li><a data-l10n-id="menuFileIssue" data-hook="issue" href="https://github.com/mozilla/testpilot/issues/new" target="_blank">File an Issue</a></li>
                    <li><a data-l10n-id="menuLogout" data-hook="logout">Logout</a></li>
                    <li><hr></li>
                    <li><a data-l10n-id="menuRetire" data-hook="retire">Retire</a></li>
@@ -24,6 +24,8 @@ export default BaseView.extend({
 
   events: {
     'click [data-hook=logout]': 'logout',
+    'click [data-hook=wiki]': 'wiki',
+    'click [data-hook=issue]': 'fileIssue',
     'click [data-hook=retire]': 'retire',
     'click [data-hook=settings-button]': 'toggleSettings'
   },
@@ -81,5 +83,27 @@ export default BaseView.extend({
         app.trigger('router:new-page', {page: 'retire'});
       }
     }), 'body');
+  },
+
+  wiki(ev) {
+    ev.preventDefault();
+    app.sendToGA('event', {
+      eventCategory: 'Menu Interactions',
+      eventAction: 'drop-down menu',
+      eventLabel: 'wiki',
+      newTab: true,
+      outboundURL: ev.target.getAttribute('href')
+    });
+  },
+
+  fileIssue(ev) {
+    ev.preventDefault();
+    app.sendToGA('event', {
+      eventCategory: 'Menu Interactions',
+      eventAction: 'drop-down menu',
+      eventLabel: 'file issue',
+      newTab: true,
+      outboundURL: ev.target.getAttribute('href')
+    });
   }
 });

--- a/testpilot/frontend/static-src/test/views/landing-page.js
+++ b/testpilot/frontend/static-src/test/views/landing-page.js
@@ -11,7 +11,8 @@ const test = around(tape)
     app.me = new Me({
       user: {
         addon: {url: '/bleh'}
-      }
+      },
+      installed: []
     });
     t.end();
   })


### PR DESCRIPTION
#615 is blocked by #681
- refs #615
- added "Active Experiments Running" dimension to ga in `landing-page.js`
- added "Number of Active Experiments Running" dimension to ga in `landing-page.js`
- remove extra "logout" event handler in header-view.js since we already handle in settings-menu-view.js
- added "wiki" event to ga in `settings-menu.js`
- added "file issue" event to ga in `settings-menu.js`
- added "tour" events to ga in `experiment-tour-dialog-view.js`, 'start', 'cancel', 'next', and 'back'
- added "cancel tour" event to ga in `experiment-tour-dialog-view.js`
- disable eslint on error logging in `retire-page.js`
- update `test/views/landing-page.js` so work with `app.me.installed.length` check
