### PR TITLE
Update SRI hash for pontoon dependency

### DIFF
--- a/testpilot/settings.py
+++ b/testpilot/settings.py
@@ -458,7 +458,7 @@ LOGGING = {
 # TODO: Management command to help update hashes for all listed resources?
 URL_INTEGRITY_HASHES = {
     "https://pontoon.mozilla.org/pontoon.js":
-        "sha384-Wrfqhq3/nkU9KwCpKD8b55Aq0xMbUGEd7tETkuiRGhApLJ0QvusEhLBwta1OYdwi",
+        "sha384-9wVUbSIrAcmtmml7yD1gwWDunLY1joKMG9zV6wBaWv9Ao5UKgVT6o2vvYEf2RHVS",
     "https://code.cdn.mozilla.net/fonts/fira.css":
         "sha384-APhs/OUouhH+ZbBANL3+7a5J1sVSYyfUhGxTWiDMkTuEIO5fXWZonzNEj+CagDB7",
 }


### PR DESCRIPTION
This should fix the hash mismatch error reported here:

https://bugzilla.mozilla.org/show_bug.cgi?id=1288286
