### PR TITLE
Indicator for just launched & updated experiments

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -51,6 +51,8 @@ notFoundHeader = Four Oh Four!
 experimentListPageHeader = Ready for Takeoff!
 experimentListPageSubHeader  = Pick the features you want to try. <br> Check back soon for more experiments.
 experimentListEnabledTab = Enabled
+experimentListJustLaunchedTab = Just Launched
+experimentListJustUpdatedTab = Just Updated
 isEnabledStatusMessage = {$title} is enabled.
 participantCount = <span>{$installation_count}</span> participants
 

--- a/testpilot/frontend/static-src/app/models/experiment.js
+++ b/testpilot/frontend/static-src/app/models/experiment.js
@@ -7,8 +7,10 @@ export default Model.extend({
   urlRoot: '/api/experiments',
   extraProperties: 'allow',
   props: {
-    enabled: {type: 'boolean', default: false}
+    enabled: {type: 'boolean', default: false},
+    lastSeen: {type: 'number', default: 0}
   },
+
   // This shouldn't be necessary; see comments in collections/experiments.js
   ajaxConfig: { headers: { 'Accept': 'application/json' }},
 
@@ -27,6 +29,8 @@ export default Model.extend({
         this.enabled = false;
       }
     });
+
+    this.lastSeen = this.getWhenLastSeen();
   },
 
   buildSurveyURL(ref) {
@@ -36,5 +40,15 @@ export default Model.extend({
       installed: app.me.installed ? Object.keys(app.me.installed) : []
     });
     return `${this.survey_url}?${queryParams}`;
+  },
+
+  getWhenLastSeen() {
+    const key = `experiment-last-seen-${this.id}`;
+    return parseInt(localStorage.getItem(key), 10);
+  },
+
+  updateWhenLastSeen() {
+    const key = `experiment-last-seen-${this.id}`;
+    return localStorage.setItem(key, this.lastSeen = Date.now());
   }
 });

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -206,6 +206,7 @@ export default PageView.extend({
       'dimension5': this.model.title,
       'dimension6': this.model.installation_count
     });
+    this.model.updateWhenLastSeen();
     return this;
   },
 

--- a/testpilot/frontend/static-src/styles/_variables.scss
+++ b/testpilot/frontend/static-src/styles/_variables.scss
@@ -76,3 +76,6 @@ $line-unit: 18px;
 $green: #7cd06a;
 $dark-green: #3b9827;
 $bright-green: #65c751;
+
+// "Just {Launched,Updated}" blue
+$bright-blue: #1e98f5

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -72,6 +72,22 @@
         box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green, 0 0 0 9px $transparent-white-1;
       }
     }
+
+    &.just-launched {
+      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue;
+
+      &:hover {
+        box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue, 0 0 0 9px $transparent-white-1;
+      }
+    }
+
+    &.just-updated {
+      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue;
+
+      &:hover {
+        box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue, 0 0 0 9px $transparent-white-1;
+      }
+    }
   }
 
   &.has-addon:hover {
@@ -117,6 +133,18 @@
 
   .enabled-tab {
     background: $bright-green;
+    border-bottom-color: $white;
+    color: $white;
+  }
+
+  .just-launched-tab {
+    background: $bright-blue;
+    border-bottom-color: $white;
+    color: $white;
+  }
+
+  .just-updated-tab {
+    background: $bright-blue;
     border-bottom-color: $white;
     color: $white;
   }

--- a/testpilot/frontend/static-src/test/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/test/views/experiment-row-view.js
@@ -2,6 +2,11 @@ import test from 'tape-catch';
 import Experiment from '../../app/models/experiment';
 import View from '../../app/views/experiment-row-view';
 
+const NOW = Date.now();
+const ONE_DAY = 1 * 24 * 60 * 60 * 1000;
+const TWO_DAYS = 2 * ONE_DAY;
+const THREE_DAYS = 3 * ONE_DAY;
+
 test(`Running Tests for ${__filename}`, a => a.end());
 
 test('Experiment row view renders', t => {
@@ -36,4 +41,67 @@ test('Experiment row displays short_title', t => {
   });
   const view = new View({model: model}).render();
   t.equal(view.query('.experiment-summary h3').innerHTML, expectedTitle);
+});
+
+test('Experiment row card displays "Just Launched" when experiment is new & unseen', t => {
+  t.plan(4);
+  const model = new Experiment({
+    slug: 'test',
+    title: 'long long long title',
+    created: NOW - TWO_DAYS
+  });
+  model.lastSeen = null;
+
+  const view = new View({model: model}).render();
+  t.ok(view.query('.experiment-summary.just-launched'),
+       'should appear when unseen');
+
+  model.enabled = true;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-launched'),
+       'should not appear when enabled');
+
+  model.enabled = false;
+  model.lastSeen = NOW;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-launched'),
+       'should not appear after seen');
+
+  model.lastSeen = null;
+  model.created = ONE_DAY * 30;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-launched'),
+       'should not appear when too old');
+});
+
+test('Experiment row card displays "Just Updated" when experiment is updated since last seen', t => {
+  t.plan(4);
+  const model = new Experiment({
+    slug: 'test',
+    title: 'long long long title',
+    created: NOW - TWO_DAYS,
+    modified: NOW - ONE_DAY
+  });
+  model.lastSeen = NOW - THREE_DAYS;
+
+  const view = new View({model: model}).render();
+  t.ok(view.query('.experiment-summary.just-updated'),
+       'should appear when modified after last seen');
+
+  model.enabled = true;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-updated'),
+       'should not appear when enabled');
+
+  model.enabled = false;
+  model.lastSeen = NOW;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-updated'),
+       'should not appear when seen since modified');
+
+  model.lastSeen = NOW - THREE_DAYS;
+  model.modified = NOW - ONE_DAY * 30;
+  view.render();
+  t.ok(!view.query('.experiment-summary.just-updated'),
+       'should not appear when too old');
 });


### PR DESCRIPTION
- Add `lastSeen` property to `experiment` model persisted in
  `localStorage`
- Update `lastSeen` on experiment detail page view
- When experiment created & never seen, show a "Just Launched" indicator
  for 2 weeks in experiment card view.
- When experiment modified since last seen, show a "Just Updated"
  indicator for 2 weeks in experiment card view.
- Style tweaks, strings, and tests

Fixes #1038
