### PR TITLE
Track badge state on toolbar button in experiment links and "New Experiment" label for add-on doorhanger items

### DIFF
--- a/addon/data/panel.css
+++ b/addon/data/panel.css
@@ -159,6 +159,16 @@ a {
     font-size: 14px;
 }
 
+.is-new-span {
+    display: none;
+}
+
+.is-new .is-new-span {
+    display: block;
+    color: #0996f8;
+    font-size: 14px;
+}
+
 .installed-message {
     background: #fff;
     display: flex;

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -7,13 +7,14 @@
 module.exports.experimentList = `
 <div class="experiment-list">
   {{#experiments}}
-    <a class="experiment-item {{#active}}active{{/active}}" href="{{base_url}}/experiments/{{slug}}?{{params}}">
+    <a class="experiment-item {{#active}}active{{/active}} {{#isNew}}is-new{{/isNew}}" href="{{base_url}}/experiments/{{slug}}?{{params}}">
       <div class="icon-wrapper"
            style="background-color:{{gradient_start}}; background-image: linear-gradient(300deg, {{gradient_start}}, {{gradient_stop}})">
         <div class="icon" style="background-image:url('{{thumbnail}}');"></div>
       </div>
       <div class="experiment-title">{{title}}
         <span class="active-span {{#active}}visible{{/active}}">Enabled</span>
+        <span class="is-new-span {{#isNew}}visible{{/isNew}}">New Experiment</span>
       </div>
     </a>
   {{/experiments}}

--- a/docs/README-GOOGLE-ANALYTICS.md
+++ b/docs/README-GOOGLE-ANALYTICS.md
@@ -123,5 +123,5 @@ We should maintain a consistent convention when using campaign parameters.
 
 | Description                                                   | utm_source      | utm_medium      | utm_campaign         | utm_content        |
 |---------------------------------------------------------------|-----------------|-----------------|----------------------|--------------------|
-| Clicking on an experiment (or "view all") from the doorhanger | testpilot-addon | firefox-browser | testpilot-doorhanger | {experiment title} |
+| Clicking on an experiment (or "view all") from the doorhanger | testpilot-addon | firefox-browser | testpilot-doorhanger | 'badged' or 'not badged' depending on presence of 'New' badge on add-on toolbar button |
 | Clicking on an experiment from the in-product messaging       | testpilot-addon | firefox-browser | push notification    | {messageID}        |


### PR DESCRIPTION
Fixes #1109, Fixes #1037 
