### PR TITLE
Add variant testing framework for experiments.

### DIFF
--- a/addon/.jpmignore
+++ b/addon/.jpmignore
@@ -8,3 +8,4 @@
 !/package.json
 !/route.js
 !/node_modules/mustache/**
+!/node_modules/seedrandom/**

--- a/addon/package.json
+++ b/addon/package.json
@@ -67,6 +67,7 @@
     }
   ],
   "dependencies": {
-    "mustache": "2.2.1"
+    "mustache": "2.2.1",
+    "seedrandom": "^2.4.2"
   }
 }

--- a/docs/examples/addon-restartless/bootstrap.js
+++ b/docs/examples/addon-restartless/bootstrap.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+let console = Cu.import('resource://gre/modules/Console.jsm').console;
+let {setTimeout} = Cu.import('resource://gre/modules/Timer.jsm', {});
+
+XPCOMUtils.defineLazyModuleGetter(this, 'Services',
+  'resource://gre/modules/Services.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'registerVariants',
+  'chrome://restartless-experiment/content/variants.js');
+
+
+const addonId = 'restartless-experiment@mozilla.com';
+let variants;
+
+// Define your tests...
+const variantTests = {
+  someFeature: {
+    name: 'Some Feature',
+    description: 'An example A/B test.',
+    variants: [
+      { description: 'A', value: 'A', weight: 1 },
+      { description: 'B', value: 'B', weight: 1 }
+    ]
+  }
+};
+
+// Then, on startup, ask Test Pilot what to do.
+function startup(data, reason) {
+  registerVariants(addonId, variantTests).then(payload => {
+
+    // When Test Pilot responds, finish initialization with the payload:
+    variants = JSON.parse(payload.data);
+    console.log('Variants received', variants);
+
+    // Future metrics pings will include that data.
+    setTimeout(() => {
+      sendMetric({
+        hello: 'world'
+      });
+    }, 3000);
+  });
+}
+
+function shutdown(data, reason) {
+  Cu.unload('chrome://restartless-experiment/content/variants.js');
+}
+
+function install(data, reason) {}
+
+function uninstall(data, reason) {}
+
+
+// Metrics utilities
+
+const observerService = Cc["@mozilla.org/observer-service;1"]
+                        .getService(Ci.nsIObserverService);
+
+function makeSubject(addonId) {
+  return {
+    wrappedJSObject: {
+      observersModuleSubjectWrapper: true,
+      object: addonId
+    }
+  };
+}
+
+function sendMetric(payload) {
+  const subject = makeSubject(addonId);
+  const topic = 'testpilot::send-metric';
+  observerService.notifyObservers(subject, topic, JSON.stringify(payload));
+}

--- a/docs/examples/addon-restartless/chrome.manifest
+++ b/docs/examples/addon-restartless/chrome.manifest
@@ -1,0 +1,1 @@
+content restartless-experiment lib/

--- a/docs/examples/addon-restartless/install.rdf
+++ b/docs/examples/addon-restartless/install.rdf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RDF xmlns="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:em="http://www.mozilla.org/2004/em-rdf#">
+  <Description about="urn:mozilla:install-manifest">
+    <em:id>restartless-experiment@mozilla.com</em:id>
+    <em:bootstrap>true</em:bootstrap>
+    <em:type>2</em:type>
+    <em:unpack>false</em:unpack>
+    <em:version>1.0.0</em:version>
+    <em:name>Restartless Experiment</em:name>
+    <em:description>Demonstration of restartless Test Pilot experiment</em:description>
+    <em:targetApplication>
+      <Description>
+        <em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id>
+        <em:minVersion>45.0</em:minVersion>
+        <em:maxVersion>*</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+  </Description>
+</RDF>

--- a/docs/examples/addon-restartless/lib/variants.js
+++ b/docs/examples/addon-restartless/lib/variants.js
@@ -1,0 +1,72 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const EXPORTED_SYMBOLS = ['registerVariants'];
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+Cu.import('resource://gre/modules/XPCOMUtils.jsm');
+
+XPCOMUtils.defineLazyModuleGetter(this, 'clearInterval',
+                                  'resource://gre/modules/Timer.jsm');
+XPCOMUtils.defineLazyModuleGetter(this, 'setInterval',
+                                  'resource://gre/modules/Timer.jsm');
+
+
+function TestPilotObserver(topic, resolve) {
+  this.topic = topic;
+  this.resolve = resolve;
+  this.register();
+}
+
+TestPilotObserver.prototype = {
+  observe: function(subject, topic, data) {
+    this.resolve({
+      subject: subject,
+      topic: topic,
+      data: data
+    });
+    this.unregister();
+  },
+
+  register: function() {
+    let observerService = Cc["@mozilla.org/observer-service;1"]
+                          .getService(Ci.nsIObserverService);
+    observerService.addObserver(this, this.topic, false);
+  },
+
+  unregister: function() {
+    let observerService = Cc["@mozilla.org/observer-service;1"]
+                          .getService(Ci.nsIObserverService);
+    observerService.removeObserver(this, this.topic);
+  }
+};
+
+
+function registerVariants(addonId, payload) {
+  let observerService = Cc["@mozilla.org/observer-service;1"]
+                        .getService(Ci.nsIObserverService);
+
+  let receiveTopic = 'testpilot::receive-variants';
+  let registerTopic = 'testpilot::register-variants';
+
+  return new Promise((resolve, reject) => {
+    let intervalPing = setInterval(() => {
+      observerService.notifyObservers(
+        {
+          wrappedJSObject: {
+            observersModuleSubjectWrapper: true,
+            object: addonId
+          }
+        },
+        registerTopic,
+        JSON.stringify(payload)
+      );
+    }, 100);
+    let observer = new TestPilotObserver(receiveTopic, data => {
+      clearInterval(intervalPing);
+      resolve(data);
+    });
+    observerService.addObserver(observer, receiveTopic, false);
+  });
+};


### PR DESCRIPTION
So, here's a very rough sketch at what a fix for #477 could look like. It works like this:
1. Upon initialization, an experiment spams Test Pilot with a [test and variant definition](https://gist.github.com/chuckharmston/b8b728844c44fa931ace881e92286b4d#experiment---test-pilot) using [`nslObserverService`](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIObserverService) and the `testpilot::register-variants` topic. This is done in an interval, as there is no guarantee that experiments are loaded after Test Pilot is.
2. The first time Test Pilot receives that message, it [does some magic](https://gist.github.com/chuckharmston/b8b728844c44fa931ace881e92286b4d) and deterministically (seeded by test name and `clientUUID`) places users into variants for each test.
3. Test Pilot stores and ships a payload containing those results back to the experiment, using `testpilot::receive-variants`. When received, the experiment clears the interval and can do whatever it would like with the payload.
4. In any future `testpilot::send-metric` messages sent by experiments, the variants are appended to the payload before `submitExternalPing` is called. This will let us segment any metric based on variant placement.

In addition to the code in the PR, we'd include something approximating the following in some sort of experiment developer SDK:

``` javascript
const {classes: Cc, interfaces: Ci, utils: Cu} = Components;

function TestPilotObserver(topic, resolve) {
  this.topic = topic;
  this.resolve = resolve;
  this.register();
}

TestPilotObserver.prototype = {
  observe: function(subject, topic, data) {
    this.resolve({
      subject: subject,
      topic: topic,
      data: data
    });
    this.unregister();
  },

  register: function() {
    let observerService = Cc["@mozilla.org/observer-service;1"]
                          .getService(Ci.nsIObserverService);
    observerService.addObserver(this, this.topic, false);
  },

  unregister: function() {
    let observerService = Cc["@mozilla.org/observer-service;1"]
                          .getService(Ci.nsIObserverService);
    observerService.removeObserver(this, this.topic);
  }
};

const registerVariants = function(addonId, payload) {
  let observerService = Cc["@mozilla.org/observer-service;1"]
                        .getService(Ci.nsIObserverService);

  let receiveTopic = 'testpilot::receive-variants';
  let registerTopic = 'testpilot::register-variants';

  return new Promise((resolve, reject) => {
    let intervalPing = win.setInterval(() => {
      observerService.notifyObservers(
        {
          wrappedJSObject: {
            observersModuleSubjectWrapper: true,
            object: addonId
          }
        },
        registerTopic,
        JSON.stringify(payload)
      );
    }, 100);
    let observer = new TestPilotObserver(receiveTopic, data => {
      win.clearInterval(intervalPing);
      resolve(data);
    });
    observerService.addObserver(observer, receiveTopic, false);
  });
};
```

Which the experiments themselves would use like this:

``` javascript
registerVariants('universal-search@mozilla.com', payload).then(payload => {
  app.console.log(JSON.parse(payload.data));
});
```

Using the above code and [this sample JSON blob as the payload](https://gist.github.com/chuckharmston/b8b728844c44fa931ace881e92286b4d#experiment---test-pilot), Universal Search receives the following object:

<img width="169" alt="screen shot 2016-06-21 at 6 27 56 pm" src="https://cloud.githubusercontent.com/assets/23885/16250849/06a92fb4-37de-11e6-97f8-7b0a00c0a819.png">

And the telemetry pings sent by Universal Search look like this:

<img width="299" alt="screen shot 2016-06-21 at 6 23 07 pm" src="https://cloud.githubusercontent.com/assets/23885/16250856/0fb5f45c-37de-11e6-8fe6-770502adfb9f.png">

This is all very messy, but I wanted to get eyes on it early. r? @lmorchard 

Potentially-interested parties: @k88hudson @rjweiss
