### PR TITLE
Adds Discourse link to experiment details page

### DIFF
--- a/fixtures/demo_data.json
+++ b/fixtures/demo_data.json
@@ -193,7 +193,8 @@
     "slug": "universal-search",
     "xpi_url": "https://s3-us-west-2.amazonaws.com/universal-search/universal-search.xpi",
     "contribute_url": "https://github.com/mozilla/universal-search/blob/master/README.md",
-    "bug_report_url": "https://github.com/mozilla/universal-search/issues"
+    "bug_report_url": "https://github.com/mozilla/universal-search/issues",
+    "discourse_url": "https://discourse.mozilla-community.org/c/test-pilot/universal-search"
   }
 },
 {
@@ -211,7 +212,8 @@
     "slug": "mozvr",
     "xpi_url": "http://example.com",
     "contribute_url": "https://github.com/bwinton/VerticalTabs",
-    "bug_report_url": "https://github.com/bwinton/VerticalTabs/issues"
+    "bug_report_url": "https://github.com/bwinton/VerticalTabs/issues",
+    "discourse_url": "https://discourse.mozilla-community.org/c/test-pilot/tab-center"
   }
 },
 {
@@ -229,7 +231,8 @@
     "slug": "activity-stream",
     "xpi_url": "http://example.com",
     "contribute_url": "https://github.com/mozilla/activity-stream",
-    "bug_report_url": "https://github.com/mozilla/activity-stream/issues"
+    "bug_report_url": "https://github.com/mozilla/activity-stream/issues",
+    "discourse_url": "https://discourse.mozilla-community.org/c/test-pilot/activity-stream"
   }
 },
 {

--- a/locales/en-US/app.l20n
+++ b/locales/en-US/app.l20n
@@ -103,6 +103,7 @@
 <lastUpdate "Last Update">
 <contribute "Contribute">
 <bugReports "Bug Reports">
+<discourse "Discourse">
 <nowActive "Active">
 <userCount title:"Active Users of this Experiment">
 <tourOnboardingTitle "{{title}} enabled!">

--- a/testpilot/experiments/migrations/0017_discourse_url.py
+++ b/testpilot/experiments/migrations/0017_discourse_url.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0016_auto_20160512_1704'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='experiment',
+            name='discourse_url',
+            field=models.URLField(blank=True),
+        )
+]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -49,6 +49,7 @@ class Experiment(TranslatableModel):
     changelog_url = models.URLField(blank=True)
     contribute_url = models.URLField(blank=True)
     bug_report_url = models.URLField(blank=True)
+    discourse_url = models.URLField(blank=True)
     privacy_notice_url = models.URLField(blank=True)
     addon_id = models.CharField(max_length=500, blank=False,)
     gradient_start = ColorField(default='#e07634')

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -50,7 +50,7 @@ class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
         fields = ('id', 'url', 'title', 'short_title', 'slug',
                   'thumbnail', 'description', 'introduction',
                   'version', 'changelog_url', 'contribute_url',
-                  'bug_report_url', 'privacy_notice_url', 'measurements',
+                  'bug_report_url', 'discourse_url', 'privacy_notice_url', 'measurements',
                   'xpi_url', 'addon_id', 'gradient_start', 'gradient_stop',
                   'details', 'tour_steps', 'contributors',
                   'survey_url', 'installations_url',

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -91,6 +91,7 @@ class ExperimentViewTests(BaseTestCase):
                         "changelog_url": experiment.changelog_url,
                         "contribute_url": experiment.contribute_url,
                         "bug_report_url": experiment.bug_report_url,
+                        "discourse_url": experiment.discourse_url,
                         "privacy_notice_url": experiment.privacy_notice_url,
                         "addon_id": experiment.addon_id,
                         "gradient_start": experiment.gradient_start,

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -52,6 +52,11 @@ export default `
                       <td data-l10n-id="bugReports">Bug Reports</td>
                       <td><a data-hook="bug-report-url"></a></td>
                     </tr>
+
+                    <tr>
+                      <td data-l10n-id="discourse">Discourse</td>
+                      <td><a data-hook="discourse-url"></a></td>
+                    </tr>
                   </table>
                 </section>
                 <section class="contributors-section">

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -118,6 +118,15 @@ export default PageView.extend({
       hook: 'bug-report-url'
     }],
 
+    'model.discourse_url': [{
+      hook: 'discourse-url'
+    },
+    {
+      type: 'attribute',
+      name: 'href',
+      hook: 'discourse-url'
+    }],
+
     'model.introduction': [{
       type: 'innerHTML',
       hook: 'introduction-html'


### PR DESCRIPTION
- Fixes #1019
- updates frontend view, template, and test for experiment page
- updates experiment model, serializer, and test
- adds migration for model update
- adds discourse key to app.l20n
- updates `fixtures/demo_data.json` with `discourse_url`
