### PR TITLE
Switch to `exec gunicorn` on prod for better signal handling

### DIFF
--- a/bin/run-prod.sh
+++ b/bin/run-prod.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 ./bin/run-common.sh
-gunicorn testpilot.wsgi:application -b 0.0.0.0:${PORT:-8000} --log-file -
+exec gunicorn testpilot.wsgi:application -b 0.0.0.0:${PORT:-8000} --log-file -


### PR DESCRIPTION
> <mostlygeek> could you make it "exec gunicorn ..." instead
> <mostlygeek> that will cause bash to replace itself with gunicorn and
>              we can send SIGHUP/SIGKILL/SIG\* to it without any
>              timeouts

Issue #810
