### PR TITLE
Bugfix for TypeError in add-on onExperimentPing

### DIFF
--- a/addon/lib/metrics.js
+++ b/addon/lib/metrics.js
@@ -174,7 +174,7 @@ module.exports = {
     // TODO: Map add-on ID (subject) to other pingTypes as necessary
     const pingType = 'testpilottest';
 
-    if (subject in store.experimentVariants) {
+    if (store.experimentVariants && subject in store.experimentVariants) {
       dataParsed.variants = store.experimentVariants[subject];
     }
 


### PR DESCRIPTION
- Check for existence of store.experimentVariants before using
- Should fix errors like `TypeError invalid 'in' operand store.experimentVariants`

Fixes #1123
