### PR TITLE
Initialize add-on toolbar last clicked timestamp to now

### DIFF
--- a/addon/lib/toolbar-button.js
+++ b/addon/lib/toolbar-button.js
@@ -145,9 +145,7 @@ const ToolbarButton = module.exports = {
 
     // Initialize the last button click timestamp if necessary.
     if (!('toolbarButtonLastClicked' in store)) {
-      // HACK: Set this to 1 so there's a value, but one that will initially be
-      // less than the current time.
-      store.toolbarButtonLastClicked = 1;
+      store.toolbarButtonLastClicked = Date.now();
     }
 
     // Look through available experiments for anything newer than the last


### PR DESCRIPTION
Should result in no "New" badge on initial install and only show the badge when things are created after then

Fixes #1170
