### PR TITLE
Add meta charset

### DIFF
--- a/testpilot/frontend/templates/testpilot/frontend/index.html
+++ b/testpilot/frontend/templates/testpilot/frontend/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
 <head>
+    <meta charset="utf-8" />
     <link rel="shortcut icon" href="{{ static('images/favicon.ico') }}">
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="{{ static('styles/main.css') }}">


### PR DESCRIPTION
@pdehaan [noted that we should add `<meta charset="utf-8" />`](https://github.com/mozilla/testpilot/pull/872#discussion_r63760415) to the head. I merged this in before the comment was addressed.

It was working locally, but dev is throwing a 500 error with `The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.` This ~~should~~ may fix it. /edit I can't confirm it wasn't broken before.
