### PR TITLE
fix(legal): Fix link to /terms in legal pages

### DIFF
--- a/legal-copy/legal-templates.js
+++ b/legal-copy/legal-templates.js
@@ -34,7 +34,7 @@ module.exports.templateEnd = `
           <a href="https://www.mozilla.org" class="mozilla-logo"></a>
           <a data-l10n-id="footerLinkLegal" href="https://www.mozilla.org/about/legal/" class="boilerplate">Legal</a>
 <a data-l10n-id="footerLinkPrivacy" href="/privacy" class="boilerplate">Privacy</a>
-<a data-l10n-id="footerLinkTerms" href="/privacy" class="boilerplate">Terms of Use</a>
+<a data-l10n-id="footerLinkTerms" href="/terms" class="boilerplate">Terms of Use</a>
           <a data-l10n-id="footerLinkCookies" href="https://www.mozilla.org/privacy/websites/#cookies" class="boilerplate">Cookies</a>
           <a data-l10n-id="footerLinkContribute" href="https://www.mozilla.org/contribute/signup/" class="boilerplate">Contribute</a>
         </div>


### PR DESCRIPTION
Ref: https://github.com/mozilla/testpilot/pull/706#discussion_r62126442
