### PR TITLE
Add a legacy user migration page. Fixes #1079

### DIFF
--- a/testpilot/frontend/static-src/app/lib/page-manager.js
+++ b/testpilot/frontend/static-src/app/lib/page-manager.js
@@ -5,6 +5,7 @@ import ErrorPage from '../views/error-page';
 import ExperimentPage from '../views/experiment-page';
 import ExperimentListPage from '../views/experiment-list-page';
 import LandingPage from '../views/landing-page';
+import LegacyPage from '../views/legacy-page';
 import NotFoundPage from '../views/not-found-page';
 import OnboardingPage from '../views/onboarding-page';
 import RetirePage from '../views/retire-page';
@@ -24,6 +25,7 @@ export default class PageManager {
       'landing': LandingPage,
       'experiments': ExperimentListPage,
       'experimentDetail': ExperimentPage,
+      'legacy': LegacyPage,
       'share': SharePage,
       'notFound': NotFoundPage,
       'onboarding': OnboardingPage,

--- a/testpilot/frontend/static-src/app/lib/router.js
+++ b/testpilot/frontend/static-src/app/lib/router.js
@@ -12,6 +12,7 @@ export default Router.extend({
     'home(/)': 'home',
     'experiments/:experiment(/)': 'experimentDetail',
     'experiments(/)': 'experiments',
+    'legacy(/)': 'legacy',
     '404': 'notFound',
     'share(/)': 'share',
     'error': 'error',
@@ -63,6 +64,10 @@ export default Router.extend({
 
   onboarding() {
     app.trigger('router:new-page', {page: 'onboarding'});
+  },
+
+  legacy() {
+    app.trigger('router:new-page', {page: 'legacy'});
   },
 
   notFound() {

--- a/testpilot/frontend/static-src/app/views/legacy-page.js
+++ b/testpilot/frontend/static-src/app/views/legacy-page.js
@@ -1,0 +1,36 @@
+import PageView from './page-view';
+
+//  Regarding localization: These strings were originally in the app.ftl, but
+//  they make up a decent amount of words in there for localizers to work on,
+//  and this is a view-once, temporary page for an (I think?) English-only
+//  program.  So I took them back out and hardcoded them here.
+export default PageView.extend({
+  template: `
+<div class="blue">
+  <div class="stars"></div>
+  <header data-hook="header-view"></header>
+  <div class="full-page-wrapper space-between">
+    <div class="centered-banner">
+      <div id="legacy-modal" class="modal delayed-fade-in">
+        <div class="modal-content">
+          <p>Hello there! Once upon a time, you installed an add-on called Test Pilot for Firefox.</p>
+          <p>Well the Test Pilot program for trying experimental features in Firefox is back, and we thought you might like to check it out.</p>
+          <p>The old add-on has been uninstalled for you. If you'd like the new one, just click the link.</p>
+          <p>If you're not interested, simply close this tab and get back to browsing.</p>
+        </div>
+        <div class="modal-actions">
+          <a class="button default large" href="/?utm_source=testpilot_legacy&utm_medium=firefox-browser">Check out Test Pilot</a>
+        </div>
+      </div>
+      <div class="copter-wrapper">
+        <div class="copter fade-in-fly-up"></div>
+      </div>
+    </div>
+    <footer id="main-footer" class="content-wrapper">
+      <div data-hook="footer-view"></div>
+    </footer>
+  </div>
+</div>
+  `,
+  skipHeader: false
+});

--- a/testpilot/frontend/static-src/app/views/legacy-page.js
+++ b/testpilot/frontend/static-src/app/views/legacy-page.js
@@ -8,8 +8,12 @@ export default PageView.extend({
   template: `
 <div class="blue">
   <div class="stars"></div>
-  <header data-hook="header-view"></header>
   <div class="full-page-wrapper space-between">
+    <header id="main-header" class="responsive-content-wrapper">
+      <h1>
+        <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
+      </h1>
+    </header>
     <div class="centered-banner">
       <div id="legacy-modal" class="modal delayed-fade-in">
         <div class="modal-content">
@@ -32,5 +36,5 @@ export default PageView.extend({
   </div>
 </div>
   `,
-  skipHeader: false
+  skipHeader: true
 });

--- a/testpilot/frontend/static-src/styles/modules/_footer.scss
+++ b/testpilot/frontend/static-src/styles/modules/_footer.scss
@@ -1,10 +1,10 @@
 #main-footer {
   @include respond-to('not-small') {
-    padding: $grid-unit * 4 0 0;
+    padding: $grid-unit * 2 0 0;
   }
 
   @include respond-to('small') {
-    padding: $grid-unit * 2 0 0;
+    padding: $grid-unit * 1 0 0;
   }
 
   position: relative;

--- a/testpilot/frontend/static-src/styles/modules/_modals.scss
+++ b/testpilot/frontend/static-src/styles/modules/_modals.scss
@@ -42,9 +42,17 @@
   }
 }
 
-#legacy-modal .modal-content{
+#legacy-modal {
 
-// TODO XXX Something with line spacing
+  p {
+    font-size: $font-unit * 1.5;
+    margin: 0 $grid-unit * -.5 $grid-unit;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
 
 }
 

--- a/testpilot/frontend/static-src/styles/modules/_modals.scss
+++ b/testpilot/frontend/static-src/styles/modules/_modals.scss
@@ -1,6 +1,7 @@
 #four-oh-four,
 #retire,
 #share,
+#legacy-modal,
 #onboarding {
   margin-bottom: $grid-unit * 1.5;
   position: relative;
@@ -39,6 +40,12 @@
   .modal-content {
     padding: 20px 20px 30px;
   }
+}
+
+#legacy-modal .modal-content{
+
+// TODO XXX Something with line spacing
+
 }
 
 .modal-container {


### PR DESCRIPTION
Not ready to land, but r?

This is my first time in these internals so making an early PR for review.  Two things are left:

1) The header only works when I have the add-on installed (which people looking at this page won't have).  Loading the page in safari or private browsing mode shows the page with no header.  The other pages all seem to be a series of special cases so they are hard to copy directly. :)

2) The spacing of the paragraphs are wrong.  @johngruen said he wanted to come up with some fancy CSS.

The spec is at https://mozilla.invisionapp.com/share/Q77S1H6ZC#/screens/169034030
