### PR TITLE
Implement subresource integrity for JS & CSS assets

### DIFF
--- a/testpilot/base/jinja.py
+++ b/testpilot/base/jinja.py
@@ -1,0 +1,75 @@
+import base64
+import hashlib
+import json
+
+from django.conf import settings
+from django.core.cache import cache
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.contrib.staticfiles import finders
+
+from waffle.views import wafflejs
+from constance import config as constance_config
+
+import jinja2
+from jinja2.ext import Extension
+
+
+DEFAULT_CHUNK_SIZE = 64 * 2 ** 10
+
+
+def _hash_content(content):
+    """Build a sha384 hash for subresource integrity use"""
+    hash = hashlib.sha384()
+    hash.update(content)
+    hash_base64 = base64.b64encode(hash.digest()).decode()
+    return 'sha384-{}'.format(hash_base64)
+
+
+@jinja2.contextfunction
+def staticintegrity(context, name):
+    """Hash a local static file for subresource integrity"""
+    if settings.DEBUG:
+        # In DEBUG, static files are scattered around and need to be found.
+        path = finders.find(name)
+    else:
+        # Otherwise, we can just look in the static root
+        path = staticfiles_storage.path(name)
+
+    key = 'staticintegrity-%s' % path
+    out = cache.get(key)
+
+    if out is None:
+        with open(path, 'rb') as content_file:
+            out = _hash_content(content_file.read())
+        cache.set(key, out)
+
+    return out
+
+
+@jinja2.contextfunction
+def urlintegrity(context, url):
+    """Grab a pre-defined subresource hash for a URL from settings"""
+    url_hashes = settings.URL_INTEGRITY_HASHES
+    try:
+        url_hashes_overrides = json.loads(getattr(
+            constance_config, 'URL_INTEGRITY_HASHES_OVERRIDES', '{}'))
+    except:
+        url_hashes_overrides = {}
+
+    # Try the overrides first, then fall back to straight settings
+    return url_hashes_overrides.get(url, url_hashes.get(url, ''))
+
+
+# TODO: Would be nice to replace this waffle-specific helper with something
+# that could produce a hash with a sub-request to any view.
+@jinja2.contextfunction
+def waffleintegrity(context, request):
+    """Hash the content of /wafflejs for subresource integrity"""
+    return _hash_content(wafflejs(request).content)
+
+
+class TestPilotExtension(Extension):
+    def __init__(self, environment):
+        environment.globals['staticintegrity'] = staticintegrity
+        environment.globals['urlintegrity'] = urlintegrity
+        environment.globals['waffleintegrity'] = waffleintegrity

--- a/testpilot/frontend/templates/testpilot/frontend/index.html
+++ b/testpilot/frontend/templates/testpilot/frontend/index.html
@@ -3,8 +3,11 @@
 <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="{{ static('images/favicon.ico') }}">
-    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
-    <link rel="stylesheet" href="{{ static('styles/main.css') }}">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css"
+                           crossorigin="anonymous"
+                           integrity="{{ urlintegrity('https://code.cdn.mozilla.net/fonts/fira.css') }}">
+    <link rel="stylesheet" href="{{ static('styles/main.css') }}"
+                           integrity="{{ staticintegrity('styles/main.css') }}">
 
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="en-US">
@@ -63,9 +66,14 @@
 
   </div>
 
-  <script src="{{ url('wafflejs') }}"></script>
-  <script src="{{ static('app/app.js') }}"></script>
-  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+  <script src="{{ url('wafflejs') }}"
+          integrity="{{ waffleintegrity(request) }}"></script>
+  <script src="{{ static('app/app.js') }}"
+          integrity="{{ staticintegrity('app/app.js') }}"></script>
+  <script src="https://pontoon.mozilla.org/pontoon.js"
+          crossorigin="anonymous"
+          integrity="{{ urlintegrity('https://pontoon.mozilla.org/pontoon.js') }}"></script>
+
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
     (i[r].q=i[r].q||[]).push(arguments)

--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -337,6 +337,7 @@ TEMPLATES = [
             'newstyle_gettext': True,
             'extensions': DJANGO_JINJA_DEFAULT_EXTENSIONS + [
                 'waffle.jinja.WaffleExtension',
+                'testpilot.base.jinja.TestPilotExtension',
             ],
             'context_processors': [
                 'testpilot.base.context_processors.settings',
@@ -466,6 +467,34 @@ LOGGING = {
     }
 }
 
+# Subresource integrity hashes used by urlintegrity() in templates
+#
+# NOTE: These need to be updated manually whenever these remote resources
+# change, ideally along with at least some review of what changed. The hashes
+# can be generated at https://www.srihash.org/ or with a command like:
+#
+# curl -s https://pontoon.mozilla.org/pontoon.js \
+#     | openssl dgst -sha384 -binary \
+#     | openssl base64 -A
+#
+# See also:
+#   https://hacks.mozilla.org/2015/09/subresource-integrity-in-firefox-43/
+#
+# TODO: Management command to help update hashes for all listed resources?
+URL_INTEGRITY_HASHES = {
+    "https://pontoon.mozilla.org/pontoon.js":
+        "sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb",
+    "https://code.cdn.mozilla.net/fonts/fira.css":
+        "sha384-APhs/OUouhH+ZbBANL3+7a5J1sVSYyfUhGxTWiDMkTuEIO5fXWZonzNEj+CagDB7",
+}
+
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
 CONSTANCE_CONFIG = {
+    'URL_INTEGRITY_HASHES_OVERRIDES': (
+        '{}',
+        'JSON map of URLs to subresource integrity hashes, overrides '
+        'URL_INTEGRITY_HASHES in settings.py. Useful for updates in 3rd party '
+        'resources between deployment windows - '
+        '{"https://example.com/foo.js": "sha384-yaddayadda"}'
+    ),
 }


### PR DESCRIPTION
- Add jinja helpers to generate resource hashes for local static files,
  remote resources, and wafflejs
- URL_INTEGRITY_HASHES setting to collect hashes for 3rd party resources
- URL_INTEGRITY_HASHES_OVERRIDES constance config for tweaking 3rd party
  hashes in between deployments
- Tests

Fixes #881
