### PR TITLE
Bugfixes for telemetry ping timing

### DIFF
--- a/addon/dev-prefs.json
+++ b/addon/dev-prefs.json
@@ -1,5 +1,4 @@
 {
-  "BASE_URL": "http://testpilot.dev:8000",
-  "HOSTNAME": "testpilot.dev",
-  "ALLOWED_ORIGINS": "http://testpilot.dev:8000/*,https://testpilot.firefox.com/*"
+  "toolkit.telemetry.server": "http://127.0.0.1/",
+  "extensions.@testpilot-addon.SERVER_ENVIRONMENT": "local"
 }


### PR DESCRIPTION
- Perform initial ping immediately on initialization rather than 24
  hours + 10 min later.
- `store.telemetryPing` -> `store.telemetryPingPayload` in init.
- Ensure `pingTimer` property exists in metrics.js module.

Fixes #936, Fixes #815
