### PR TITLE
Fix unclosed tag attribute in landing-page

### DIFF
--- a/testpilot/base/templates/testpilot/base.html
+++ b/testpilot/base/templates/testpilot/base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     {% block head %}
-    <title>Test Pilot</title>
+    <title>Firefox Test Pilot</title>
     <link rel="shortcut icon" href="{{ static('images/favicon.ico') }}">
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="{{ static('styles/main.css') }}">

--- a/testpilot/frontend/static-src/app/templates/landing-page.js
+++ b/testpilot/frontend/static-src/app/templates/landing-page.js
@@ -30,7 +30,7 @@ export default `
         <div class="centered-banner responsive-content-wrapper">
           {{^isFirefox}}
             <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
-            <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
+            <a href="https://www.mozilla.org/firefox" class="button primary download-firefox">
               <div class="button-icon">
                 <div class="button-icon-badge"></div>
               </div>
@@ -67,13 +67,13 @@ export default `
             <div class="card">
               <div class="card-icon test-pilot-icon"></div>
               <h3 class="card-title" data-l10n-id="landingStepThree">Step three</h3>
-              <div class="card-copy data-l10n-id="landingCardThree">Enable experimental features!</div>
+              <div class="card-copy" data-l10n-id="landingCardThree">Enable experimental features!</div>
             </div>
           </div>
           <div class="centered-banner">
             {{^isFirefox}}
               <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
-              <a href="https://www.mozilla.org/en-US/firefox" class="button primary download-firefox">
+              <a href="https://www.mozilla.org/firefox" class="button primary download-firefox">
                 <div class="button-icon">
                   <div class="button-icon-badge"></div>
                 </div>


### PR DESCRIPTION
Removed locale-specific download pages (since Mozilla.org does that for us, and is better for l10n), and fixed an unclosed `class` attribute in landing-page.js.

r? anybody with a thumb and a desire to press a green button.
