### PR TITLE
Dismiss installed message doorhanger when leaving page

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.5.9",
+  "version": "0.6.0",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- partial solution for #799
- add listener for 'close' and 'deactivate'
- bump addon version to `0.6.0`
- remove unused link handling for installMsgPanel
- add comment for upstream 'deactivate' bug
  https://bugzilla.mozilla.org/show_bug.cgi?id=1230816
