### PR TITLE
Extract PageMod bits of addon into a new module

### DIFF
--- a/addon/lib/app.js
+++ b/addon/lib/app.js
@@ -1,0 +1,91 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the 'License'). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+const { Class } = require('sdk/core/heritage');
+const { emit, setListeners } = require('sdk/event/core');
+const { EventTarget } = require('sdk/event/target');
+const { PageMod } = require('sdk/page-mod');
+const { Request } = require('sdk/request');
+const { setInterval, clearInterval } = require('sdk/timers');
+
+const App = Class({ // eslint-disable-line new-cap
+  implements: [EventTarget],
+  initialize: function(options) {
+    setListeners(this, options);
+    this.baseUrl = options.baseUrl;
+    this.badgeColor = options.badgeColor;
+    this.experiments = {};
+    this.workers = new Set();
+    this.reloadInterval = setInterval(
+      () => this.loadExperimentList(),
+      options.reloadInterval
+    );
+
+    const pageIncludes = this.baseUrl + '/*';
+    this.page = new PageMod({
+      include: pageIncludes,
+      contentScriptFile: './message-bridge.js',
+      contentScriptWhen: 'start',
+      attachTo: ['top', 'existing']
+    });
+    this.page.on(
+      'attach',
+      worker => {
+        this.workers.add(worker);
+        worker.on('detach', () => this.workers.delete(worker));
+        worker.port.on('from-web-to-addon', ev => emit(this, ev.type, ev.data));
+      }
+    );
+    const beaconIncludes = (pageIncludes + ',' + options.whitelist).split(',');
+    this.beacon = new PageMod({
+      include: beaconIncludes,
+      contentScriptFile: './set-installed-flag.js',
+      contentScriptWhen: 'start',
+      attachTo: ['top', 'existing'],
+      contentScriptOptions: {
+        version: options.addonVersion
+      }
+    });
+    this.loadExperimentList();
+  },
+  loadExperimentList: function() {
+    const r = new Request({
+      headers: { 'Accept': 'application/json' },
+      url: this.baseUrl + '/api/experiments',
+      contentType: 'application/json'
+    });
+    r.on(
+      'complete',
+      res => {
+        if (res.status === 200) {
+          this.experiments = {};
+          for (let xp of res.json.results) { // eslint-disable-line prefer-const
+            this.experiments[xp.addon_id] = xp;
+          }
+          emit(this, 'loaded', this.experiments);
+        } else {
+          emit(this, 'loadError', res);
+        }
+      }
+    );
+    r.get();
+  },
+  hasAddonID: function(id) {
+    return !!this.experiments[id];
+  },
+  send: function(type, data) {
+    for (let worker of this.workers) { // eslint-disable-line prefer-const
+      worker.port.emit('from-addon-to-web', {type: type, data: data});
+    }
+  },
+  destroy: function() {
+    this.page.destroy();
+    this.beacon.destroy();
+    clearInterval(this.reloadInterval);
+  }
+});
+
+exports.App = App;


### PR DESCRIPTION
This is a heavyweight fix for #1021. I apologize for the huge diff. 

The main problem in #1021 is that the `installListener` functions could run either before `app` was initialized [1] or the worker port for the pagemod had been detached [2]. The quick solution would be to check if `app` is defined and that there's still a worker on the pagemod. Since I felt like I had time I opted to try a less hacky approach. Hopefully I didn't get _too_ carried away.

The gist of this patch is
- extract the pagemod bits into its own module `app.js` to make changing envs cleaner
- initialize `app` to the most likely env on startup
- set the `active` flags correctly without refreshing from the server
- trigger the onboarding tab after the final env is known

Which is _way_ more stuff than required for #1021 so I'm ok with undoing anything that is too far.

(questions and comments coming inline)

[1] - Example: a fresh browser start then install an addon without ever visiting testpilot
[2] - Example: visited testpilot, closed the tab, then install an addon
