### PR TITLE
Remove user dependency from installation tracking API

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -164,12 +164,10 @@ function setupApp() {
 
     app.on('uninstall-experiment', uninstallExperiment);
 
-    app.on('sync-installed', serverInstalled => {
-      syncAllAddonInstallations(serverInstalled).then(() => {
-        app.send('sync-installed-result', {
-          clientUUID: store.clientUUID,
-          installed: store.installedAddons
-        });
+    app.on('sync-installed', () => {
+      app.send('sync-installed-result', {
+        clientUUID: store.clientUUID,
+        installed: store.installedAddons
       });
     });
 
@@ -345,29 +343,6 @@ function updateExperiments() {
           });
     return store.installedAddons;
   });
-}
-
-function syncAllAddonInstallations(serverInstalled) {
-  const availableIDs = Object.keys(store.availableExperiments);
-  const clientIDs = Object.keys(store.installedAddons);
-  const serverIDs = [];
-
-  for (let key in serverInstalled) { // eslint-disable-line prefer-const
-    if (serverInstalled[key].client_id === store.clientUUID) {
-      serverIDs.push(key);
-    }
-  }
-
-  return Promise.all(availableIDs.filter(id => {
-    const cidx = clientIDs.indexOf(id);
-    const sidx = serverIDs.indexOf(id);
-    // Both missing? Okay.
-    if (cidx === -1 && sidx === -1) { return false; }
-    // Both found? Okay.
-    if (cidx !== -1 && sidx !== -1) { return false; }
-    // One found, one not? Better sync.
-    return true;
-  }).map(syncAddonInstallation));
 }
 
 function uninstallExperiment(experiment) {

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/testpilot/experiments/admin.py
+++ b/testpilot/experiments/admin.py
@@ -2,8 +2,7 @@ from django.contrib import admin
 
 from hvad.admin import TranslatableAdmin, TranslatableTabularInline
 
-from .models import (Experiment, ExperimentDetail, ExperimentTourStep,
-                     UserInstallation)
+from .models import (Experiment, ExperimentDetail, ExperimentTourStep)
 from ..utils import (show_image, parent_link, related_changelist_link,
                      translated)
 
@@ -25,7 +24,6 @@ class ExperimentAdmin(TranslatableAdmin):
                     translated('title'), translated('short_title'),
                     'version', 'addon_id',
                     related_changelist_link('details'),
-                    related_changelist_link('users'),
                     'created', 'modified',)
 
     raw_id_fields = ('contributors',)
@@ -51,17 +49,7 @@ class ExperimentTourStepAdmin(TranslatableAdmin):
                     'created', 'modified',)
 
 
-class UserInstallationAdmin(admin.ModelAdmin):
-
-    list_display = ('id', parent_link('experiment'), parent_link('user'),
-                    'client_id',
-                    'created', 'modified',)
-
-    list_filter = ('experiment',)
-
-
 for x in ((Experiment, ExperimentAdmin),
           (ExperimentDetail, ExperimentDetailAdmin),
-          (ExperimentTourStep, ExperimentTourStepAdmin),
-          (UserInstallation, UserInstallationAdmin),):
+          (ExperimentTourStep, ExperimentTourStepAdmin),):
     admin.site.register(*x)

--- a/testpilot/experiments/migrations/0019_auto_20160707_2050.py
+++ b/testpilot/experiments/migrations/0019_auto_20160707_2050.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('experiments', '0018_auto_20160709_0247'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='experiment',
+            name='users',
+        ),
+        migrations.AlterUniqueTogether(
+            name='userinstallation',
+            unique_together=set([('experiment', 'client_id')]),
+        ),
+        migrations.RemoveField(
+            model_name='userinstallation',
+            name='user',
+        ),
+    ]

--- a/testpilot/experiments/models.py
+++ b/testpilot/experiments/models.py
@@ -52,7 +52,6 @@ class Experiment(TranslatableModel):
     gradient_start = ColorField(default='#e07634')
     gradient_stop = ColorField(default='#4cffa8')
 
-    users = models.ManyToManyField(User, through='UserInstallation')
     contributors = models.ManyToManyField(User, related_name='contributor')
 
     created = models.DateTimeField(auto_now_add=True)
@@ -60,8 +59,7 @@ class Experiment(TranslatableModel):
 
     @cached_property
     def installation_count(self):
-        return UserInstallation.objects.distinct('user').filter(
-            experiment=self).count()
+        return UserInstallation.objects.filter(experiment=self).count()
 
     def __str__(self):
         return self.title
@@ -109,11 +107,10 @@ class ExperimentTourStep(TranslatableModel):
 class UserInstallation(models.Model):
 
     experiment = models.ForeignKey(Experiment)
-    user = models.ForeignKey(User)
     client_id = models.CharField(blank=True, max_length=128)
 
     created = models.DateTimeField(auto_now_add=True)
     modified = models.DateTimeField(auto_now=True)
 
     class Meta:
-        unique_together = ('experiment', 'user', 'client_id',)
+        unique_together = ('experiment', 'client_id',)

--- a/testpilot/experiments/serializers.py
+++ b/testpilot/experiments/serializers.py
@@ -66,8 +66,7 @@ class ExperimentSerializer(HyperlinkedTranslatableModelSerializer):
 
     def get_installations_url(self, obj):
         request = self.context['request']
-        path = reverse('experiment-installation-list',
-                       args=(obj.pk,))
+        path = '%s/installations/' % reverse('experiment-detail', args=(obj.pk,))
         return request.build_absolute_uri(path)
 
     def get_survey_url(self, obj):

--- a/testpilot/experiments/urls.py
+++ b/testpilot/experiments/urls.py
@@ -6,6 +6,4 @@ urlpatterns = patterns(
     '',
     url(r'^(?P<experiment_pk>[\w-]+)/installations/(?P<client_id>[\w-]+)',
         views.installation_detail, name='experiment-installation-detail'),
-    url(r'^(?P<experiment_pk>[\w-]+)/installations/',
-        views.installation_list, name='experiment-installation-list'),
 )

--- a/testpilot/experiments/views.py
+++ b/testpilot/experiments/views.py
@@ -1,5 +1,5 @@
 from rest_framework import viewsets, status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.decorators import (detail_route, permission_classes,
                                        api_view)
@@ -44,24 +44,14 @@ class ExperimentViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-@api_view(['GET'])
-@permission_classes([IsAuthenticated])
-def installation_list(request, experiment_pk):
-    experiment = get_object_or_404(Experiment, pk=experiment_pk)
-    queryset = UserInstallation.objects.filter(
-        user=request.user, experiment=experiment)
-    return Response(UserInstallationSerializer(
-        queryset, many=True, context={'request': request}).data)
-
-
 @api_view(['GET', 'PUT', 'DELETE'])
-@permission_classes([IsAuthenticated])
+@permission_classes([AllowAny])
 def installation_detail(request, experiment_pk, client_id):
     experiment = get_object_or_404(Experiment, pk=experiment_pk)
 
     if 'PUT' == request.method:
         installation, created = UserInstallation.objects.get_or_create(
-            user=request.user, experiment=experiment, client_id=client_id)
+            experiment=experiment, client_id=client_id)
         installation.save()
         logging.getLogger('testpilot.test-install').info('', extra={
             'uid': request.user.id,
@@ -70,7 +60,7 @@ def installation_detail(request, experiment_pk, client_id):
     else:
         installation = get_object_or_404(
             UserInstallation,
-            user=request.user, experiment=experiment, client_id=client_id)
+            experiment=experiment, client_id=client_id)
 
     if 'DELETE' == request.method:
         installation.delete()

--- a/testpilot/users/tests.py
+++ b/testpilot/users/tests.py
@@ -9,8 +9,6 @@ from django.test import TestCase, Client
 from django.test.utils import override_settings
 from django.contrib.auth.models import User
 
-from rest_framework import fields
-
 from testfixtures import LogCapture
 
 from allauth.account.signals import user_signed_up
@@ -18,7 +16,7 @@ from allauth.account.signals import user_signed_up
 from mozilla_cloud_services_logger.formatters import JsonLogFormatter
 
 from ..utils import gravatar_url
-from ..experiments.models import (Experiment, UserInstallation)
+from ..experiments.models import (Experiment)
 
 from .models import UserProfile
 
@@ -262,36 +260,6 @@ class MeViewSetTests(TestCase):
                     'username': 'johndoe'
                 },
                 'addon': self.addonData,
-                'installed': {}
-            }
-        )
-
-        experiment = self.experiments['test-1']
-        client_id = '8675309'
-
-        installation = UserInstallation.objects.create(
-            experiment=experiment, user=self.user, client_id=client_id)
-
-        # HACK: Use a rest framework field to format dates as expected
-        date_field = fields.DateTimeField()
-
-        resp = self.client.get(self.url)
-        result_data = json.loads(str(resp.content, 'utf-8'))
-
-        self.assertEqual(len(result_data['installed']), 1)
-        self.assertDictEqual(
-            result_data['installed'],
-            {
-                'addon-1@example.com': {
-                    'experiment': 'http://testserver/api/experiments/%s' % experiment.pk,
-                    'addon_id': 'addon-1@example.com',
-                    'client_id': client_id,
-                    'url':
-                    'http://testserver/api/experiments/%s/installations/%s' %
-                    (experiment.pk, client_id),
-                    'created': date_field.to_representation(installation.created),
-                    'modified': date_field.to_representation(installation.modified),
-                }
             }
         )
 

--- a/testpilot/users/views.py
+++ b/testpilot/users/views.py
@@ -3,8 +3,6 @@ from django.conf import settings
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 
-from ..experiments.serializers import UserInstallationSerializer
-from ..experiments.models import UserInstallation
 from .models import UserProfile
 from .serializers import UserProfileSerializer
 
@@ -32,13 +30,6 @@ class MeViewSet(ViewSet):
                 "name": "Test Pilot",
                 "url": settings.ADDON_URL
             },
-            "installed": dict(
-                (obj.experiment.addon_id,
-                 UserInstallationSerializer(obj, context={
-                     'request': request
-                 }).data)
-                for obj in UserInstallation.objects.filter(user=user)
-            )
         })
 
 


### PR DESCRIPTION
- Migration to drop user field from UserInstallation model, users
  relation in Experiment model.
- Remove `distinct('user')` filter from `installation_count` property in
  Experiment model.
- Drop auth requirement from installation tracking API resources.
- Remove unused `experiment-installation-list` API resource.
- Remove list of installed experiments from `/api/me` resource.
- Stop doing a full sync of experiments with the server, list of enabled
  experiments from the add-on is authoritative
- Separate call to fetch installed experiments and request to fetch
  `/api/me` resource in frontend Me model.
- Remove deletion of user installations from user retire API resource.
- Bump add-on to v0.8.0
- Updated tests.

Fixes #1040
