### PR TITLE
Send installed experiments to external survey

### DIFF
--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -149,7 +149,8 @@ function getRatingUI(win, notifyBox, box, messageText, addonId,
     notifyBox.removeNotification(box);
     const params = querystring.stringify({id: addonId,
                                           rating: rating,
-                                          interval: interval});
+                                          interval: interval,
+                                          installed: Object.keys(store.installedAddons)});
     tabs.open(`${surveyUrl}?${params}`);
   }
 

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -12,7 +12,7 @@ export default `
           <span class="now-active" data-hook="now-active" data-l10n-id="nowActive">Active</span>
           <div class="experiment-controls">
             <a data-hook="highlight-privacy" class="highlight-privacy" data-l10n-id=highlightPrivacy>Your privacy</a>
-            <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default" target="_blank">Give Feedback</a>
+            <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default">Give Feedback</a>
             <button data-hook="uninstall" id="uninstall-button" class="button secondary"><span class="state-change-inner"></span><span data-l10n-id="disableExperimentTransition" class="transition-text">Disabling...</span><span data-l10n-id="disableExperiment" class="default-text">Disable <span data-hook="title"></span></span></button>
             <button data-hook="install" id="install-button" class="button default"><span class="state-change-inner"></span><span data-l10n-id="enableExperimentTransition" class="transition-text">Enabling...</span><span data-l10n-id="enableExperiment" class="default-text">Enable <span data-hook="title"></span></span></button>
           </div>

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -152,12 +152,6 @@ export default PageView.extend({
       type: 'attribute',
       name: 'src',
       hook: 'thumbnail'
-    },
-
-    'model.survey_url': {
-      type: 'attribute',
-      name: 'href',
-      hook: 'feedback'
     }
   },
 
@@ -273,7 +267,10 @@ export default PageView.extend({
       eventLabel: 'Disable Experiment'
     });
 
-    const queryParams = querystring.stringify({ref: 'disable', experiment: this.model.title});
+    const installed = Object.keys(app.me.installed);
+    const queryParams = querystring.stringify({ref: 'disable',
+                                               experiment: this.model.title,
+                                               installed: installed});
 
     this.uninstall(evt);
 
@@ -311,12 +308,18 @@ export default PageView.extend({
     this.didScroll = false;
   },
 
-  feedback() {
-    // Survey link is opened via href link in the template
+  feedback(evt) {
+    evt.preventDefault();
+    const installed = Object.keys(app.me.installed);
+    const queryParams = querystring.stringify({ref: 'givefeedback',
+                                               experiment: this.model.title,
+                                               installed: installed});
+
     app.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
       eventAction: 'button click',
-      eventLabel: 'Give Feedback'
+      eventLabel: 'Give Feedback',
+      outboundURL: `${this.model.survey_url}?${queryParams}`
     });
   }
 });


### PR DESCRIPTION
- fixes #667
- bump addon version to 0.5.5
- sends installed experiments to external survey under key `installed`

cc/ @ckprice 
