### PR TITLE
Make "enabled" indicators more clear

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -52,9 +52,9 @@ notFoundHeader = Four Oh Four!
 
 experimentListPageHeader = Ready for Takeoff!
 experimentListPageSubHeader  = Pick the features you want to try. <br> Check back soon for more experiments.
-
-experimentListInactiveHover = Get Started
-experimentListActiveHover = Manage
+experimentListEnabledTab = Enabled
+isEnabled = {$title} is enabled.
+participantCount = <span>{$installation_count}</span> participants
 
 giveFeedback = Give Feedback
 

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -5,11 +5,10 @@ export default `
       <header data-hook="header-view"></header>
     </div>
     <div class="default-background">
-      <div class="spacer"></div>
       <div class="details-header-wrapper">
+        <div class="status-bar is-enabled" data-hook="is-enabled" data-l10n-id="isEnabled"><span data-hook="title"></span> is enabled.</div>
         <div class="details-header content-wrapper">
           <h1 data-hook="title"></h1>
-          <span class="now-active" data-hook="now-active" data-l10n-id="nowActive">Active</span>
           <div class="experiment-controls">
             <a data-hook="highlight-privacy" class="highlight-privacy" data-l10n-id=highlightPrivacy>Your privacy</a>
             <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default" target="_blank">Give Feedback</a>

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -57,7 +57,7 @@ export default PageView.extend({
     },
     {
       type: 'toggle',
-      hook: 'now-active'
+      hook: 'is-enabled',
     },
     {
       type: 'toggle',

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -4,6 +4,9 @@ import BaseView from './base-view';
 
 export default BaseView.extend({
   template: `<div data-hook="show-detail" class="experiment-summary">
+                <div class="experiment-actions">
+                  <div data-l10n-id="experimentListEnabledTab" data-hook="enabled-tab" class="tab show-when-enabled"></div>
+                </div>
               <div class="experiment-icon-wrapper" data-hook="bg">
                 <div class="experiment-icon" data-hook="thumbnail"></div>
               </div>
@@ -12,11 +15,8 @@ export default BaseView.extend({
                   <h3 data-hook="title"></h3>
                 </header>
                 <p data-hook="description"></p>
+                <span class="participant-count" data-l10n-id="participantCount"</span>
               </div>
-               <div class="experiment-actions">
-                  <button data-l10n-id="experimentListInactiveHover" class="button default show-when-inactive">Get Started</button>
-                  <button data-l10n-id="experimentListActiveHover" class="button secondary show-when-active">Manage</button>
-               </div>
              </div>`,
 
   props: {
@@ -49,11 +49,15 @@ export default BaseView.extend({
       },
       hook: 'thumbnail'
     },
-    'model.enabled': {
+    'model.enabled': [{
       type: 'booleanClass',
       hook: 'show-detail',
-      name: 'active'
+      name: 'enabled'
     },
+    {
+      type: 'toggle',
+      hook: 'enabled-tab'
+    }],
     'loggedIn': {
       type: 'booleanClass',
       hook: 'show-detail',
@@ -71,16 +75,9 @@ export default BaseView.extend({
 
   openDetailPage(evt) {
     evt.preventDefault();
-    if (this.model.enabled) {
       app.sendToGA('event', {
         eventCategory: 'ExperimentsPage Interactions',
-        eventAction: 'Manage experiment button',
-        eventLabel: this.model.title
-      });
-    } else {
-      app.sendToGA('event', {
-        eventCategory: 'ExperimentsPage Interactions',
-        eventAction: 'Get Started experiment button',
+        eventAction: 'Open detail page',
         eventLabel: this.model.title
       });
     }

--- a/testpilot/frontend/static-src/styles/_variables.scss
+++ b/testpilot/frontend/static-src/styles/_variables.scss
@@ -71,3 +71,8 @@ $circle-border-radius: 50%;
 $grid-unit: 20px;
 $font-unit: 12px;
 $line-unit: 18px;
+
+// "Enabled" greens
+$green: #7cd06a;
+$dark-green: #3b9827;
+$bright-green: #65c751;

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -1,9 +1,29 @@
 .details-header-wrapper {
 
+  &:not(.is-enabled) {
+    padding-top: $grid-unit * 1.8;
+  }
+
+  .status-bar {
+    &.is-enabled {
+      background: $green;
+      border-bottom: 1px solid $dark-green;
+      color: $white;
+      font-weight: 300;
+      line-height: $line-unit * 2;
+      text-align: center;
+    }
+
+    &:not(.is-enabled) {
+      display: none;
+    }
+  }
+
   &.stick {
     background: $transparent-white-96;
     box-shadow: 0 0 5px $transparent-black-5;
     left: 0;
+    padding-top: 0;
     position: fixed;
     top: 0;
     width: 100%;
@@ -239,36 +259,5 @@
     font-size: $font-unit;
     margin-top: $grid-unit * .5;
     padding: 0 $grid-unit * .25;
-  }
-}
-
-.now-active {
-  color: $primary;
-  display: block;
-  font-weight: bold;
-  left: $grid-unit * .75;
-  position: absolute;
-  top: -$grid-unit;
-
-  .stick & {
-    display: none;
-  }
-
-  &::before {
-    @media (min-resolution: 1.3dppx) {
-      animation: pop 2000ms alternate ease-in-out;
-      animation-iteration-count: 5;
-    }
-
-    background: $primary;
-    border-radius: 50%;
-    content: '';
-    display: inline-block;
-    filter: blur(.1px);
-    height: $grid-unit;
-    margin-right: $grid-unit * .4;
-    position: relative;
-    top: $grid-unit * .2;
-    width: $grid-unit;
   }
 }

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -47,39 +47,33 @@
 
   p {
     line-height: 1.4 * $line-unit;
+    margin-bottom: $grid-unit * .5;
+  }
+
+  span {
+    color: $transparent-black-4;
+    font-size: 1.1 * $font-unit;
     margin: 0;
   }
+
 
   &.logged-in {
     cursor: pointer;
 
-    &.active {
-      box-shadow: 0 0 0 3px $white, 0 0 0 6px $primary;
+    &:hover {
+      box-shadow: 0 0 0 3px $transparent-white-1;
+    }
+
+    &.enabled {
+      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green;
 
       &:hover {
-        box-shadow: 0 0 0 3px $white, 0 0 0 8px $primary;
-      }
-
-      &::after {
-        @include hidpi-background-image('check', 36px 27px);
-        background-color: $primary;
-        background-position: center center;
-        background-repeat: no-repeat;
-        border: 3px solid $white;
-        border-radius: $circle-border-radius;
-        content: '';
-        height: 56px;
-        position: absolute;
-        right: -26px;
-        top: -26px;
-        width: 56px;
-        z-index: 2;
+        box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green, 0 0 0 9px $transparent-white-1;
       }
     }
   }
 
   &.logged-in:hover {
-    box-shadow: 0 1px 0 0 $transparent-white-2, 0 0 0 5px $transparent-white-2;
     transition: box-shadow 150ms;
 
     h3 {
@@ -90,19 +84,38 @@
 }
 
 .experiment-actions {
-  padding: 0 $grid-unit $grid-unit;
-
-  .button {
+  :not(.logged-in) {
     display: none;
-    text-align: center;
-    width: 100%;
+  }
 
-    .active &.show-when-active {
-      display: block;
-    }
+  .tab {
 
-    .logged-in:not(.active) &.show-when-inactive {
-      display: block;
+    .logged-in &.show-when-enabled {
+      background: $bright-green;
+      border-bottom-color: $white;
+      border-bottom-right-radius: 5px;
+      border-bottom-width: 3px;
+      border-left-width: 0;
+      border-right-color: $white;
+      border-right-width: 3px;
+      border-style: solid;
+      border-top-left-radius: 6px;
+      border-top-width: 0;
+      color: $white;
+      display: inline-block;
+      font-weight: 300;
+      height: $grid-unit * 1.5;
+      left: -3px;
+      line-height: $grid-unit * 1.5;
+      outline: none;
+      padding: 0 20px;
+      position: absolute;
+      text-align: center;
+      text-decoration: none;
+      top: -3px;
+      transition: background 150ms;
+      white-space: nowrap;
+      z-index: 99999;
     }
   }
 }
@@ -134,6 +147,6 @@
   background-size: $grid-unit * 4 $grid-unit * 4;
   filter: drop-shadow(0 1px 0 $transparent-black-1);
   flex: 0 0 $grid-unit * 4;
-  height: $grid-unit * 4;
+  height: $grid-unit * 5;
   opacity: .9;
 }

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -67,16 +67,16 @@ test('afterRender attaches detailView and contributorView', t => {
   t.ok(myView.query('.contributors'));
 });
 
-test('now active indicator shows when experiment is enabled', t => {
+test('indicator bar shows when experiment is enabled', t => {
   t.plan(2);
 
   const myView = new MyView({headerScroll: false, slug: 'slsk'});
   myView.render();
 
-  t.ok(myView.query('.now-active'));
+  t.ok(myView.query('.is-enabled'));
   const model = app.experiments.get('slsk', 'slug');
   model.enabled = false;
-  t.equal(myView.query('.now-active').style.display, 'none');
+  t.equal(myView.query('.is-enabled').style.display, 'none');
 });
 
 test('introduction appears in view', t => {


### PR DESCRIPTION
-fixes #968 
-fixes #1067 
-changes "active" indicator circle to "enabled" indicator bar on experiment detail page
-adds "enabled" tab to experiment list view
-replaces "manage" and "get started" buttons with participant count
-adds localization for enabled tab and enabled indicator bar
-creates color variables for the greens in the design spec
