### PR TITLE
Enable full Telemetry on install/enable

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -538,12 +538,19 @@ const installListener = {
 };
 AddonManager.addInstallListener(installListener);
 
-exports.main = function() {
+exports.main = function(options) {
+  const reason = options.loadReason;
+
   if (!store.clientUUID) {
     // Generate a UUID for this client, so we can manage experiment
     // installations for multiple browsers per user. DO NOT USE IN METRICS.
     store.clientUUID = require('sdk/util/uuid').uuid().toString().slice(1, -1);
   }
+
+  if (reason === 'install' || reason === 'enable') {
+    Metrics.onEnable();
+  }
+
   initServerEnvironmentPreference();
   Metrics.init();
 };
@@ -555,6 +562,11 @@ exports.onUnload = function(reason) {
   button.destroy();
   Metrics.destroy();
   survey.destroy();
+
+  if (reason === 'uninstall' || reason === 'disable') {
+    Metrics.onDisable();
+  }
+
   if (reason === 'uninstall') {
     if (store.installedAddons) {
       Object.keys(store.installedAddons).forEach(id => {

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- Preserve original preferences on enable / install, then overrides
  preferences to enable full Telemetry collection. Original preferences
  are restored on disable / uninstall.
- Bump addon to v0.5.4

Closes #655
