### PR TITLE
Use 127.0.0.1 instead of localhost in jpm watchpost.

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "start": "npm run watch",
     "once": "jpm run -b beta --prefs dev-prefs.json",
-    "watch": "jpm watchpost --post-url http://localhost:8888",
+    "watch": "jpm watchpost --post-url http://127.0.0.1:8888",
     "watch-ui": "watchify-server ui-test.js --index ui-test.html",
     "lint": "eslint .",
     "sign": "./bin/update-version && ./bin/sign",


### PR DESCRIPTION
I struggled getting autoinstaller working; it was trying to use IPv6 and failing silently. Changing the `watchpost` command to use the `127.0.0.1` IP address directly forces it to use IPv4 and fixes that issue.

r? @lmorchard @meandavejustice 

Ref: https://github.com/palant/autoinstaller/issues/8#issuecomment-215949994
