### PR TITLE
Build separate frontend app and vendor JS bundles

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ampersand-app": "^1.0.4",
     "ampersand-collection": "^1.4.5",
     "ampersand-collection-view": "^1.4.0",
-    "ampersand-events": "2.0.1",
+    "ampersand-events": "1.1.1",
     "ampersand-model": "7.0.0",
     "ampersand-rest-collection": "^5.0.0",
     "ampersand-router": "^3.0.2",
@@ -24,9 +24,7 @@
     "es6-promise": "^3.0.2",
     "isomorphic-fetch": "^2.1.1",
     "js-cookie": "2.1.1",
-    "mustache": "^2.1.3",
-    "remarkable": "1.6.2",
-    "through2": "2.0.1"
+    "mustache": "^2.1.3"
   },
   "devDependencies": {
     "babel": "^5.8.21",
@@ -39,7 +37,6 @@
     "doctoc": "1.0.0",
     "eslint-config-airbnb": "0.0.8",
     "faucet": "0.0.1",
-    "globby": "^3.0.0",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
     "gulp-cache": "^0.2.10",
@@ -56,6 +53,7 @@
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
     "node-normalize-scss": "1.1.1",
+    "remarkable": "1.6.2",
     "require-globify": "^1.3.0",
     "run-sequence": "^1.1.2",
     "tape": "^4.4.0",
@@ -63,6 +61,7 @@
     "tape-catch": "1.0.4",
     "tape-dom": "0.0.10",
     "testling": "^1.7.1",
+    "through2": "2.0.1",
     "try-require": "1.2.1",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0"

--- a/testpilot/frontend/templates/testpilot/frontend/index.html
+++ b/testpilot/frontend/templates/testpilot/frontend/index.html
@@ -68,27 +68,12 @@
 
   <script src="{{ url('wafflejs') }}"
           integrity="{{ waffleintegrity(request) }}"></script>
+  <script src="{{ static('app/vendor.js') }}"
+          integrity="{{ staticintegrity('app/vendor.js') }}"></script>
   <script src="{{ static('app/app.js') }}"
           integrity="{{ staticintegrity('app/app.js') }}"></script>
   <script src="https://pontoon.mozilla.org/pontoon.js"
           crossorigin="anonymous"
           integrity="{{ urlintegrity('https://pontoon.mozilla.org/pontoon.js') }}"></script>
-
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)
-    },i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    if (typeof(ga) !== 'undefined') {
-        ga('create', 'UA-49796218-34', 'auto');
-    } else {
-        console.warn(
-          'You have google analytics blocked. We understand. Take a ' +
-          'look at our privacy policy to see how we handle your data.'
-        );
-    }
-  </script>
 </body>
 </html>


### PR DESCRIPTION
- fix version on ampersand-event dependency
- move some devDependencies found in dependencies in package.json
- scripts-app task to build app bundle, watches for changes to app
- scripts-vendor task to build vendor bundle, only watches for changes
  to package.json
- add vendor.js script tag to frontend template
- refactor & simplify browserify build chain
- remove now-unused globby dependency, because we can give browserify a
  single app/main.js entry point and it finds other dependencies
- stop applying babel to vendor modules
- auto-assemble list of vendor dependencies from package.json

Fixes #665
