### PR TITLE
Implement testpilot.{newuser,test-install} server log events

### DIFF
--- a/docs/README-METRICS.md
+++ b/docs/README-METRICS.md
@@ -69,8 +69,6 @@ Events recorded in the logs will include:
 
 * request.summary (a generic event fired for each visit)
 * testpilot.newuser
-* testpilot.newfeedback
-* testpilot.main-install
 * testpilot.test-install
 
 Data recorded by the log files will include standard system logging (in the

--- a/testpilot/experiments/views.py
+++ b/testpilot/experiments/views.py
@@ -63,6 +63,10 @@ def installation_detail(request, experiment_pk, client_id):
         installation, created = UserInstallation.objects.get_or_create(
             user=request.user, experiment=experiment, client_id=client_id)
         installation.save()
+        logging.getLogger('testpilot.test-install').info('', extra={
+            'uid': request.user.id,
+            'context': experiment.title
+        })
     else:
         installation = get_object_or_404(
             UserInstallation,

--- a/testpilot/users/apps.py
+++ b/testpilot/users/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class TestPilotUsersAppConfig(AppConfig):
     name = 'testpilot.users'
     verbose_name = 'Test Pilot Users'
+
+    def ready(self):
+        import testpilot.users.signals  # noqa

--- a/testpilot/users/signals.py
+++ b/testpilot/users/signals.py
@@ -1,0 +1,20 @@
+"""
+Customizations to the signup & login process for Test Pilot.
+
+See also: http://django-allauth.readthedocs.org/en/latest/signals.html
+"""
+from django.dispatch import receiver
+
+from allauth.account.signals import user_signed_up
+
+import logging
+
+
+@receiver(user_signed_up)
+def invite_only_signup_handler(sender, **kwargs):
+    """
+    Sent when a user signs up for an account.
+    """
+    user = kwargs['user']
+    logger = logging.getLogger('testpilot.newuser')
+    logger.info('', extra={'uid': user.id})


### PR DESCRIPTION
Also, update README-METRICS to remove testpilot.{newfeedback,
main-install} because they're client-side events that we're capturing
elsewhere.

Fixes #866
