### PR TITLE
Make "enabled" indicators more clear

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -53,9 +53,9 @@ notFoundHeader = Four Oh Four!
 
 experimentListPageHeader = Ready for Takeoff!
 experimentListPageSubHeader  = Pick the features you want to try. <br> Check back soon for more experiments.
-
-experimentListInactiveHover = Get Started
-experimentListActiveHover = Manage
+experimentListEnabledTab = Enabled
+isEnabledStatusMessage = {$title} is enabled.
+participantCount = <span>{$installation_count}</span> participants
 
 giveFeedback = Give Feedback
 

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -5,12 +5,10 @@ export default `
       <header data-hook="header-view"></header>
     </div>
     <div class="default-background">
-      <div class="spacer"></div>
-      <div class="details-header-wrapper">
+      <div class="details-header-wrapper" data-hook="is-enabled">
+        <div class="status-bar enabled" data-l10n-id="isEnabledStatusMessage"><span data-hook="title"></span> is enabled.</div>
         <div class="details-header content-wrapper">
-          <h1 data-hook="title"></h1>
-          <span class="now-active" data-hook="now-active" data-l10n-id="nowActive">Active</span>
-          <div class="experiment-controls">
+          <h1 data-hook="title"></h1> <div class="experiment-controls">
             <a data-hook="highlight-privacy" class="highlight-privacy" data-l10n-id=highlightPrivacy>Your privacy</a>
             <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default" target="_blank">Give Feedback</a>
             <button data-hook="uninstall" id="uninstall-button" class="button secondary"><span class="state-change-inner"></span><span data-l10n-id="disableExperimentTransition" class="transition-text">Disabling...</span><span data-l10n-id="disableExperiment" class="default-text">Disable <span data-hook="title"></span></span></button>

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -56,8 +56,9 @@ export default PageView.extend({
       hook: 'feedback'
     },
     {
-      type: 'toggle',
-      hook: 'now-active'
+      type: 'booleanClass',
+      hook: 'is-enabled',
+      name: 'is-enabled'
     },
     {
       type: 'toggle',

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -4,6 +4,9 @@ import BaseView from './base-view';
 
 export default BaseView.extend({
   template: `<div data-hook="show-detail" class="experiment-summary">
+                <div class="experiment-actions">
+                  <div data-l10n-id="experimentListEnabledTab" data-hook="enabled-tab" class="tab enabled-tab"></div>
+                </div>
               <div class="experiment-icon-wrapper" data-hook="bg">
                 <div class="experiment-icon" data-hook="thumbnail"></div>
               </div>
@@ -12,11 +15,8 @@ export default BaseView.extend({
                   <h3 data-hook="title"></h3>
                 </header>
                 <p data-hook="description"></p>
+                <span class="participant-count" data-l10n-id="participantCount"</span>
               </div>
-               <div class="experiment-actions">
-                  <button data-l10n-id="experimentListInactiveHover" class="button default show-when-inactive">Get Started</button>
-                  <button data-l10n-id="experimentListActiveHover" class="button secondary show-when-active">Manage</button>
-               </div>
              </div>`,
 
   props: {
@@ -49,11 +49,15 @@ export default BaseView.extend({
       },
       hook: 'thumbnail'
     },
-    'model.enabled': {
+    'model.enabled': [{
       type: 'booleanClass',
       hook: 'show-detail',
-      name: 'active'
+      name: 'enabled'
     },
+    {
+      type: 'toggle',
+      hook: 'enabled-tab'
+    }],
     'hasAddon': {
       type: 'booleanClass',
       hook: 'show-detail',
@@ -62,7 +66,7 @@ export default BaseView.extend({
   },
 
   events: {
-    'click [data-hook=show-detail].logged-in': 'openDetailPage'
+    'click [data-hook=show-detail].has-addon': 'openDetailPage'
   },
 
   initialize(opts) {
@@ -71,19 +75,11 @@ export default BaseView.extend({
 
   openDetailPage(evt) {
     evt.preventDefault();
-    if (this.model.enabled) {
-      app.sendToGA('event', {
-        eventCategory: 'ExperimentsPage Interactions',
-        eventAction: 'Manage experiment button',
-        eventLabel: this.model.title
-      });
-    } else {
-      app.sendToGA('event', {
-        eventCategory: 'ExperimentsPage Interactions',
-        eventAction: 'Get Started experiment button',
-        eventLabel: this.model.title
-      });
-    }
+    app.sendToGA('event', {
+      eventCategory: 'ExperimentsPage Interactions',
+      eventAction: 'Open detail page',
+      eventLabel: this.model.title
+    });
     app.router.navigate('experiments/' + this.model.slug);
   }
 });

--- a/testpilot/frontend/static-src/styles/_variables.scss
+++ b/testpilot/frontend/static-src/styles/_variables.scss
@@ -71,3 +71,8 @@ $circle-border-radius: 50%;
 $grid-unit: 20px;
 $font-unit: 12px;
 $line-unit: 18px;
+
+// "Enabled" greens
+$green: #7cd06a;
+$dark-green: #3b9827;
+$bright-green: #65c751;

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -1,9 +1,18 @@
 .details-header-wrapper {
 
+  &:not(.is-enabled) {
+    padding-top: $grid-unit * 1.8;
+
+    .enabled {
+      display: none;
+    }
+  }
+
   &.stick {
     background: $transparent-white-96;
     box-shadow: 0 0 5px $transparent-black-5;
     left: 0;
+    padding-top: 0;
     position: fixed;
     top: 0;
     width: 100%;
@@ -12,6 +21,26 @@
     + div {
       margin-top: $grid-unit * 4.8;
     }
+  }
+}
+
+.status-bar {
+  @include flex-container(row, center, center);
+  animation: fade-in 500ms forwards;
+  font-weight: 300;
+  height: $grid-unit * 1.6;
+  margin-bottom: $grid-unit * .2;
+  opacity: 0;
+  padding-top: $grid-unit * .1;
+
+  &.enabled {
+    background: $green;
+    border-bottom: 1px solid $dark-green;
+    color: $white;
+  }
+
+  .stick & {
+    margin-bottom: 0;
   }
 }
 
@@ -44,12 +73,12 @@
   position: relative;
 
   h1 {
-    @include respond-to('not-small') {
+    @include respond-to('big') {
       font-size: $font-unit * 4;
       line-height: $font-unit * 4;
     }
 
-    @include respond-to('small') {
+    @include respond-to('medium') {
       font-size: $font-unit * 3.5;
       line-height: $font-unit * 3.5;
     }
@@ -239,36 +268,5 @@
     font-size: $font-unit;
     margin-top: $grid-unit * .5;
     padding: 0 $grid-unit * .25;
-  }
-}
-
-.now-active {
-  color: $primary;
-  display: block;
-  font-weight: bold;
-  left: $grid-unit * .75;
-  position: absolute;
-  top: -$grid-unit;
-
-  .stick & {
-    display: none;
-  }
-
-  &::before {
-    @media (min-resolution: 1.3dppx) {
-      animation: pop 2000ms alternate ease-in-out;
-      animation-iteration-count: 5;
-    }
-
-    background: $primary;
-    border-radius: 50%;
-    content: '';
-    display: inline-block;
-    filter: blur(.1px);
-    height: $grid-unit;
-    margin-right: $grid-unit * .4;
-    position: relative;
-    top: $grid-unit * .2;
-    width: $grid-unit;
   }
 }

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -47,33 +47,27 @@
 
   p {
     line-height: 1.4 * $line-unit;
+    margin-bottom: $grid-unit * .5;
+  }
+
+  span {
+    color: $transparent-black-4;
+    font-size: 1.1 * $font-unit;
     margin: 0;
   }
 
   &.has-addon {
     cursor: pointer;
 
-    &.active {
-      box-shadow: 0 0 0 3px $white, 0 0 0 6px $primary;
+    &:hover {
+      box-shadow: 0 0 0 3px $transparent-white-1;
+    }
+
+    &.enabled {
+      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green;
 
       &:hover {
-        box-shadow: 0 0 0 3px $white, 0 0 0 8px $primary;
-      }
-
-      &::after {
-        @include hidpi-background-image('check', 36px 27px);
-        background-color: $primary;
-        background-position: center center;
-        background-repeat: no-repeat;
-        border: 3px solid $white;
-        border-radius: $circle-border-radius;
-        content: '';
-        height: 56px;
-        position: absolute;
-        right: -26px;
-        top: -26px;
-        width: 56px;
-        z-index: 2;
+        box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green, 0 0 0 9px $transparent-white-1;
       }
     }
   }
@@ -90,20 +84,39 @@
 }
 
 .experiment-actions {
-  padding: 0 $grid-unit $grid-unit;
+  .has-addon:not(.active) &.show-when-inactive {
+    display: block;
+  }
 
-  .button {
-    display: none;
+  .tab {
+    border-bottom-right-radius: 5px;
+    border-bottom-width: 3px;
+    border-left-width: 0;
+    border-right-color: $white;
+    border-right-width: 3px;
+    border-style: solid;
+    border-top-left-radius: 6px;
+    border-top-width: 0;
+    display: inline-block;
+    font-weight: 300;
+    height: $grid-unit * 1.5;
+    left: -3px;
+    line-height: $grid-unit * 1.5;
+    outline: none;
+    padding: 0 20px;
+    position: absolute;
     text-align: center;
-    width: 100%;
+    text-decoration: none;
+    top: -3px;
+    transition: background 150ms;
+    white-space: nowrap;
+    z-index: 99999;
+  }
 
-    .active &.show-when-active {
-      display: block;
-    }
-
-    .has-addon:not(.active) &.show-when-inactive {
-      display: block;
-    }
+  .enabled-tab {
+    background: $bright-green;
+    border-bottom-color: $white;
+    color: $white;
   }
 }
 
@@ -134,6 +147,6 @@
   background-size: $grid-unit * 4 $grid-unit * 4;
   filter: drop-shadow(0 1px 0 $transparent-black-1);
   flex: 0 0 $grid-unit * 4;
-  height: $grid-unit * 4;
+  height: $grid-unit * 5;
   opacity: .9;
 }

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -67,16 +67,22 @@ test('afterRender attaches detailView and contributorView', t => {
   t.ok(myView.query('.contributors'));
 });
 
-test('now active indicator shows when experiment is enabled', t => {
+test('indicator bar shows when experiment is enabled', t => {
   t.plan(2);
 
   const myView = new MyView({headerScroll: false, slug: 'slsk'});
   myView.render();
 
-  t.ok(myView.query('.now-active'));
   const model = app.experiments.get('slsk', 'slug');
+
+  model.enabled = true;
+  t.ok(myView.query('.is-enabled'));
+
   model.enabled = false;
-  t.equal(myView.query('.now-active').style.display, 'none');
+  // since the display logic is in CSS,
+  // check for the selector pattern that would
+  // show the notification
+  t.equal(myView.query('.is-enabled .enabled'), undefined);
 });
 
 test('introduction appears in view', t => {


### PR DESCRIPTION
Fixes #968.

@meandavejustice @6a68: hey, this is an extensions of @kaganjd's original PR to work out some nits with the enabled status thing scrolling. Take a look (might be good to pull down and make sure it looks right before merging)
