### PR TITLE
Fix fail on Object.keys(app.me.installed)

### DIFF
--- a/testpilot/frontend/static-src/app/models/experiment.js
+++ b/testpilot/frontend/static-src/app/models/experiment.js
@@ -30,11 +30,10 @@ export default Model.extend({
   },
 
   buildSurveyURL(ref) {
-    const installed = Object.keys(app.me.installed);
     const queryParams = querystring.stringify({
       ref: ref,
       experiment: this.title,
-      installed: installed
+      installed: app.me.installed ? Object.keys(app.me.installed) : []
     });
     return `${this.survey_url}?${queryParams}`;
   }


### PR DESCRIPTION
which was holding up page loads.

Occasionally `sync-installed` event fails (refs #960) when this happens `this.installed` is undefined. `this.installed` is undefined because AmpersandJS doesn't do what it is supposed to with default props. In order to work around this for now, we check if `this.installed` is defined before extracting keys to send to the survey. This will be revisited in #960 to address the issues with Ampersand's default behavoiur, and may get a retry for `sync-installed` when it fails.
- fixes #964
