### PR TITLE
Docker local development improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,16 @@ RUN addgroup -g 10001 app && \
 # https://github.com/python-pillow/Pillow/issues/1763#issuecomment-204252397
 ENV LIBRARY_PATH=/lib:/usr/lib
 
+# Install & cache packages for alpine
+RUN apk --no-cache add ca-certificates postgresql-dev build-base libjpeg-turbo-dev zlib-dev
+
 # Install & cache dependencies for Django/Python using pip8
 COPY requirements.txt /app/requirements.txt
-RUN apk --no-cache add ca-certificates postgresql-dev build-base libjpeg-turbo-dev zlib-dev && \
-    pip install pip==8.1.2 && \
-    pip install --require-hashes -r requirements.txt && \
-    apk del --purge build-base gcc
+RUN pip install pip==8.1.2 && \
+    pip install --require-hashes -r requirements.txt
+
+# Clean up some build packages after we're done with Python
+RUN apk del --purge build-base gcc
 
 # Copy in the whole app after dependencies have been installed & cached
 COPY . /app

--- a/Dockerfile-frontend-build
+++ b/Dockerfile-frontend-build
@@ -1,8 +1,10 @@
-FROM node:4.4.0
+FROM alpine:3.4
 
 CMD ["./bin/run-frontend-build.sh"]
 
 WORKDIR /app
 
+RUN apk --no-cache add nodejs=6.2.0-r0 python=2.7.12-r0 ca-certificates build-base
 COPY package.json /root/package.json
 RUN cd /root && npm install
+RUN apk del --purge build-base gcc

--- a/bin/run-dev.sh
+++ b/bin/run-dev.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+
+# HACK: Wait a while before starting up, to let postgres warm up and
+# frontend_watcher to finish its first build
+/bin/sleep 15
+
 ./bin/run-common.sh
 ./manage.py loaddata fixtures/initial_data_dev.json
 

--- a/docker-compose-base.yml
+++ b/docker-compose-base.yml
@@ -1,6 +1,10 @@
 frontend-watcher:
   build: .
+
+  # DEV: Uncomment image & comment out dockerfile to skip building from scratch
+  # image: lmorchard/testpilot_frontend_watcher:latest
   dockerfile: Dockerfile-frontend-build
+
   ports:
     - "9966:9966"
     - "35729:35729"
@@ -12,7 +16,11 @@ frontend-watcher:
     ./bin/run-frontend-watch.sh
 server:
   build: .
+
+  # DEV: Uncomment image & comment out dockerfile to skip building from scratch
+  # image: mozilla/testpilot:latest
   dockerfile: Dockerfile
+
   ports:
     - "8000:8000"
   # HACK: escalate to root user in dev, because we need to be able to write

--- a/docs/README-DOCKER.md
+++ b/docs/README-DOCKER.md
@@ -5,83 +5,85 @@ Using Docker in development helps produce a consistent environment that's close
 to the real production site. But, working with it is sometimes odd. This file
 lists some hints & tips we've accumulated through the course of daily work.
 
-* To shell into one of the containers:
+### To shell into the containers:
 
-  `docker exec -t -i testpilot_server_1 bash`
+* `docker exec -t -i testpilot_frontend_watcher_1 sh`
+* `docker exec -t -i testpilot_server_1 sh`
 
-  This is necessary for running Django commands, among other things.
+This is necessary for running Django commands, among other things.
 
-* To load some sample demo content into your Docker dev environment:
+### To load some sample demo content into your Docker dev environment:
+```
+mkdir -p media
+cp -r fixtures/media/demo media
+docker exec testpilot_server_1 ./manage.py loaddata fixtures/demo_data.json
+```
+
+### Syntax & unit tests for Pull Requests to be accepted on GitHub.
+
+* To run server linting & tests:
+
+  `docker exec testpilot_server_1 ./bin/run-dev-tests.sh`
+
+* To run frontend & addon code linting:
+
+  `docker exec testpilot_frontend_watcher_1 ./bin/run-frontend-lint.sh`
+
+* To start a file watcher for frontend tests:
+
+  `docker exec testpilot_frontend_watcher_1 ./bin/run-frontend-tests-watch.sh`
+
+  Then, open http://testpilot.dev:9966/ in a browser to see test results.
+
+* On OS X, the [`kicker`](https://github.com/alloy/kicker) utility might be
+  handy for running checks on local file changes:
+  ```bash
+    sudo gem install kicker
+    kicker -c -e'docker exec -t -i testpilot_server_1 ./bin/run-dev-tests.sh' ./testpilot
+    kicker -c -e'docker exec -t -i testpilot_frontend_watcher_1 ./bin/run-frontend-tests.sh' ./testpilot/frontend/static-src ./addon
   ```
-  mkdir -p media
-  cp -r fixtures/media/demo media
-  docker exec testpilot_server_1 ./manage.py loaddata fixtures/demo_data.json
-  ```
 
-* Syntax & unit tests must pass for Pull Requests to be accepted on GitHub.
+### Rebuilding when Python (requirements.txt) or Node (package.json) dependencies change
 
-    * To run server linting & tests:
+* `docker-compose build server`
+* `docker-compose build frontend_watcher`
 
-      `docker exec testpilot_server_1 ./bin/run-dev-tests.sh`
+### Database errors and 500 errors in Django
 
-    * To run frontend & addon code linting:
+Sometimes the database container hasn't fully started when the Django container
+wants to connect to it. If this happens:
 
-      `docker exec testpilot_frontend_watcher_1 ./bin/run-frontend-lint.sh`
+* `docker ps` to get the name of the Django container (something like `testpilot_server_1`)
+* `docker restart testpilot_server_1` to restart the Django container
 
-    * To start a file watcher for frontend tests:
+### [Issue #74](https://github.com/mozilla/testpilot/issues/74): Sometimes `docker-compose build` seems to hang while building the `frontend_watcher` image. 
 
-      `docker exec testpilot_frontend_watcher_1 ./bin/run-frontend-tests-watch.sh`
-
-      Then, open http://testpilot.dev:9966/ in a browser to see test results.
-
-    * On OS X, the [`kicker`](https://github.com/alloy/kicker) utility might be
-      handy for running checks on local file changes:
-      ```bash
-        sudo gem install kicker
-        kicker -c -e'docker exec -t -i testpilot_server_1 ./bin/run-dev-tests.sh' ./testpilot
-        kicker -c -e'docker exec -t -i testpilot_frontend_watcher_1 ./bin/run-frontend-tests.sh' ./testpilot/frontend/static-src ./addon
-      ```
-
-* If you change `requirements.txt` to add dependencies for Django, you must rebuild `server`:
-
-  `docker-compose build server`
-
-* If you change `package.json` to add dependencies for `gulpfile.js`, you must rebuild `frontend_watcher`:
-
-  `docker-compose build frontend_watcher`
-
-* Sometimes the database container hasn't fully started when the Django container wants to connect to it. If this happens:
-
-  * `docker ps` to get the name of the Django container (something like `testpilot_server_1`)
-  * `docker restart testpilot_server_1` to restart the Django container
-
-* [Issue #74](https://github.com/mozilla/testpilot/issues/74): Sometimes `docker-compose build` seems to hang while building the
-  `frontend_watcher` image. If this happens:
-
-  * `docker rmi $(docker images -f dangling=true -q)` to remove any dangling images
-  * `npm install` (it's not clear why this has an effect, but it seems to)
-  * `docker-compose build`
+* `docker rmi $(docker images -f dangling=true -q)` to remove any dangling images
+* `npm install` (it's not clear why this has an effect, but it seems to)
+* `docker-compose build`
 
 [dc-bug]: https://github.com/docker/compose/issues/374
 
-* You can customize settings for special development cases. For example, to
-  switch to using S3 for media uploads:
-  ```bash
-    cp docker-compose-s3.yml-dist docker-compose-s3.yml
-    # Edit docker-compose-s3.yml to include your AWS credentials
-    docker-compose -f docker-compose-s3.yml build
-    docker-compose -f docker-compose-s3.yml up
-  ```
+### Customizing settings for special development cases. 
 
-* If you'd like to run Gulp on your host computer because there are issues
-  running `frontend_watcher`, try this:
-  ```
-  docker-compose -f docker-compose-only-server.yml build
-  docker-compose -f docker-compose-only-server.yml up
-  ```
-  Then, in a second terminal, you can run Gulp like this (assuming you have
-  node.js installed locally):
-  ```
-  npm install
-  gulp
-  ```
+For example, to switch to using S3 for media uploads:
+```bash
+cp docker-compose-s3.yml-dist docker-compose-s3.yml
+# Edit docker-compose-s3.yml to include your AWS credentials
+docker-compose -f docker-compose-s3.yml build
+docker-compose -f docker-compose-s3.yml up
+```
+
+### If you'd like to run Gulp on your host computer
+
+(e.g. because there are issues running `frontend_watcher`)
+```
+docker-compose -f docker-compose-only-server.yml build
+docker-compose -f docker-compose-only-server.yml up
+```
+Then, in a second terminal, you can run Gulp like this (assuming you have
+node.js installed locally):
+```
+npm install
+gulp
+```


### PR DESCRIPTION
- Reformat docs/README-DOCKER.md to make tips more easily linkable
- Add a 15 second delay to server bin/run-dev.sh to try to compensate
  for postgres warmup and frontend_watcher initial build time
- Move frontend_watcher to much smaller Alpine linux, upgrade node to
  v6.2.0 from Alpine package
- Speed up server build by caching Alpine package installation
  separately from Python dependency installation
- Add comments to docker-compose-base.yml for optional base images to
  kickstart the process for local dev
