### PR TITLE
Wait longer for add-on setup, reload install page if it times out

### DIFF
--- a/testpilot/frontend/static-src/app/main.js
+++ b/testpilot/frontend/static-src/app/main.js
@@ -65,7 +65,7 @@ app.extend({
   },
 
   // Send webChannel message to addon, use a Promise to wait for the answer.
-  waitForMessage(type, data, timeout = 5000) {
+  waitForMessage(type, data, timeout = 10000) {
     return new Promise((resolve, reject) => {
       const rejectTimer = setTimeout(() => {
         reject('waitForMessage timeout: ' + type);

--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -61,6 +61,10 @@ export default PageView.extend({
       app.me.fetch().then(() => {
         app.webChannel.sendMessage('show-installed-panel', {});
         app.router.redirectTo('experiments');
+      }).catch(() => {
+        // HACK (for Issue #1075): Timed out while waiting for the initial sync
+        // message, so just reload the page to stop waiting.
+        window.location.reload();
       });
     }, 1000);
   },


### PR DESCRIPTION
When the add-on is first installed from the "Install the Test Pilot Add-on" button, we start an "Installing" animation. Once the add-on is installed & set up, we try to detect that and move on to the next step. If the add-on takes too long, we time out with an unhandled error.

This PR attempts to handle that error by reloading the page. If the add-on was installed but just took awhile to set up, this should result in the user seeing the experiments page. Otherwise, they'll see the "Install the Test Pilot Add-on" button again

Fixes #1075
