### PR TITLE
Enable API versioning via Accept: header

### DIFF
--- a/addon/data/set-installed-flag.js
+++ b/addon/data/set-installed-flag.js
@@ -9,3 +9,4 @@
 // Allow friendly clients to know that Test Pilot is installed.
 
 unsafeWindow.navigator.testpilotAddon = true;
+unsafeWindow.navigator.testpilotAddonVersion = self.options.version;

--- a/addon/index.js
+++ b/addon/index.js
@@ -99,7 +99,10 @@ function updatePrefs() {
     include: settings.ALLOWED_ORIGINS_VIEWINSTALLEDFLAG.split(','),
     contentScriptFile: './set-installed-flag.js',
     contentScriptWhen: 'start',
-    attachTo: ['top', 'existing']
+    attachTo: ['top', 'existing'],
+    contentScriptOptions: {
+      version: self.version
+    }
   });
 
   // Set up new PageMod for ability to install/remove add-ons.

--- a/requirements.txt
+++ b/requirements.txt
@@ -167,3 +167,6 @@ django-constance==1.1.2
 
 # sha256: KipST50FvFyKbz0TooywY4awcgzuALpY4ist5oCJxuQ
 mozilla-cloud-services-logger==1.0.1
+
+# sha256: _30ZPZ33AqjnGjEegIpOhaH0TkqcN5Nh1dNUuq7rvgI
+semver==2.5.0

--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -132,7 +132,9 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
     ],
-    'PAGE_SIZE': 10
+    'PAGE_SIZE': 10,
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
+    'DEFAULT_VERSION': '1.0.0'
 }
 
 SOCIALACCOUNT_PROVIDERS = {


### PR DESCRIPTION
- Add `window.navigator.testpilotAddonVersion` global populated with
  current add-on version
- Enable versioning via header - e.g. `Accept: application/json; version=x.x.x`
- Default version is 1.0.0
- Add semver dependency for conditional version handling

Fixes #53
