### PR TITLE
Further fixes for 500 errors on prod when DEBUG=False

### DIFF
--- a/testpilot/base/templates/testpilot/base.html
+++ b/testpilot/base/templates/testpilot/base.html
@@ -10,7 +10,7 @@
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="en-US">
     <meta name="viewport" content="width=device-width">
-    <link rel="localization" href="{{ static('locales/{locale}/app.l20n') }}">
+    <link rel="localization" href="{{ settings.STATIC_URL }}locales/{locale}/app.l20n">
     {% endblock %}
 </head>
 <body>


### PR DESCRIPTION
- Bug fixes for 500 ISEs caused by logging middleware errors.
- Use STATIC_URL setting to construct locale URL, because static()
  causes 500 ISEs when the path doesn't lead to a real file.

Issue #810
