### PR TITLE
Don't remove surveyChecks unless addon is uninstalled

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -579,13 +579,14 @@ exports.onUnload = function(reason) {
   panel.destroy();
   button.destroy();
   Metrics.destroy();
-  survey.destroy();
 
   if (reason === 'uninstall' || reason === 'disable') {
     Metrics.onDisable();
   }
 
   if (reason === 'uninstall') {
+    survey.destroy();
+
     if (store.installedAddons) {
       Object.keys(store.installedAddons).forEach(id => {
         uninstallExperiment({addon_id: id});


### PR DESCRIPTION
- refs #1006
- only call `survey.destroy()` if the addon is being `uninstalled`
  we have been calling on `unload`.
