### PR TITLE
Turn off AWS S3 pre-signed auth in image URLs

### DIFF
--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -313,6 +313,7 @@ if DEFAULT_FILE_STORAGE == 'storages.backends.s3boto.S3BotoStorage':
     AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default=None)
     AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default=None)
     AWS_STORAGE_BUCKET_NAME = config('AWS_STORAGE_BUCKET_NAME')
+    AWS_QUERYSTRING_AUTH = False
     MEDIA_URL = config('MEDIA_URL')
 else:
     MEDIA_ROOT = config('MEDIA_ROOT', default=os.path.join(BASE_DIR, 'media'))


### PR DESCRIPTION
Currently, all of our uploaded images on prod are getting linked to with lengthy and time-limited pre-signed S3 URLs generated per request:

```
https://testpilot-prod.s3.amazonaws.com/experiments_experimentdetail/3/0/30c1166dd2476cb66ec57fc3049303e6_image_1462827296_0000.jpg?Signature=My3I57E%2Ft71oz0vIOQQ4UaZq4oo%3D&Expires=1463090636&AWSAccessKeyId=ASIAJXKZRUBAS7ZHTGTA&x-amz-security-token=FQoDYXdzEDUaDCyeQb22bXsw%2BDUEISKZA2YDIK3HQiOMXtZqQci33RObjxhLNIyryfPA79yYKCh7WPPeQ5f7A6Oj38vGhNPkl%2BQdETGNwO2ey/SBrppuC/AoEBllYCs%2BCP22d3lQogeaDMkBDWvmjcI5PBeuL47Z/D%2B8/X7Dmv/3uJ%2BOXXeAo5sEeGjUdZLx018aeUhUjZWssEtf1KUXkCsyeXkZiAEqkLVK4pbuIhcIH2F/KYwSXPxUwmsdbx%2Bccoo%2Bt1ZqGYE/ODHe3RQbL6DxnRMcEQvd4OKYOQw18U3gJKK%2BzUyrskJLjfq6yqX0UM3hByILA/UhevxRpDv1FaO4T14sg7pPFAQCj1iiUUGWg/SmXySe7LKeRqt5MIm9%2BBwhO7tUE%2BQJzNJkEtUri6E3oKVrGUf3SPuaFdonX8UxXrAMt5J6TIQ/S62sT0PYN8WSekLUbCj8WGS/zDOTHaZvAULebuRSaWJ4QvsNR/df9EZhS2No29W8ihk%2BHQwxhMbK8y8TnJJsnUD5DDvbWm93x5MeEDfxzFEgdNBezAVVgpc/gWVts85wYRcfdsINKaso1bjTuQU%3D
```

Instead, they should be much shorter and not have S3 pre-signed auth tokens like so:

```
https://testpilot-prod.s3.amazonaws.com/experiments_experimentdetail/3/0/30c1166dd2476cb66ec57fc3049303e6_image_1462827296_0000.jpg
```

This PR adds the setting that turns off the pre-signing.
