### PR TITLE
remove querystring gateway for public launch (okay to merge after review)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "isomorphic-fetch": "^2.1.1",
     "js-cookie": "2.1.1",
     "mustache": "^2.1.3",
-    "query-string": "4.1.0",
     "remarkable": "1.6.2",
     "through2": "2.0.1"
   },

--- a/testpilot/frontend/static-src/app/templates/landing-page.js
+++ b/testpilot/frontend/static-src/app/templates/landing-page.js
@@ -1,123 +1,99 @@
 export default `
 <section data-hook="landing-page">
     {{^loggedIn}}
-        {{^isMoz}}
-          <div class="blue">
-            <div class="stars"></div>
-            <div class="full-page-wrapper space-between">
-              <header id="main-header" class="responsive-content-wrapper">
-                <h1>
-                  <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
-                </h1>
-              </header>
-              <div class="centered-banner responsive-content-wrapper">
-                <div class="copter-wrapper fly-in">
-                  <div class="copter"></div>
-                </div>
-                <h2>Something&#39;s up!</h2>
+      <div class="blue">
+        <div class="stars"></div>
+        <header id="main-header" class="responsive-content-wrapper">
+          <h1>
+            <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
+          </h1>
+          {{^isFirefox}}
+            <span/>
+          {{/isFirefox}}
+          {{#isFirefox}}
+            <button data-l10n-id="landingFxaAlternateButton" class="button outline" data-hook="signin">Sign in</button>
+          {{/isFirefox}}
+        </header>
+        <div class="split-banner responsive-content-wrapper">
+          <div class="copter-wrapper fly-up">
+            <div class="copter"></div>
+          </div>
+          <div class="intro-text delayed-fade-in-up">
+            <h2 class="banner">
+              <span data-l10n-id="landingIntroLead" class="block lead-in">Go beyond...</span>
+              <span data-l10n-id="landingIntroOne" class="block">Test new features.</span>
+              <span data-l10n-id="landingIntroTwo" class="block">Give us feedback.</span>
+              <span data-l10n-id="landingIntroThree" class="block">Help build Firefox.</span>
+            </h2>
+          </div>
+        </div>
+        <div class="centered-banner responsive-content-wrapper delayed-fade-in-up">
+          {{^isFirefox}}
+            <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
+            <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
+              <div class="button-icon">
+                <div class="button-icon-badge"></div>
               </div>
-              <footer id="main-footer" class="responsive-content-wrapper">
-                <div data-hook="footer-view"></div>
-              </footer>
+              <div class="button-copy">
+                <div data-l10n-id="landingDownloadFirefoxTitle" class="button-title">Firefox</div>
+                <div data-l10n-id="landingDownloadFirefoxSubTitle" class="button-description">Free Download</div>
+              </div>
+            </a>
+          {{/isFirefox}}
+          {{#isFirefox}}
+          <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
+          {{/isFirefox}}
+        </div>
+        {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
+        <div class="transparent-container">
+          <div class="responsive-content-wrapper delayed-fade-in">
+              <h2 class="card-list-header" data-l10n-id="landingExperimentsTitle">Test these features and share your feedback</h2>
+              <div data-hook='experiment-list'></div>
+          </div>
+        </div>
+        <div class="responsive-content-wrapper delayed-fade-in">
+          <h2 class="card-list-header" data-l10n-id="landingCardListTitle">Get started in 3 easy steps</h2>
+          <div id="how-to" class="card-list">
+            <div class="card">
+              <div class="card-icon firefox-icon"></div>
+              <h3 class="card-title" data-l10n-id="landingStepOne">Step one</h3>
+              <div class="card-copy" data-l10n-id="landingCardOne">Create a Firefox Account or sign in.</div>
+            </div>
+            <div class="card">
+              <div class="card-icon add-on-icon"></div>
+              <h3 class="card-title" data-l10n-id="landingStepTwo">Step two</h3>
+              <div class="card-copy" data-l10n-id="landingCardTwo">Get the Test Pilot add-on.</div>
+            </div>
+            <div class="card">
+              <div class="card-icon test-pilot-icon"></div>
+              <h3 class="card-title" data-l10n-id="landingStepThree">Step three</h3>
+              <div class="card-copy data-l10n-id="landingCardThree">Enable experimental features!</div>
             </div>
           </div>
-        {{/isMoz}}
-        {{#isMoz}}
-          <div class="blue">
-            <div class="stars"></div>
-            <header id="main-header" class="responsive-content-wrapper">
-              <h1>
-                <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
-              </h1>
-              {{^isFirefox}}
-                <span/>
-              {{/isFirefox}}
-              {{#isFirefox}}
-                <button data-l10n-id="landingFxaAlternateButton" class="button outline" data-hook="signin">Sign in</button>
-              {{/isFirefox}}
-            </header>
-            <div class="split-banner responsive-content-wrapper">
-              <div class="copter-wrapper fly-up">
-                <div class="copter"></div>
-              </div>
-              <div class="intro-text delayed-fade-in-up">
-                <h2 class="banner">
-                  <span data-l10n-id="landingIntroLead" class="block lead-in">Go beyond...</span>
-                  <span data-l10n-id="landingIntroOne" class="block">Test new features.</span>
-                  <span data-l10n-id="landingIntroTwo" class="block">Give us feedback.</span>
-                  <span data-l10n-id="landingIntroThree" class="block">Help build Firefox.</span>
-                </h2>
-              </div>
-            </div>
-
-            <div class="centered-banner responsive-content-wrapper delayed-fade-in-up">
-              {{^isFirefox}}
-                <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
-                <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
-                  <div class="button-icon">
-                    <div class="button-icon-badge"></div>
-                  </div>
-                  <div class="button-copy">
-                    <div data-l10n-id="landingDownloadFirefoxTitle" class="button-title">Firefox</div>
-                    <div data-l10n-id="landingDownloadFirefoxSubTitle" class="button-description">Free Download</div>
-                  </div>
-                </a>
-              {{/isFirefox}}
-              {{#isFirefox}}
-              <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
-              {{/isFirefox}}
-            </div>
-            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
-            <div class="transparent-container">
-              <div class="responsive-content-wrapper delayed-fade-in">
-                  <h2 class="card-list-header" data-l10n-id="landingExperimentsTitle">Test these features and share your feedback</h2>
-                  <div data-hook='experiment-list'></div>
-              </div>
-            </div>
-            <div class="responsive-content-wrapper delayed-fade-in">
-              <h2 class="card-list-header" data-l10n-id="landingCardListTitle">Get started in 3 easy steps</h2>
-              <div id="how-to" class="card-list">
-                <div class="card">
-                  <div class="card-icon firefox-icon"></div>
-                  <h3 class="card-title" data-l10n-id="landingStepOne">Step one</h3>
-                  <div class="card-copy" data-l10n-id="landingCardOne">Create a Firefox Account or sign in.</div>
+          <div class="centered-banner">
+            {{^isFirefox}}
+              <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
+              <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
+                <div class="button-icon">
+                  <div class="button-icon-badge"></div>
                 </div>
-                <div class="card">
-                  <div class="card-icon add-on-icon"></div>
-                  <h3 class="card-title" data-l10n-id="landingStepTwo">Step two</h3>
-                  <div class="card-copy" data-l10n-id="landingCardTwo">Get the Test Pilot add-on.</div>
+                <div class="button-copy">
+                  <div data-l10n-id="landingDownloadFirefoxTitle" class="button-title">Firefox</div>
+                  <div data-l10n-id="landingDownloadFirefoxSubTitle" class="button-description">Free Download</div>
                 </div>
-                <div class="card">
-                  <div class="card-icon test-pilot-icon"></div>
-                  <h3 class="card-title" data-l10n-id="landingStepThree">Step three</h3>
-                  <div class="card-copy data-l10n-id="landingCardThree">Enable experimental features!</div>
-                </div>
-              </div>
-              <div class="centered-banner">
-                {{^isFirefox}}
-                  <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
-                  <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
-                    <div class="button-icon">
-                      <div class="button-icon-badge"></div>
-                    </div>
-                    <div class="button-copy">
-                      <div data-l10n-id="landingDownloadFirefoxTitle" class="button-title">Firefox</div>
-                      <div data-l10n-id="landingDownloadFirefoxSubTitle" class="button-description">Free Download</div>
-                    </div>
-                  </a>
-                {{/isFirefox}}
-                {{#isFirefox}}
-                <div class="small-spacer"></div>
-                <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
-                {{/isFirefox}}
-              </div>
-            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
-            </div>
-            <footer id="main-footer" class="responsive-content-wrapper">
-              <div data-hook="footer-view"></div>
-            </footer>
+              </a>
+            {{/isFirefox}}
+            {{#isFirefox}}
+            <div class="small-spacer"></div>
+            <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
+            {{/isFirefox}}
           </div>
-      {{/isMoz}}
+        {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
+        </div>
+        <footer id="main-footer" class="responsive-content-wrapper">
+          <div data-hook="footer-view"></div>
+        </footer>
+      </div>
     {{/loggedIn}}
     {{#loggedIn}}
       <div class="blue">

--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -3,9 +3,6 @@ import PageView from './page-view';
 import template from '../templates/landing-page';
 import ExperimentListView from './experiment-list-view';
 
-// TODO back out this commit (78bd0a93a1q) before launch.
-import queryString from 'query-string';
-
 export default PageView.extend({
   _template: template,
 
@@ -20,15 +17,13 @@ export default PageView.extend({
 
   render() {
     const isLoggedIn = !!app.me.user.id;
-    const query = queryString.parse(location.search);
-    this.isMoz = ('butimspecial' in query);
     this.loggedIn = isLoggedIn;
     this.addonInstalled = app.me.hasAddon;
     this.isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
 
     PageView.prototype.render.apply(this, arguments);
 
-    if (!this.loggedIn && this.isMoz) {
+    if (!this.loggedIn) {
       this.renderSubview(new ExperimentListView({
         loggedIn: this.loggedIn,
         isFirefox: this.isFirefox,


### PR DESCRIPTION
- fixes #688
- remove `query-string` module. (Not sure why we were using, since we get `querystring`
  from browserify.)
