### PR TITLE
Fix 500 errors for prod when DEBUG=False

### DIFF
--- a/testpilot/frontend/templates/testpilot/frontend/index.html
+++ b/testpilot/frontend/templates/testpilot/frontend/index.html
@@ -9,7 +9,7 @@
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="en-US">
     <meta name="viewport" content="width=device-width">
-    <link rel="localization" href="{{ static('locales/{locale}/app.l20n') }}">
+    <link rel="localization" href="{{ settings.STATIC_URL }}locales/{locale}/app.l20n">
 
 </head>
 <body>


### PR DESCRIPTION
- Use STATIC_URL setting to construct locale URL, because static()
  causes 500 ISEs when the path doesn't lead to a real file.

Issue #810
