### PR TITLE
Enable Content Security Policy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,6 +108,14 @@ function commonBrowserify(sourceName, b) {
     .pipe(gulp.dest(DEST_PATH + 'app/'));
 }
 
+gulp.task('scripts', shouldLint('js-lint', 'lint'), function extraScriptsTask() {
+  return gulp.src(SRC_PATH + 'scripts/**/*')
+    .pipe(gulpif(IS_DEBUG, sourcemaps.init({loadMaps: true})))
+    .pipe(gulpif(!IS_DEBUG, uglify()))
+    .pipe(gulpif(IS_DEBUG, sourcemaps.write('./')))
+    .pipe(gulp.dest(DEST_PATH + 'scripts'));
+});
+
 gulp.task('styles', shouldLint('sass-lint', 'sass-lint'), function stylesTask() {
   return gulp.src(SRC_PATH + 'styles/**/*.scss')
     .pipe(sourcemaps.init())
@@ -155,23 +163,17 @@ gulp.task('addon', function localesTask() {
     .pipe(gulp.dest(DEST_PATH + 'addon'));
 });
 
-// Copy the static legal.js file to dest
-gulp.task('static-script-copy', function staticScriptCopyTask() {
-  return gulp.src(SRC_PATH + 'scripts/**/*')
-    .pipe(gulp.dest(DEST_PATH + 'scripts'));
-});
-
 gulp.task('build', function buildTask(done) {
   runSequence(
     'clean',
     'app-vendor',
     'app-main',
+    'scripts',
     'styles',
     'images',
     'locales',
     'addon',
     'legal',
-    'static-script-copy',
     done
   );
 });
@@ -181,6 +183,7 @@ gulp.task('watch', ['build'], function watchTask() {
   gulp.watch(SRC_PATH + 'images/**/*', ['images']);
   gulp.watch(SRC_PATH + 'app/**/*.js', ['app-main']);
   gulp.watch('./package.json', ['app-vendor']);
+  gulp.watch(SRC_PATH + 'scripts/**/*.js', ['scripts']);
   gulp.watch(SRC_PATH + 'addon/**/*', ['addon']);
   gulp.watch(['./legal-copy/*.md', './legal-copy/*.js'], ['legal']);
   gulp.watch('./locales/**/*', ['locales']);

--- a/legal-copy/legal-templates.js
+++ b/legal-copy/legal-templates.js
@@ -41,23 +41,6 @@ module.exports.templateEnd = `
       </footer>
     </div>
   </div>
-  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
-  <script src="/static/scripts/legal.js"></script>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)
-    },i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    if (typeof(ga) !== 'undefined') {
-        ga('create', 'UA-49796218-34', 'auto');
-    } else {
-        console.warn(
-          'You have google analytics blocked. We understand. Take a ' +
-          'look at our privacy policy to see how we handle your data.'
-        );
-    }
-  </script>
+  <script src="/static/scripts/legal.js"></scripts>
 </body>
 </html>`;

--- a/testpilot/base/urls.py
+++ b/testpilot/base/urls.py
@@ -8,6 +8,7 @@ urlpatterns = patterns(
     url(r'^__version__', views.ops_version, name='ops-version'),
     url(r'^__heartbeat__', views.ops_heartbeat, name='ops-heartbeat'),
     url(r'^__lbheartbeat__', views.ops_lbheartbeat, name='ops-lbheartbeat'),
+    url(r'^__cspreport__', views.csp_report, name='csp-report'),
     url(r'^contribute\.json$', views.contribute_json, name='contribute-json'),
     url(r'^privacy', views.privacy, name='privacy-notice'),
     url(r'^terms', views.terms, name='terms-of-service'),

--- a/testpilot/base/views.py
+++ b/testpilot/base/views.py
@@ -1,9 +1,12 @@
 import json
 import os.path
 
+import logging
+
 from django.conf import settings
 from django.http import HttpResponse, HttpResponseServerError, JsonResponse
 from django.views import static
+from django.views.decorators.csrf import csrf_exempt
 
 from ..experiments.models import Experiment
 
@@ -33,6 +36,13 @@ def ops_version(request):
             "commit": "dev"
         }
     return JsonResponse(data)
+
+
+@csrf_exempt
+def csp_report(request):
+    logger = logging.getLogger('testpilot.csp')
+    logger.info('', extra=json.loads(request.body.decode("utf-8")))
+    return HttpResponse('ok')
 
 
 def contribute_json(request):

--- a/testpilot/frontend/static-src/app/main.js
+++ b/testpilot/frontend/static-src/app/main.js
@@ -17,6 +17,23 @@ import Router from './lib/router';
 import domReady from 'domready';
 
 /* global ga*/
+/*eslint-disable*/
+// HACK: Google Analytics lives here, because CSP won't let it live inline
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)
+},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+/*eslint-enable*/
+
+if (typeof(ga) !== 'undefined') {
+  ga('create', 'UA-49796218-34', 'auto');
+} else {
+  console.warn(
+    'You have google analytics blocked. We understand. Take a ' +
+    'look at our privacy policy to see how we handle your data.'
+  );
+}
 
 app.extend({
   router: new Router(),

--- a/testpilot/frontend/static-src/scripts/legal.js
+++ b/testpilot/frontend/static-src/scripts/legal.js
@@ -1,3 +1,22 @@
+/* global ga*/
+/*eslint-disable*/
+// HACK: Google Analytics lives here, because CSP won't let it live inline
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)
+},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+/*eslint-enable*/
+
+if (typeof(ga) !== 'undefined') {
+  ga('create', 'UA-49796218-34', 'auto');
+} else {
+  console.warn(
+    'You have google analytics blocked. We understand. Take a ' +
+    'look at our privacy policy to see how we handle your data.'
+  );
+}
+
 window.addEventListener('DOMContentLoaded', function (event) {
   'use strict';
 

--- a/testpilot/frontend/templates/testpilot/frontend/index.html
+++ b/testpilot/frontend/templates/testpilot/frontend/index.html
@@ -65,7 +65,6 @@
     </noscript>
 
   </div>
-
   <script src="{{ url('wafflejs') }}"
           integrity="{{ waffleintegrity(request) }}"></script>
   <script src="{{ static('app/vendor.js') }}"

--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -75,6 +75,7 @@ INSTALLED_APPS = [
     'django_jinja',
     'django_cleanup',
 
+    'csp',
     'colorfield',
     'rest_framework',
     'storages',
@@ -111,6 +112,7 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
+    'csp.middleware.CSPMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'mozilla_cloud_services_logger.django.middleware.RequestSummaryLogger',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -369,8 +371,19 @@ TEMPLATES = [
 ]
 
 # Django-CSP
+if DEBUG:
+    CSP_REPORT_URI = '/__cspreport__'
+
+CSP_REPORT_ONLY = False
 CSP_DEFAULT_SRC = (
     "'self'",
+)
+CSP_CONNECT_SRC = (
+    "'self'",
+    'http://*.mozilla.net',
+    'https://*.mozilla.net',
+    'http://*.mozilla.org',
+    'https://*.mozilla.org',
 )
 CSP_FONT_SRC = (
     "'self'",
@@ -385,6 +398,11 @@ CSP_IMG_SRC = (
     'https://*.mozilla.net',
     'http://*.mozilla.org',
     'https://*.mozilla.org',
+    'http://*.gravatar.com',
+    'https://*.gravatar.com',
+    'http://*.google-analytics.com',
+    'https://*.google-analytics.com',
+    'https://ssl.gstatic.com/',
 )
 CSP_SCRIPT_SRC = (
     "'self'",
@@ -392,6 +410,9 @@ CSP_SCRIPT_SRC = (
     'https://*.mozilla.org',
     'http://*.mozilla.net',
     'https://*.mozilla.net',
+    'http://*.google-analytics.com',
+    'https://*.google-analytics.com',
+    'https://apis.google.com',
 )
 CSP_STYLE_SRC = (
     "'self'",


### PR DESCRIPTION
- Enable django-csp middleware
- Add Google & Gravatar origins to CSP policy
- Add /__cspreport__ endpoint to log CSP violation reports
- Move Google Analytics snippet out of inline HTML
- Create scripts/legal.js to contain inline JS from legal templates
- Add extra-scripts gulp task to minify & move scripts/*js

Fixes #882
