### PR TITLE
update retire modal header

### DIFF
--- a/testpilot/frontend/static-src/styles/modules/_modals.scss
+++ b/testpilot/frontend/static-src/styles/modules/_modals.scss
@@ -22,7 +22,8 @@
   }
 }
 
-#four-oh-four {
+#four-oh-four,
+#retire {
   .title {
     background: $transparent-black-05;
     border-bottom: 1px solid $transparent-black-1;


### PR DESCRIPTION
Fix for issue #884, in _modals.scss I added the retire id to the title class so now it will look the same as the 404 page modal header.
