### PR TITLE
Bug fix for SRI hash when used with Django hashed filenames

### DIFF
--- a/testpilot/base/jinja.py
+++ b/testpilot/base/jinja.py
@@ -33,6 +33,8 @@ def staticintegrity(context, name):
         path = finders.find(name)
     else:
         # Otherwise, we can just look in the static root
+        if hasattr(staticfiles_storage, 'hashed_files'):
+            name = staticfiles_storage.hashed_files.get(name, name)
         path = staticfiles_storage.path(name)
 
     key = 'staticintegrity-%s' % path

--- a/testpilot/base/tests.py
+++ b/testpilot/base/tests.py
@@ -96,6 +96,7 @@ class _MockJinjaEnvironment(object):
 
 MockStorageInstance = Mock()
 MockStorageInstance.path = Mock(return_value='foo')
+MockStorageInstance.hashed_files = {"foo": "bar"}
 MockStorage = Mock(return_value=MockStorageInstance)
 
 
@@ -135,6 +136,7 @@ class TestPilotJinjaExtensionTests(TestCase):
         expected_hash = _hash_content(content.encode())
         mock_open.return_value = io.BytesIO(content.encode('utf-8'))
         result = self.environment.globals['staticintegrity'](None, 'foo')
+        MockStorageInstance.path.assert_called_with('bar')
         self.assertEqual(result, expected_hash)
 
     def test_urlintegrity(self):


### PR DESCRIPTION
Quick bugfix - converts raw static path to Django hashed manifest path so that we generate the correct SRI hash for what we're linking to
