### PR TITLE
Replace sdk/button/toggle with sdk/button/action

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",


### PR DESCRIPTION
- fixes #860
- replaces `ToggleButton` with `ActionButton` to avoid
  error from upstream issue. https://bugzilla.mozilla.org/show_bug.cgi?id=1273293
- bump addon version to `0.6.1`
