### PR TITLE
Add bug report link to experiment model

### DIFF
--- a/fixtures/demo_data.json
+++ b/fixtures/demo_data.json
@@ -192,7 +192,8 @@
     "created": "2015-12-09T15:45:42.395Z",
     "slug": "universal-search",
     "xpi_url": "https://s3-us-west-2.amazonaws.com/universal-search/universal-search.xpi",
-    "contribute_url": "https://github.com/mozilla/universal-search/blob/master/README.md"
+    "contribute_url": "https://github.com/mozilla/universal-search/blob/master/README.md",
+    "bug_report_url": "https://github.com/mozilla/universal-search/issues"
   }
 },
 {
@@ -209,7 +210,8 @@
     "created": "2015-12-09T15:47:56.050Z",
     "slug": "mozvr",
     "xpi_url": "http://example.com",
-    "contribute_url": ""
+    "contribute_url": "https://github.com/bwinton/VerticalTabs",
+    "bug_report_url": "https://github.com/bwinton/VerticalTabs/issues"
   }
 },
 {
@@ -226,7 +228,8 @@
     "created": "2015-12-10T20:11:55.207Z",
     "slug": "activity-stream",
     "xpi_url": "http://example.com",
-    "contribute_url": ""
+    "contribute_url": "https://github.com/mozilla/activity-stream",
+    "bug_report_url": "https://github.com/mozilla/activity-stream/issues"
   }
 },
 {

--- a/locales/en-US/app.l20n
+++ b/locales/en-US/app.l20n
@@ -86,6 +86,7 @@
 <changelog "changelog">
 <lastUpdate "Last Update">
 <contribute "Contribute">
+<bugReports "Bug Reports">
 <nowActive "Active">
 <userCount title:"Active Users of this Experiment">
 <tourOnboardingTitle "{{title}} enabled!">

--- a/testpilot/experiments/migrations/0016_auto_20160512_1704.py
+++ b/testpilot/experiments/migrations/0016_auto_20160512_1704.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0015_experimenttourstep'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='bug_report_url',
+            field=models.URLField(blank=True),
+        )
+    ]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -48,6 +48,7 @@ class Experiment(TranslatableModel):
     order = models.IntegerField(default=0)
     changelog_url = models.URLField(blank=True)
     contribute_url = models.URLField(blank=True)
+    bug_report_url = models.URLField(blank=True)
     privacy_notice_url = models.URLField(blank=True)
     addon_id = models.CharField(max_length=500, blank=False,)
     gradient_start = ColorField(default='#e07634')

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -50,8 +50,8 @@ class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
         fields = ('id', 'url', 'title', 'short_title', 'slug',
                   'thumbnail', 'description', 'introduction',
                   'version', 'changelog_url', 'contribute_url',
-                  'privacy_notice_url', 'measurements', 'xpi_url',
-                  'addon_id', 'gradient_start', 'gradient_stop',
+                  'bug_report_url', 'privacy_notice_url', 'measurements',
+                  'xpi_url', 'addon_id', 'gradient_start', 'gradient_stop',
                   'details', 'tour_steps', 'contributors',
                   'survey_url', 'installations_url',
                   'installation_count', 'created', 'modified', 'order',)

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -81,6 +81,7 @@ class ExperimentViewTests(BaseTestCase):
                         "version": experiment.version,
                         "changelog_url": experiment.changelog_url,
                         "contribute_url": experiment.contribute_url,
+                        "bug_report_url": experiment.bug_report_url,
                         "privacy_notice_url": experiment.privacy_notice_url,
                         "addon_id": experiment.addon_id,
                         "gradient_start": experiment.gradient_start,

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -47,6 +47,11 @@ export default `
                       <td data-l10n-id="contribute">Contribute</td>
                       <td><a data-hook="contribute-url"></a></td>
                     </tr>
+
+                    <tr>
+                      <td data-l10n-id="bugReports">Bug Reports</td>
+                      <td><a data-hook="bug-report-url"></a></td>
+                    </tr>
                   </table>
                 </section>
                 <section class="contributors-section">

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -106,6 +106,15 @@ export default PageView.extend({
       hook: 'contribute-url'
     }],
 
+    'model.bug_report_url': [{
+      hook: 'bug-report-url'
+    },
+    {
+      type: 'attribute',
+      name: 'href',
+      hook: 'bug-report-url'
+    }],
+
     'model.introduction': [{
       type: 'innerHTML',
       hook: 'introduction-html'


### PR DESCRIPTION
- fixes #721
- updates frontend view, template, and test for experiment page
- updates experiment model, serializer, and test
- adds migration for model update
- add bugReport key to app.l20n
- updates `fixtures/demo_data.json` with `bug_report_url`
