### PR TITLE
Fix inconsistency in app.me.installed

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -349,9 +349,13 @@ function updateExperiments() {
 function syncAllAddonInstallations(serverInstalled) {
   const availableIDs = Object.keys(store.availableExperiments);
   const clientIDs = Object.keys(store.installedAddons);
-  const serverIDs = serverInstalled
-    .filter(item => item.client_id === store.clientUUID)
-    .map(item => item.addon_id);
+  const serverIDs = [];
+
+  for (let key in serverInstalled) { // eslint-disable-line prefer-const
+    if (serverInstalled[key].client_id === store.clientUUID) {
+      serverIDs.push(key);
+    }
+  }
 
   return Promise.all(availableIDs.filter(id => {
     const cidx = clientIDs.indexOf(id);

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -80,8 +80,8 @@ class UserInstallationSerializer(serializers.HyperlinkedModelSerializer):
 
     class Meta:
         model = UserInstallation
-        fields = ('url', 'experiment', 'client_id', 'addon_id', 'features',
-                  'created', 'modified')
+        fields = ('url', 'experiment', 'client_id', 'addon_id',
+                  'features', 'created', 'modified')
 
     def get_url(self, obj):
         request = self.context['request']

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -308,7 +308,7 @@ class FeaturesBasicTests(BaseTestCase):
     def test_me_list(self):
         """/api/me installation listing should include feature flags"""
         result = self.jsonGet('me-list')
-        self.assertEqual(result['installed'][0]['features'], {
+        self.assertEqual(list(result['installed'].values())[0]['features'], {
             self.feature1_title: True,
             self.feature2_title: True
         })

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -14,6 +14,10 @@ const test = around(tape)
       app.me = new Me({
         user: {
           id: 'gary@busey.net'
+        },
+        installed: {
+          'slsk@google.net': {},
+          'wheee@mozilla.org': {}
         }
       });
       app.sendToGA = () => {};
@@ -143,11 +147,6 @@ test('feedback button uses the expected survey URL', t => {
     '&experiment=SLSK' +
     '&installed=slsk%40google.net' +
     '&installed=wheee%40mozilla.org';
-
-  app.me.installed = {
-    'slsk@google.net': {},
-    'wheee@mozilla.org': {}
-  };
 
   myView.render();
 

--- a/testpilot/users/tests.py
+++ b/testpilot/users/tests.py
@@ -267,7 +267,7 @@ class MeViewSetTests(TestCase):
                     'username': 'johndoe'
                 },
                 'addon': self.addonData,
-                'installed': []
+                'installed': {}
             }
         )
 
@@ -285,17 +285,19 @@ class MeViewSetTests(TestCase):
 
         self.assertEqual(len(result_data['installed']), 1)
         self.assertDictEqual(
-            result_data['installed'][0],
+            result_data['installed'],
             {
-                'experiment': 'http://testserver/api/experiments/%s' % experiment.pk,
-                'addon_id': 'addon-1@example.com',
-                'client_id': client_id,
-                'features': {},
-                'url':
+                'addon-1@example.com': {
+                    'experiment': 'http://testserver/api/experiments/%s' % experiment.pk,
+                    'addon_id': 'addon-1@example.com',
+                    'client_id': client_id,
+                    'features': {},
+                    'url':
                     'http://testserver/api/experiments/%s/installations/%s' %
                     (experiment.pk, client_id),
-                'created': date_field.to_representation(installation.created),
-                'modified': date_field.to_representation(installation.modified),
+                    'created': date_field.to_representation(installation.created),
+                    'modified': date_field.to_representation(installation.modified),
+                }
             }
         )
 

--- a/testpilot/users/views.py
+++ b/testpilot/users/views.py
@@ -8,8 +8,8 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.decorators import api_view, permission_classes
 
-from ..experiments.models import UserInstallation
 from ..experiments.serializers import UserInstallationSerializer
+from ..experiments.models import UserInstallation
 from .models import UserProfile
 from .serializers import UserProfileSerializer
 
@@ -37,9 +37,13 @@ class MeViewSet(ViewSet):
                 "name": "Test Pilot",
                 "url": settings.ADDON_URL
             },
-            "installed": UserInstallationSerializer(
-                UserInstallation.objects.filter(user=user), many=True,
-                context={'request': request}).data
+            "installed": dict(
+                (obj.experiment.addon_id,
+                 UserInstallationSerializer(obj, context={
+                     'request': request
+                 }).data)
+                for obj in UserInstallation.objects.filter(user=user)
+            )
         })
 
 


### PR DESCRIPTION
- fixes #742
- users/serializers Me now returns installed in format:
  {addon_id: {addon: data}}
- fix consumption of me.installed data in addon/index.js
- bump addon package version to 0.6.4
- update experiments/tests to match new data shape
- fix default obj for installed in me.js model
- catch and log occasional error in me.js when sync-installed fails
- update experiment-page.js tests for installed shape update
- update users view and tests to send data correctly
- reformate line in experiments/serializers.py for pep8

I think this will take care of the white screen of death issue as well. refs #719 
There was an issue where `sync-installed` would timeout/fail and we did nothing with the error except reject. Which in turn threw an error in the `async.all` call in main.js, essentially sabotaging our whole plot to ship new features.
