### PR TITLE
[fix #1026] Encode email before sending to basket

### DIFF
--- a/testpilot/frontend/static-src/app/main.js
+++ b/testpilot/frontend/static-src/app/main.js
@@ -100,7 +100,7 @@ app.extend({
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: 'newsletters=test-pilot&email=' + email
+      body: 'newsletters=test-pilot&email=' + encodeURIComponent(email)
     }).then(callback)
     .catch(err => {
       // for now, log the error in the console & do nothing in the UI


### PR DESCRIPTION
Fixes #1026.

Tested with a couple emails with `+` in it, and got responses from the Test Pilot auto responder.

![image 2016-07-11 at 2 29 29 pm](https://cloud.githubusercontent.com/assets/8632184/16747448/0ec54fb6-4774-11e6-8af7-d45b1bd40483.png)
