### PR TITLE
add context query params to addon doorhanger links

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -27,6 +27,7 @@ const tabs = require('sdk/tabs');
 const {ToggleButton} = require('sdk/ui/button/toggle');
 const request = require('sdk/request').Request;
 const simplePrefs = require('sdk/simple-prefs');
+const querystring = require('sdk/querystring');
 const URL = require('sdk/url').URL;
 const history = require('sdk/places/history');
 
@@ -238,13 +239,24 @@ panel.port.on('link', url => {
   panel.hide();
 });
 
+function getParams(title) {
+  return querystring.stringify({
+    utm_source: 'testpilot-addon',
+    utm_medium: 'firefox-browser',
+    utm_campaign: 'testpilot-doorhanger',
+    utm_content: title
+  });
+}
+
 function getExperimentList(availableExperiments, installedAddons) {
   return Mustache.render(templates.experimentList, {
     base_url: settings.BASE_URL,
+    view_all_params: getParams('view-all-experiments'),
     experiments: Object.keys(availableExperiments).map(k => {
       if (installedAddons[k]) {
         availableExperiments[k].active = installedAddons[k].active;
       }
+      availableExperiments[k].params = getParams(availableExperiments[k].title);
       return availableExperiments[k];
     })
   });

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -7,7 +7,7 @@
 module.exports.experimentList = `
 <div class="experiment-list">
   {{#experiments}}
-    <a class="experiment-item {{#active}}active{{/active}}" href="{{base_url}}/experiments/{{slug}}">
+    <a class="experiment-item {{#active}}active{{/active}}" href="{{base_url}}/experiments/{{slug}}?{{params}}">
       <div class="icon-wrapper"
            style="background-color:{{gradient_start}}; background-image: linear-gradient(300deg, {{gradient_start}}, {{gradient_stop}})">
         <div class="icon" style="background-image:url('{{thumbnail}}');"></div>
@@ -18,7 +18,7 @@ module.exports.experimentList = `
     </a>
   {{/experiments}}
 </div>
-<a class="view-all" href="{{base_url}}">View all experiments</a>`;
+<a class="view-all" href="{{base_url}}/experiments?{{view_all_params}}">View all experiments</a>`;
 
 module.exports.installed = `
 <div class="installed-message">

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- fixes #745
- bump `addon/package.json` version to `0.5.9`
