### PR TITLE
Add privacy and terms of use pages

### DIFF
--- a/legal-copy/legal-templates.js
+++ b/legal-copy/legal-templates.js
@@ -1,0 +1,62 @@
+module.exports.templateBegin = `
+<!doctype html>
+<html>
+<head>
+    <title>Test Pilot</title>
+    <link rel="shortcut icon" href="/static/images/favicon.ico">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
+    <link rel="stylesheet" href="/static/styles/main.css">
+
+    <meta charset="utf-8">
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US">
+    <meta name="viewport" content="width=device-width">
+    <link rel="localization" href="/static/locales/{locale}/app.l20n'">
+
+</head>
+<body>
+  <div data-hook="page-container">
+    <div class="flat-blue">
+      <div class="shifted-stars"></div>
+      <header id="main-header" class="responsive-content-wrapper">
+          <h1>
+            <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
+          </h1>
+        </header>
+    </div>
+    <div class="full-page-wrapper space-between">
+      <div class="responsive-content-wrapper">`,
+
+module.exports.templateEnd = `
+      </div>
+      <footer id="main-footer" class="responsive-content-wrapper">
+        <div id="footer-links">
+          <a href="https://www.mozilla.org" class="mozilla-logo"></a>
+          <a data-l10n-id="footerLinkLegal" href="https://www.mozilla.org/about/legal/" class="boilerplate">Legal</a>
+<a data-l10n-id="footerLinkPrivacy" href="/privacy" class="boilerplate">Privacy</a>
+<a data-l10n-id="footerLinkTerms" href="/privacy" class="boilerplate">Terms of Use</a>
+          <a data-l10n-id="footerLinkCookies" href="https://www.mozilla.org/privacy/websites/#cookies" class="boilerplate">Cookies</a>
+          <a data-l10n-id="footerLinkContribute" href="https://www.mozilla.org/contribute/signup/" class="boilerplate">Contribute</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)
+    },i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    if (typeof(ga) !== 'undefined') {
+        ga('create', 'UA-49796218-34', 'auto');
+    } else {
+        console.warn(
+          'You have google analytics blocked. We understand. Take a ' +
+          'look at our privacy policy to see how we handle your data.'
+        );
+    }
+  </script>
+</body>
+</html>`;

--- a/legal-copy/privacy-notice.html
+++ b/legal-copy/privacy-notice.html
@@ -1,0 +1,84 @@
+
+<!doctype html>
+<html>
+<head>
+    <title>Test Pilot</title>
+    <link rel="shortcut icon" href="/static/images/favicon.ico">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
+    <link rel="stylesheet" href="/static/styles/main.css">
+
+    <meta charset="utf-8">
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US">
+    <meta name="viewport" content="width=device-width">
+    <link rel="localization" href="/static/locales/{locale}/app.l20n'">
+
+</head>
+<body>
+  <div data-hook="page-container">
+    <div class="flat-blue">
+      <div class="shifted-stars"></div>
+      <header id="main-header" class="responsive-content-wrapper">
+          <h1>
+            <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
+          </h1>
+        </header>
+    </div>
+    <div class="full-page-wrapper space-between">
+      <div class="responsive-content-wrapper">
+                                <h1>Test Pilot Privacy Notice</h1>
+<p>May 3, 2016</p>
+<p>Mozilla cares about your Privacy.  The <a href="https://www.mozilla.org/privacy/">Mozilla Privacy Policy</a> describes how we handle information that we receive from you in connection with Test Pilot.</p>
+<h2>Things you should know</h2>
+<p>Firefox sends Mozilla data when Test Pilot is installed; and also if a Test Pilot Experiment is enabled.  This includes data on Firefox and user interactions with Firefox.  We use this data to build better Firefox features. &lt;a&gt;Learn More.&lt;/a&gt;</p>
+<ul>
+<li><p><strong>General Data Collection:</strong> Firefox starts sending Mozilla data once the Test Pilot Add-On is installed.  In addition, Mozilla receives data from enabled Test Pilot Experiments.  Before enabling a Test Pilot Experiment, you can review the specific data collection by checking the “Your Privacy” section of the Experiment’s information page.</p>
+<ul>
+<li><p><strong>Telemetry and Browser Data:</strong> Test Pilot uses Firefox’s Telemetry to send Mozilla data about your Browser and Test Pilot. Installing the Test Pilot Add-On will enable Telemetry if it was not already enabled. Telemetry is a feature in Firefox that sends Mozilla usage, performance, and responsiveness statistics about user interface features, memory, and hardware configuration. Your IP address is also collected as a part of a standard server log. Usage statistics are transmitted using SSL and help us improve future versions of Firefox. In addition to the normal data sent by Firefox’s Telemetry, the Test Pilot Add-On also sends <a href="https://github.com/mozilla/testpilot/blob/master/docs/README-METRICS.md">information</a> about your installed Test Pilot Experiments and User Agent String to Mozilla.</p></li>
+<li><p><strong>Usage Data:</strong> We want to better understand how Test Pilot users interact with Firefox during specific Test Pilot Experiments.  For example, in addition to the normal data collected by Firefox’s Telemetry, we may measure user interactions with mouse, touch, and accessibility tools, as well as Firefox interfaces and controls; the timing and frequency of these actions, etc.</p></li>
+</ul></li>
+<li><p><strong>Turning-off Data Collection:</strong>  Individual Test Pilot Experiments can be disabled by you at anytime, which will stop corresponding data collection.  Note, however, that we’ll continue to receive data from Firefox, and the Test Pilot webpages you visit, until the Test Pilot Add-on is uninstalled.</p></li>
+<li><p><strong>Choice, Control, Minimization:</strong>  We try to balance your privacy with our need for data to improve Firefox.  Test Pilot, and each Test Pilot Experiment, are optional.  We minimize data collection to only what is needed.  We also try to separate personal information (such as your Firefox Account email) from browser, usage, and referral data; this allows us to better understand user engagement without identifying your behavior specifically.</p></li>
+</ul>
+<p>We connect with Test Pilot participants using email, Firefox, and on the Test Pilot website.  To better understand user engagement with Test Pilot, we also use cookies, analytics, and non-Mozilla services.  &lt;a&gt;Learn More.&lt;/a&gt;</p>
+<ul>
+<li><p><strong>Server Logs:</strong> Your interaction with the Test Pilot website, including the installation of the Test Pilot Add-On and any Experiments, is collected as part of a standard server log. This server log data will be associated with your IP address and Firefox Account ID, and will be routinely destroyed in accordance with our Privacy Policies.</p></li>
+<li><p><strong>Communications:</strong> When Test Pilot is enabled, we use your Firefox Account email address or Firefox, to obtain feedback and notify you of new Test Pilot Experiments.  If you disable a specific Test Pilot Experiment, we may contact you to learn more about your experience.  You can opt-out from email communications using the “unsubscribe” link or by uninstalling the Test Pilot Add-On.</p></li>
+<li><p><strong>Cookies and Analytics:</strong> We use cookies, clear GIFs, and analytics in our communications and on our webpages.  For example, cookies are used to remember your Firefox Account information and analytics are used to measure engagement with our emails and webpages. Learn more about our privacy practices in connection with websites, communications, and cookies <a href="https://www.mozilla.org/en-US/privacy/websites/">here</a>.</p></li>
+<li><p><strong>Referral Data:</strong> We collect information about the source that referred you to Test Pilot (e.g., Firefox snippet, email, webpage link, etc.).</p></li>
+<li><p><strong>Non-Mozilla Services:</strong> We use services of other companies like ExactTarget, Google, and SurveyGizmo for emails, analytics, and surveys.  We encourage you to review their privacy policies and terms, as they are different from ours.</p></li>
+</ul>
+
+                                
+      </div>
+      <footer id="main-footer" class="responsive-content-wrapper">
+        <div id="footer-links">
+          <a href="https://www.mozilla.org" class="mozilla-logo"></a>
+          <a data-l10n-id="footerLinkLegal" href="https://www.mozilla.org/about/legal/" class="boilerplate">Legal</a>
+<a data-l10n-id="footerLinkPrivacy" href="/privacy" class="boilerplate">Privacy</a>
+<a data-l10n-id="footerLinkTerms" href="/privacy" class="boilerplate">Terms of Use</a>
+          <a data-l10n-id="footerLinkCookies" href="https://www.mozilla.org/privacy/websites/#cookies" class="boilerplate">Cookies</a>
+          <a data-l10n-id="footerLinkContribute" href="https://www.mozilla.org/contribute/signup/" class="boilerplate">Contribute</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)
+    },i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    if (typeof(ga) !== 'undefined') {
+        ga('create', 'UA-49796218-34', 'auto');
+    } else {
+        console.warn(
+          'You have google analytics blocked. We understand. Take a ' +
+          'look at our privacy policy to see how we handle your data.'
+        );
+    }
+  </script>
+</body>
+</html>

--- a/legal-copy/privacy-notice.md
+++ b/legal-copy/privacy-notice.md
@@ -1,0 +1,30 @@
+# Test Pilot Privacy Notice
+May 3, 2016
+
+Mozilla cares about your Privacy.  The [Mozilla Privacy Policy](https://www.mozilla.org/privacy/) describes how we handle information that we receive from you in connection with Test Pilot.
+
+## Things you should know
+
+Firefox sends Mozilla data when Test Pilot is installed; and also if a Test Pilot Experiment is enabled.  This includes data on Firefox and user interactions with Firefox.  We use this data to build better Firefox features. <a>Learn More.</a>
+
+- **General Data Collection:** Firefox starts sending Mozilla data once the Test Pilot Add-On is installed.  In addition, Mozilla receives data from enabled Test Pilot Experiments.  Before enabling a Test Pilot Experiment, you can review the specific data collection by checking the “Your Privacy” section of the Experiment’s information page.
+
+  - **Telemetry and Browser Data:** Test Pilot uses Firefox’s Telemetry to send Mozilla data about your Browser and Test Pilot. Installing the Test Pilot Add-On will enable Telemetry if it was not already enabled. Telemetry is a feature in Firefox that sends Mozilla usage, performance, and responsiveness statistics about user interface features, memory, and hardware configuration. Your IP address is also collected as a part of a standard server log. Usage statistics are transmitted using SSL and help us improve future versions of Firefox. In addition to the normal data sent by Firefox’s Telemetry, the Test Pilot Add-On also sends [information](https://github.com/mozilla/testpilot/blob/master/docs/README-METRICS.md) about your installed Test Pilot Experiments and User Agent String to Mozilla.
+
+  - **Usage Data:** We want to better understand how Test Pilot users interact with Firefox during specific Test Pilot Experiments.  For example, in addition to the normal data collected by Firefox’s Telemetry, we may measure user interactions with mouse, touch, and accessibility tools, as well as Firefox interfaces and controls; the timing and frequency of these actions, etc.
+
+- **Turning-off Data Collection:**  Individual Test Pilot Experiments can be disabled by you at anytime, which will stop corresponding data collection.  Note, however, that we’ll continue to receive data from Firefox, and the Test Pilot webpages you visit, until the Test Pilot Add-on is uninstalled.
+
+- **Choice, Control, Minimization:**  We try to balance your privacy with our need for data to improve Firefox.  Test Pilot, and each Test Pilot Experiment, are optional.  We minimize data collection to only what is needed.  We also try to separate personal information (such as your Firefox Account email) from browser, usage, and referral data; this allows us to better understand user engagement without identifying your behavior specifically.
+
+We connect with Test Pilot participants using email, Firefox, and on the Test Pilot website.  To better understand user engagement with Test Pilot, we also use cookies, analytics, and non-Mozilla services.  <a>Learn More.</a>
+
+- **Server Logs:** Your interaction with the Test Pilot website, including the installation of the Test Pilot Add-On and any Experiments, is collected as part of a standard server log. This server log data will be associated with your IP address and Firefox Account ID, and will be routinely destroyed in accordance with our Privacy Policies.
+
+- **Communications:** When Test Pilot is enabled, we use your Firefox Account email address or Firefox, to obtain feedback and notify you of new Test Pilot Experiments.  If you disable a specific Test Pilot Experiment, we may contact you to learn more about your experience.  You can opt-out from email communications using the “unsubscribe” link or by uninstalling the Test Pilot Add-On.
+
+- **Cookies and Analytics:** We use cookies, clear GIFs, and analytics in our communications and on our webpages.  For example, cookies are used to remember your Firefox Account information and analytics are used to measure engagement with our emails and webpages. Learn more about our privacy practices in connection with websites, communications, and cookies [here](https://www.mozilla.org/en-US/privacy/websites/).
+
+- **Referral Data:** We collect information about the source that referred you to Test Pilot (e.g., Firefox snippet, email, webpage link, etc.).
+
+- **Non-Mozilla Services:** We use services of other companies like ExactTarget, Google, and SurveyGizmo for emails, analytics, and surveys.  We encourage you to review their privacy policies and terms, as they are different from ours.

--- a/legal-copy/terms-of-use.html
+++ b/legal-copy/terms-of-use.html
@@ -1,0 +1,101 @@
+
+<!doctype html>
+<html>
+<head>
+    <title>Test Pilot</title>
+    <link rel="shortcut icon" href="/static/images/favicon.ico">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
+    <link rel="stylesheet" href="/static/styles/main.css">
+
+    <meta charset="utf-8">
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US">
+    <meta name="viewport" content="width=device-width">
+    <link rel="localization" href="/static/locales/{locale}/app.l20n'">
+
+</head>
+<body>
+  <div data-hook="page-container">
+    <div class="flat-blue">
+      <div class="shifted-stars"></div>
+      <header id="main-header" class="responsive-content-wrapper">
+          <h1>
+            <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
+          </h1>
+        </header>
+    </div>
+    <div class="full-page-wrapper space-between">
+      <div class="responsive-content-wrapper">
+                                <h1>Test Pilot Terms of Use</h1>
+<p>May 3, 2016</p>
+<ol>
+<li><h2>Introduction</h2>
+<p>“Test Pilot” is Mozilla’s platform to share the next generation of Firefox features (“Test Pilot Experiments”) with volunteers interested in testing, providing feedback, and possibly contributing to code.  Please read this entire document (“Terms”) carefully because it explains your rights and responsibilities when you use Test Pilot or any individual Test Pilot Experiment. By accessing the Test Pilot website, the Test Pilot Add-On, or any Test Pilot Experiment, you agree to be bound by these Terms.</p></li>
+<li><h2>Account</h2>
+<p>You'll need to have a Firefox Account to participate in Test Pilot. If you sign up for a Firefox Account, you agree to its Terms of Service and Privacy Notice.</p></li>
+<li><h2>Features &amp; Feedback</h2>
+<p>To participate, you’ll be asked to install an Add-On (“Test Pilot Add-on”).  An icon will then be added to your Firefox toolbar so you can easily access the Test Pilot site.  From this site, you can learn more about available and upcoming Test Pilot Experiments.  Once you start a Test Pilot Experiment it will display as “active” until (a) the Test Pilot Experiment automatically ends or (b) you choose to end the Test Pilot Experiment by selecting “stop”.</p>
+<p>As part of each Test Pilot Experiment we’ll prompt you with feedback requests.  This may include surveys, emails, or quick pulse checks.  Some of these feedback requests may be through third-party services, like Google Forms.  Because third-party services have different legal and privacy terms, we encourage you to review them before use.</p>
+<p>Any feedback you share with us will only be made publicly accessible in an aggregated format without identifying you.</p></li>
+<li><h2>Privacy</h2>
+<p>The Test Pilot Privacy Notice describes, generally, what data we receive from your participation in any Test Pilot Experiment. We use the information we receive through Test Pilot as described in our Mozilla Privacy Policy.</p></li>
+<li><h2>Termination</h2>
+<p>These Terms will continue to apply until ended by either you or Mozilla. You can choose to end them at any time for any reason by deactivating your Test Pilot account and  discontinuing your use of Test Pilot and all Test Pilot Experiments. If at any time, you decide you no longer wish to participate in Test Pilot, you may deactivate your Test Pilot account by visiting https://testpilot.firefox.com, signing in using your Firefox Account, clicking the &quot;Settings&quot; button, and clicking &quot;Leave Test Pilot&quot;.</p>
+<p>We may suspend or terminate your access to Test Pilot at any time for any reason, or no reason at all, including, but not limited to, if we reasonably believe: (i) you have violated these Terms; (ii) you create risk or possible legal exposure for us; or (iii) our provision of Test Pilot to you is no longer commercially viable.</p>
+<p>In all such cases, these Terms shall terminate, except that the following sections shall continue to apply: Section 7 - Indemnification, Section 8 - Disclaimer; Limitation of Liability, and Section 10 - Miscellaneous.</p></li>
+<li><h2>Voluntary Participation</h2>
+<p>You acknowledge that your participation in Test Pilot is voluntary and does not create any employment relationship between you and Mozilla.  You further acknowledge that Mozilla is an open source project with open channels for feedback, code contribution, and participation.  Any feedback you provide to Test Pilot, or derivative thereof, may be used by Mozilla and its community without any remuneration, compensation, or credit to you.</p></li>
+<li><h2>Indemnification</h2>
+<p>You agree to defend, indemnify and hold harmless Mozilla, its contractors, contributors, licensors, and partners; and the respective directors, officers, employees and agents of the foregoing (&quot;Indemnified Parties&quot;) from and against any and all third party claims and expenses, including attorneys' fees, arising out of or related to your use of Test Pilot.</p></li>
+<li><h2>Disclaimer; Limitation of Liability</h2>
+<p>TEST PILOT, ANY SOFTWARE PROVIDED AS PART OF TEST PILOT AND ALL FEATURE PREVIEWS ARE PROVIDED &quot;AS IS&quot; WITH ALL FAULTS. TO THE EXTENT PERMITTED BY LAW, MOZILLA AND THE INDEMNIFIED PARTIES HEREBY DISCLAIM ALL WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES THAT TEST PILOT IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE, AND NON-INFRINGING. YOU BEAR THE ENTIRE RISK AS TO USING TEST PILOT FOR YOUR PURPOSES AND AS TO THE QUALITY AND PERFORMANCE OF TEST PILOT, INCLUDING WITHOUT LIMITATION THE RISK THAT YOUR HARDWARE, SOFTWARE, OR CONTENT IS DELETED OR CORRUPTED, THAT SOMEONE ELSE GAINS UNAUTHORIZED ACCESS TO YOUR INFORMATION. THIS LIMITATION WILL APPLY NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF IMPLIED WARRANTIES, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.</p>
+<p>EXCEPT AS REQUIRED BY LAW, MOZILLA AND THE INDEMNIFIED PARTIES WILL NOT BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING OUT OF OR IN ANY WAY RELATING TO THESE TERMS OR THE USE OF OR INABILITY TO USE TEST PILOT, INCLUDING WITHOUT LIMITATION DIRECT AND INDIRECT DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, LOST PROFITS, LOSS OF DATA, AND COMPUTER FAILURE OR MALFUNCTION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF THE THEORY (CONTRACT, TORT, OR OTHERWISE) UPON WHICH SUCH CLAIM IS BASED. THE COLLECTIVE LIABILITY OF MOZILLA AND THE INDEMNIFIED PARTIES UNDER THIS AGREEMENT WILL NOT EXCEED $500 (FIVE HUNDRED DOLLARS). SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.</p></li>
+<li><h2>Modification to these Terms</h2>
+<p>We may update these Terms to address a new feature of Test Pilot or to clarify a provision. If the changes are substantive, we will announce the update through our usual channels such as blog posts, banners, emails, or forums. Your continued use of Test Pilot after the effective date of such changes constitutes your acceptance of such changes.</p></li>
+<li><h2>Miscellaneous</h2>
+<p>These Terms constitute the entire agreement between you and Mozilla concerning Test Pilot and supersede any prior versions of these Terms. These Terms are governed by the laws of the State of California, U.S.A., excluding its conflict of law provisions. All claims and disputes arising out of  these Terms shall be brought exclusively in the courts of Santa Clara County, California, and you consent to personal jurisdiction in those courts. If any portion of these Terms is held to be invalid or unenforceable, the remaining portions will remain in full force and effect. In the event of a conflict between a translated version of these Terms and the English language version, the English language version shall control.</p></li>
+<li><h2>Contact</h2>
+<p>Legal questions can be directed to:</p>
+<p>Legal-notices at mozilla.com<br>
+Telephone: 650-903-0800<br>
+Fax: 650-903-0875<br>
+Mail: Mozilla Corporation<br>
+  Attn: Mozilla – Legal Notices<br>
+  331 E. Evelyn Ave.,<br>
+  Mountain View, CA 94041<br>
+  USA</p></li>
+</ol>
+
+                                
+      </div>
+      <footer id="main-footer" class="responsive-content-wrapper">
+        <div id="footer-links">
+          <a href="https://www.mozilla.org" class="mozilla-logo"></a>
+          <a data-l10n-id="footerLinkLegal" href="https://www.mozilla.org/about/legal/" class="boilerplate">Legal</a>
+<a data-l10n-id="footerLinkPrivacy" href="/privacy" class="boilerplate">Privacy</a>
+<a data-l10n-id="footerLinkTerms" href="/privacy" class="boilerplate">Terms of Use</a>
+          <a data-l10n-id="footerLinkCookies" href="https://www.mozilla.org/privacy/websites/#cookies" class="boilerplate">Cookies</a>
+          <a data-l10n-id="footerLinkContribute" href="https://www.mozilla.org/contribute/signup/" class="boilerplate">Contribute</a>
+        </div>
+      </footer>
+    </div>
+  </div>
+  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)
+    },i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    if (typeof(ga) !== 'undefined') {
+        ga('create', 'UA-49796218-34', 'auto');
+    } else {
+        console.warn(
+          'You have google analytics blocked. We understand. Take a ' +
+          'look at our privacy policy to see how we handle your data.'
+        );
+    }
+  </script>
+</body>
+</html>

--- a/legal-copy/terms-of-use.md
+++ b/legal-copy/terms-of-use.md
@@ -1,0 +1,54 @@
+# Test Pilot Terms of Use
+May 3, 2016
+
+0. ## Introduction
+    “Test Pilot” is Mozilla’s platform to share the next generation of Firefox features (“Test Pilot Experiments”) with volunteers interested in testing, providing feedback, and possibly contributing to code.  Please read this entire document (“Terms”) carefully because it explains your rights and responsibilities when you use Test Pilot or any individual Test Pilot Experiment. By accessing the Test Pilot website, the Test Pilot Add-On, or any Test Pilot Experiment, you agree to be bound by these Terms.
+
+0. ## Account
+    You'll need to have a Firefox Account to participate in Test Pilot. If you sign up for a Firefox Account, you agree to its Terms of Service and Privacy Notice.
+
+0. ## Features & Feedback
+    To participate, you’ll be asked to install an Add-On (“Test Pilot Add-on”).  An icon will then be added to your Firefox toolbar so you can easily access the Test Pilot site.  From this site, you can learn more about available and upcoming Test Pilot Experiments.  Once you start a Test Pilot Experiment it will display as “active” until (a) the Test Pilot Experiment automatically ends or (b) you choose to end the Test Pilot Experiment by selecting “stop”.
+
+    As part of each Test Pilot Experiment we’ll prompt you with feedback requests.  This may include surveys, emails, or quick pulse checks.  Some of these feedback requests may be through third-party services, like Google Forms.  Because third-party services have different legal and privacy terms, we encourage you to review them before use.
+
+    Any feedback you share with us will only be made publicly accessible in an aggregated format without identifying you.
+
+0. ## Privacy
+    The Test Pilot Privacy Notice describes, generally, what data we receive from your participation in any Test Pilot Experiment. We use the information we receive through Test Pilot as described in our Mozilla Privacy Policy.
+
+0. ## Termination
+    These Terms will continue to apply until ended by either you or Mozilla. You can choose to end them at any time for any reason by deactivating your Test Pilot account and  discontinuing your use of Test Pilot and all Test Pilot Experiments. If at any time, you decide you no longer wish to participate in Test Pilot, you may deactivate your Test Pilot account by visiting https://testpilot.firefox.com, signing in using your Firefox Account, clicking the "Settings" button, and clicking "Leave Test Pilot".
+
+    We may suspend or terminate your access to Test Pilot at any time for any reason, or no reason at all, including, but not limited to, if we reasonably believe: (i) you have violated these Terms; (ii) you create risk or possible legal exposure for us; or (iii) our provision of Test Pilot to you is no longer commercially viable.
+
+    In all such cases, these Terms shall terminate, except that the following sections shall continue to apply: Section 7 - Indemnification, Section 8 - Disclaimer; Limitation of Liability, and Section 10 - Miscellaneous.
+
+0. ## Voluntary Participation
+    You acknowledge that your participation in Test Pilot is voluntary and does not create any employment relationship between you and Mozilla.  You further acknowledge that Mozilla is an open source project with open channels for feedback, code contribution, and participation.  Any feedback you provide to Test Pilot, or derivative thereof, may be used by Mozilla and its community without any remuneration, compensation, or credit to you.
+
+0. ## Indemnification
+    You agree to defend, indemnify and hold harmless Mozilla, its contractors, contributors, licensors, and partners; and the respective directors, officers, employees and agents of the foregoing ("Indemnified Parties") from and against any and all third party claims and expenses, including attorneys' fees, arising out of or related to your use of Test Pilot.
+
+0. ## Disclaimer; Limitation of Liability
+    TEST PILOT, ANY SOFTWARE PROVIDED AS PART OF TEST PILOT AND ALL FEATURE PREVIEWS ARE PROVIDED "AS IS" WITH ALL FAULTS. TO THE EXTENT PERMITTED BY LAW, MOZILLA AND THE INDEMNIFIED PARTIES HEREBY DISCLAIM ALL WARRANTIES, WHETHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES THAT TEST PILOT IS FREE OF DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE, AND NON-INFRINGING. YOU BEAR THE ENTIRE RISK AS TO USING TEST PILOT FOR YOUR PURPOSES AND AS TO THE QUALITY AND PERFORMANCE OF TEST PILOT, INCLUDING WITHOUT LIMITATION THE RISK THAT YOUR HARDWARE, SOFTWARE, OR CONTENT IS DELETED OR CORRUPTED, THAT SOMEONE ELSE GAINS UNAUTHORIZED ACCESS TO YOUR INFORMATION. THIS LIMITATION WILL APPLY NOTWITHSTANDING THE FAILURE OF ESSENTIAL PURPOSE OF ANY REMEDY. SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF IMPLIED WARRANTIES, SO THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+    EXCEPT AS REQUIRED BY LAW, MOZILLA AND THE INDEMNIFIED PARTIES WILL NOT BE LIABLE FOR ANY INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL, OR EXEMPLARY DAMAGES ARISING OUT OF OR IN ANY WAY RELATING TO THESE TERMS OR THE USE OF OR INABILITY TO USE TEST PILOT, INCLUDING WITHOUT LIMITATION DIRECT AND INDIRECT DAMAGES FOR LOSS OF GOODWILL, WORK STOPPAGE, LOST PROFITS, LOSS OF DATA, AND COMPUTER FAILURE OR MALFUNCTION, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES AND REGARDLESS OF THE THEORY (CONTRACT, TORT, OR OTHERWISE) UPON WHICH SUCH CLAIM IS BASED. THE COLLECTIVE LIABILITY OF MOZILLA AND THE INDEMNIFIED PARTIES UNDER THIS AGREEMENT WILL NOT EXCEED $500 (FIVE HUNDRED DOLLARS). SOME JURISDICTIONS DO NOT ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL, CONSEQUENTIAL, OR SPECIAL DAMAGES, SO THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+0. ## Modification to these Terms
+    We may update these Terms to address a new feature of Test Pilot or to clarify a provision. If the changes are substantive, we will announce the update through our usual channels such as blog posts, banners, emails, or forums. Your continued use of Test Pilot after the effective date of such changes constitutes your acceptance of such changes.
+
+0. ## Miscellaneous
+    These Terms constitute the entire agreement between you and Mozilla concerning Test Pilot and supersede any prior versions of these Terms. These Terms are governed by the laws of the State of California, U.S.A., excluding its conflict of law provisions. All claims and disputes arising out of  these Terms shall be brought exclusively in the courts of Santa Clara County, California, and you consent to personal jurisdiction in those courts. If any portion of these Terms is held to be invalid or unenforceable, the remaining portions will remain in full force and effect. In the event of a conflict between a translated version of these Terms and the English language version, the English language version shall control.
+
+0. ## Contact
+    Legal questions can be directed to:
+
+    Legal-notices at mozilla.com  
+    Telephone: 650-903-0800  
+    Fax: 650-903-0875  
+    Mail: Mozilla Corporation  
+      &nbsp; Attn: Mozilla – Legal Notices  
+      &nbsp; 331 E. Evelyn Ave.,  
+      &nbsp; Mountain View, CA 94041  
+      &nbsp; USA  

--- a/locales/en-US/app.l20n
+++ b/locales/en-US/app.l20n
@@ -10,6 +10,7 @@
 <footerLinkContribute "Contribute">
 <footerLinkCookies "Cookies">
 <footerLinkPrivacy "Privacy">
+<footerLinkTerms "Terms">
 <footerLinkLegal "Legal">
 
 <home "Home">

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "isomorphic-fetch": "^2.1.1",
     "js-cookie": "2.1.1",
     "mustache": "^2.1.3",
-    "query-string": "4.1.0"
+    "query-string": "4.1.0",
+    "remarkable": "1.6.2",
+    "through2": "2.0.1"
   },
   "devDependencies": {
     "babel": "^5.8.21",

--- a/testpilot/base/urls.py
+++ b/testpilot/base/urls.py
@@ -9,4 +9,6 @@ urlpatterns = patterns(
     url(r'^__heartbeat__', views.ops_heartbeat, name='ops-heartbeat'),
     url(r'^__lbheartbeat__', views.ops_lbheartbeat, name='ops-lbheartbeat'),
     url(r'^contribute\.json$', views.contribute_json, name='contribute-json'),
+    url(r'^privacy', views.privacy, name='privacy-notice'),
+    url(r'^terms', views.terms, name='terms-of-service'),
 )

--- a/testpilot/base/views.py
+++ b/testpilot/base/views.py
@@ -37,3 +37,11 @@ def ops_version(request):
 
 def contribute_json(request):
     return static.serve(request, 'contribute.json', document_root=settings.ROOT)
+
+
+def privacy(request):
+    return static.serve(request, 'legal-copy/privacy-notice.html', document_root=settings.ROOT)
+
+
+def terms(request):
+    return static.serve(request, 'legal-copy/terms-of-use.html', document_root=settings.ROOT)

--- a/testpilot/frontend/static-src/app/templates/landing-page.js
+++ b/testpilot/frontend/static-src/app/templates/landing-page.js
@@ -67,7 +67,7 @@ export default `
               <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
               {{/isFirefox}}
             </div>
-            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="https://www.mozilla.org/about/legal/terms/services/">Terms of Service</a> and <a href="https://www.mozilla.org/privacy/firefox-cloud/">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
+            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
             <div class="transparent-container">
               <div class="responsive-content-wrapper delayed-fade-in">
                   <h2 class="card-list-header" data-l10n-id="landingExperimentsTitle">Try these features today with Test Pilot</h2>
@@ -111,7 +111,7 @@ export default `
                 <button data-l10n-id="landingFxaGetStartedButton" class="button extra-large primary" data-hook="get-started-with-account">Get started with a Firefox Account</button>
                 {{/isFirefox}}
               </div>
-            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="https://www.mozilla.org/about/legal/terms/services/">Terms of Service</a> and <a href="https://www.mozilla.org/privacy/firefox-cloud/">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
+            {{#isFirefox}}<p data-l10n-id="landingLegalNotice" class="legal-information delayed-fade-in-up">By proceeding, you agree to the <a href="/terms">Terms of Service</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>{{/isFirefox}}
             </div>
             <footer id="main-footer" class="responsive-content-wrapper">
               <div data-hook="footer-view"></div>
@@ -156,5 +156,3 @@ export default `
     {{/loggedIn}}
 </section>
 `;
-
-

--- a/testpilot/frontend/static-src/app/views/footer-view.js
+++ b/testpilot/frontend/static-src/app/views/footer-view.js
@@ -4,7 +4,8 @@ export default BaseView.extend({
   template: `<div id="footer-links">
                  <a href="https://www.mozilla.org" class="mozilla-logo"></a>
                  <a data-l10n-id="footerLinkLegal" href="https://www.mozilla.org/about/legal/" class="boilerplate">Legal</a>
-                 <a data-l10n-id="footerLinkPrivacy" href="https://www.mozilla.org/privacy/" class="boilerplate">Privacy</a>
+                 <a data-l10n-id="footerLinkPrivacy" href="/privacy" class="boilerplate">Privacy</a>
+                 <a data-l10n-id="footerLinkTerms" href="/terms" class="boilerplate">Terms of Use</a>
                  <a data-l10n-id="footerLinkCookies" href="https://www.mozilla.org/privacy/websites/#cookies" class="boilerplate">Cookies</a>
                  <a data-l10n-id="footerLinkContribute" href="https://www.mozilla.org/contribute/signup/" class="boilerplate">Contribute</a>
              </div>`


### PR DESCRIPTION
- fixes #619
- add routes to serve static legal pages in `base/views.py`
- add gulp task `legal` to generate legal pages from markdown files
- add `legal-copy` dir to house legal md and html files
- update privacy and terms links in front end and footer
- update locales/en-US to reflect new footer link(terms)

ugh finally

cc/ @johngruen @pdehaan @lmorchard @ckprice 
