### PR TITLE
Initial implementation of integration tests

### DIFF
--- a/addon/bin/sign
+++ b/addon/bin/sign
@@ -58,7 +58,7 @@ function distAddon() {
     if (err) return console.error(err);
 
     // sign our add-on
-    var generatedXpi = '@testpilot-addon-' + version + '.xpi';
+    var generatedXpi = 'testpilot-addon.xpi';
 
     signAddon(generatedXpi, function(err, signedXpiPath) {
       if (err) return console.error(err);

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.8.3",
+  "version": "0.8.5",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",
@@ -25,7 +25,7 @@
     "watch-ui": "watchify-server ui-test.js --index ui-test.html",
     "lint": "eslint .",
     "sign": "./bin/update-version && ./bin/sign",
-    "package": "jpm xpi && mv @testpilot-addon-$npm_package_version.xpi ../testpilot/frontend/static-src/addon/addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf ../testpilot/frontend/static-src/addon/update.rdf",
+    "package": "jpm xpi && mv testpilot-addon.xpi ../testpilot/frontend/static-src/addon/addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf ../testpilot/frontend/static-src/addon/update.rdf",
     "lint-addon": "addons-linter ../testpilot/frontend/static-src/addon/addon.xpi -o text"
   },
   "license": "MPL-2.0",
@@ -34,7 +34,7 @@
     "babel-eslint": "4.1.8",
     "eslint": "^1.10.3",
     "eslint-config-airbnb": "^0.0.8",
-    "jpm": "1.0.6",
+    "jpm": "1.1.3",
     "jsonwebtoken": "5.7.0",
     "request": "2.69.0",
     "watchify-server": "1.0.2"

--- a/bin/circleci/build-addon.sh
+++ b/bin/circleci/build-addon.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+cd addon/
+npm config set spin false
+npm install
+npm run lint
+# only sign when on master branch or a tag
+if [[ $CIRCLE_BRANCH == 'master' || $CIRCLE_TAG != '' ]]; then
+    npm run sign;
+else
+    npm run package;
+fi
+npm run lint-addon

--- a/bin/circleci/build-frontend.sh
+++ b/bin/circleci/build-frontend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+npm install
+npm run build
+npm test

--- a/bin/circleci/build-server.sh
+++ b/bin/circleci/build-server.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+
+I="image-$(date +%j).tgz"
+
+# build the container, use circleci's docker cache workaround
+# only use 1 image per day to keep the cache size from getting
+# too big and slowing down the build
+if [[ -e ~/docker/$I ]]; then
+    echo "Loading $I"
+    pigz -d -c ~/docker/$I | docker load
+fi
+
+# build the actual deployment container
+docker build -t app:build .
+
+# Clean up any old images and save the new one
+mkdir -p ~/docker
+rm ~/docker/*
+docker save app:build | pigz --fast -c > ~/docker/$I
+ls -l ~/docker

--- a/bin/circleci/build-version-json.sh
+++ b/bin/circleci/build-version-json.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -ex
+printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n' \
+    "$CIRCLE_SHA1" \
+    "$CIRCLE_TAG" \
+    "$CIRCLE_PROJECT_USERNAME" \
+    "$CIRCLE_PROJECT_REPONAME" \
+    "$CIRCLE_BUILD_URL" \
+    > version.json
+cat version.json

--- a/bin/circleci/run-integration-test-server.sh
+++ b/bin/circleci/run-integration-test-server.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+./bin/run-common.sh
+./manage.py loaddata fixtures/initial_data_dev.json
+mkdir -p media
+cp -r fixtures/media/demo media
+./manage.py loaddata fixtures/demo_data.json
+./manage.py runserver 0.0.0.0:8000

--- a/bin/circleci/run-integration-tests.sh
+++ b/bin/circleci/run-integration-tests.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Fire up an instance of the site configured for integration testing
+docker run \
+    --name integration \
+    --detach \
+    --net=host \
+    -p 127.0.0.1:8000:8000 \
+    -e 'DEBUG=False' \
+    -e 'SECRET_KEY=Foo' \
+    -e 'ALLOWED_HOSTS=testpilot.dev' \
+    -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test' \
+    app:build \
+    bin/circleci/run-integration-test-server.sh
+
+# Wait until the server is available...
+until $(curl --output /dev/null --silent --head --fail http://testpilot.dev:8000); do
+    printf '.'; sleep 1
+done
+
+# Fire up the integration tests with Marionette
+python integration/runtests.py \
+    --binary=$HOME/firefox/firefox-bin \
+    --verbose \
+    integration
+TEST_STATUS=$?
+
+# Clean up - these commands will sometimes produce errors, but ignore them
+docker kill integration
+docker rm integration
+
+# Report what happened
+if [ $TEST_STATUS -eq 0 ]
+then
+  echo "Integration tests passed."
+  exit 0
+else
+  echo "Integration tests failed!"
+  exit 1
+fi

--- a/bin/circleci/run-server-unit-tests.sh
+++ b/bin/circleci/run-server-unit-tests.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -ex
+
+docker run \
+    --net=host \
+    -e 'DEBUG=False' \
+    -e 'SECRET_KEY=Foo' \
+    -e 'ALLOWED_HOSTS=localhost' \
+    -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test' \
+    --user root \
+    app:build \
+    sh -c 'flake8 testpilot && ./manage.py test -v2 testpilot'

--- a/bin/circleci/setup-integration-tests.sh
+++ b/bin/circleci/setup-integration-tests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+
+# TODO: Update this occasionally from here:
+# https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds
+FIREFOX_URL=http://archive.mozilla.org/pub/firefox/tinderbox-builds/mozilla-release-linux64-add-on-devel/1470649852/firefox-48.0.1.en-US.linux-x86_64-add-on-devel.tar.bz2
+
+wget -qO $HOME/fx-release.tar.bz2 $FIREFOX_URL
+tar -C $HOME -jxf $HOME/fx-release.tar.bz2
+$HOME/firefox/firefox-bin --version
+
+cd integration
+pip install -r requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -8,78 +8,42 @@
 # DOCKER_PASS
 
 machine:
+  hosts:
+    testpilot.dev: 127.0.0.1
   services:
     - docker
 
   node:
-    version: 4.4.0
+    version: 6.2.0
 
 dependencies:
 
   # Keep docker dir and addon dependencies
   cache_directories:
     - "~/docker"
+    - "~/virtualenvs/venv-system"
     - "addon/node_modules"
+    - "node_modules"
 
   pre:
     # https://discuss.circleci.com/t/nvm-commands-are-not-evaluated/943
-    - nvm use 4.4.0 && nvm alias default 4.4.0
+    - nvm use 6.2.0 && nvm alias default 6.2.0
 
   override:
     - docker info
     - node --version
     - npm --version
-
-    # used by npm test for frontend testing
     - google-chrome --version
-
-    # build the container, use circleci's docker cache workaround
-    # only use 1 image per day to keep the cache size from getting
-    # too big and slowing down the build
-    - I="image-$(date +%j).tgz"; if [[ -e ~/docker/$I ]]; then echo "Loading $I"; pigz -d -c ~/docker/$I | docker load; fi
-
-    # create a version.json
-    - >
-        printf '{"commit":"%s","version":"%s","source":"https://github.com/%s/%s","build":"%s"}\n'
-        "$CIRCLE_SHA1"
-        "$CIRCLE_TAG"
-        "$CIRCLE_PROJECT_USERNAME"
-        "$CIRCLE_PROJECT_REPONAME"
-        "$CIRCLE_BUILD_URL"
-        > version.json
-
-    # build addon - only sign when on master branch or a tag
-    - cd addon/ &&
-      npm config set spin false &&
-      npm install &&
-      npm run lint &&
-      if [[ $CIRCLE_BRANCH == 'master' || $CIRCLE_TAG != '' ]]; then
-        npm run sign;
-      else
-        npm run package;
-      fi &&
-      npm run lint-addon
-
-    # build static assets
-    - npm install
-    - npm run build
-    - npm test
-
-    # build the actual deployment container
-    - docker build -t app:build .
-
-    # Clean up any old images and save the new one
-    - I="image-$(date +%j).tgz"; mkdir -p ~/docker; rm ~/docker/*; docker save app:build | pigz --fast -c > ~/docker/$I; ls -l ~/docker
+    - ./bin/circleci/build-version-json.sh
+    - ./bin/circleci/build-addon.sh
+    - ./bin/circleci/build-frontend.sh
+    - ./bin/circleci/build-server.sh
+    - ./bin/circleci/setup-integration-tests.sh
 
 test:
   override:
-    - >
-        docker run --net=host
-        -e 'DEBUG=False'
-        -e 'SECRET_KEY=Foo'
-        -e 'ALLOWED_HOSTS=localhost'
-        -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test'
-        --user root app:build sh -c 'flake8 testpilot && ./manage.py test -v2 testpilot'
+    - ./bin/circleci/run-server-unit-tests.sh
+    - ./bin/circleci/run-integration-tests.sh
 
 # appropriately tag and push the container to dockerhub
 deployment:

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,11 +1,18 @@
 # Testing
 
-We currently have two different ways to write tests. Server tests are fairly
-standard [django tests](https://docs.djangoproject.com/en/1.9/topics/testing/).
-The client tests are written with [tape](https://www.npmjs.com/package/tape)
-to produce [tap](https://en.wikipedia.org/wiki/Test_Anything_Protocol) output,
-and run with [testling](https://www.npmjs.com/package/testling).
-We use [tape-after](https://www.npmjs.com/package/tape-around) to extend tape
+We have several mechanisms for testing parts of Test Pilot.
+
+## Server tests (Django)
+
+- [Basic Django server tests](https://docs.djangoproject.com/en/1.9/topics/testing/).
+
+## Front-end client tests
+
+Tests for the front-end web client are written with
+[tape](https://www.npmjs.com/package/tape) to produce
+[tap](https://en.wikipedia.org/wiki/Test_Anything_Protocol) output, and run
+with [testling](https://www.npmjs.com/package/testling).  We use
+[tape-after](https://www.npmjs.com/package/tape-around) to extend tape
 for `before` and `after` methods.
 
 Here are a couple of tips to help out when testing client-side code:
@@ -52,3 +59,52 @@ You can do this via https://github.com/graingert/slimerjs
 or
 
 `npm install -g slimerjs`
+
+## Integration tests
+
+Integration tests that exercise the entire stack consisting of the server, web
+front-end, and Firefox add-on are written in Python using [Marionette][] and
+[Firefox Puppeteer][].
+
+Most features of the site should be covered first by unit tests. But, since
+Test Pilot has many parts communicating with each other, we need integration
+tests to cover some of the critical interactions.
+
+[marionette]: https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette
+[firefox puppeteer]: http://firefox-puppeteer.readthedocs.io/en/aurora/index.html
+
+### Running the tests
+
+Since integration tests exercise the whole stack, you'll need to ensure a few
+things are set up before attempting to run them:
+
+1. You should have a fully working instance of the Django server running at
+   `http://testpilot.dev:8000`. [A normal Docker development setup should cover
+   this](../README.md#development).
+
+1. Ensure [you've built the add-on](../addon/README.md) using either `npm run
+   package` or `npm run sign`. If you do not have AMO credentials to generate a
+   signed package, you'll need to use `npm run package` and [download an
+   unbranded build of Firefox][unbranded] to run the tests with an unsigned
+   add-on.
+
+1. Ensure you've built the web frontend with gulp, which should ensure the
+   add-on get served up properly as well.
+
+[unbranded]: https://wiki.mozilla.org/Add-ons/Extension_Signing#Unbranded_Builds
+
+Once you've got that whole stack available, you can run the tests like so:
+
+```
+pip install -r integration/requirements.txt
+python integration/runtests.py \
+    --binary=/Applications/Nightly.app/Contents/MacOS/firefox-bin \
+    --verbose integration
+```
+
+The first line installs the requires Python modules. The second line starts an
+instance of Firefox using a fresh profile and runs the integration tests
+against it via Marionette.
+
+The `--binary` option specifies the Firefox installation that the tests should
+use. You can change it to launch any version you have available.

--- a/integration/__init__.py
+++ b/integration/__init__.py
@@ -1,0 +1,24 @@
+from marionette import Marionette, MarionetteTestCase
+from firefox_puppeteer.testcases import BaseFirefoxTestCase
+
+
+class FirefoxTestCase(BaseFirefoxTestCase, MarionetteTestCase):
+
+    # HACK: Replicate setUp from superclass, but just without the navigation to
+    # browser.newtab.url
+    def setUp(self, *args, **kwargs):
+        super(BaseFirefoxTestCase, self).setUp(*args, **kwargs)
+
+        self._start_handle_count = len(self.marionette.window_handles)
+        self._init_tab_handles = self.marionette.window_handles
+        self.marionette.set_context('chrome')
+        self.marionette.set_search_timeout(10000)
+
+        self.browser = self.windows.current
+        self.browser.focus()
+
+        # Ensure the Test Pilot environment is set to local before installation
+        self.marionette.set_prefs({
+          'testpilot.env': 'local',
+          'xpinstall.signatures.required': False,
+        })

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,0 +1,3 @@
+marionette_client==3.1.0
+firefox-puppeteer==50.0.0
+mozlog==3.3

--- a/integration/runtests.py
+++ b/integration/runtests.py
@@ -1,0 +1,93 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys
+
+from marionette import __version__
+from marionette_driver import __version__ as driver_version
+from marionette.marionette_test import MarionetteTestCase, MarionetteJSTestCase
+from marionette.runner import (
+    BaseMarionetteTestRunner,
+    BaseMarionetteArguments,
+)
+import mozlog
+
+
+class MarionetteTestRunner(BaseMarionetteTestRunner):
+    def __init__(self, **kwargs):
+        BaseMarionetteTestRunner.__init__(self, **kwargs)
+        self.test_handlers = [MarionetteTestCase, MarionetteJSTestCase]
+
+
+class MarionetteArguments(BaseMarionetteArguments):
+    def __init__(self, **kwargs):
+        BaseMarionetteArguments.__init__(self, **kwargs)
+
+
+class MarionetteHarness(object):
+    def __init__(self,
+                 runner_class=MarionetteTestRunner,
+                 parser_class=MarionetteArguments,
+                 testcase_class=MarionetteTestCase,
+                 args=None):
+        self._runner_class = runner_class
+        self._parser_class = parser_class
+        self._testcase_class = testcase_class
+        self.args = args or self.parse_args()
+
+    def parse_args(self, logger_defaults=None):
+        parser = self._parser_class(usage='%(prog)s [options] test_file_or_dir <test_file_or_dir> ...')
+        parser.add_argument('--version', action='version',
+            help="Show version information.",
+            version="%(prog)s {version}"
+                    " (using marionette-driver: {driver_version}, ".format(
+                        version=__version__,
+                        driver_version=driver_version
+                    ))
+        mozlog.commandline.add_logging_group(parser)
+        args = parser.parse_args()
+        parser.verify_usage(args)
+
+        logger = mozlog.commandline.setup_logging(
+            args.logger_name, args, logger_defaults or {"tbpl": sys.stdout})
+
+        args.logger = logger
+        return vars(args)
+
+    def process_args(self):
+        if self.args.get('pydebugger'):
+            self._testcase_class.pydebugger = __import__(self.args['pydebugger'])
+
+    def run(self):
+        self.process_args()
+        tests = self.args.pop('tests')
+        runner = self._runner_class(**self.args)
+        runner.run_tests(tests)
+        return runner.failed + runner.crashed
+
+
+def cli(runner_class=MarionetteTestRunner, parser_class=MarionetteArguments,
+        harness_class=MarionetteHarness, testcase_class=MarionetteTestCase, args=None):
+    """
+    Call the harness to parse args and run tests.
+
+    The following exit codes are expected:
+    - Test failures: 10
+    - Harness/other failures: 1
+    - Success: 0
+    """
+    logger = mozlog.commandline.setup_logging('Marionette test runner', {})
+    try:
+        harness_instance = harness_class(runner_class, parser_class, testcase_class,
+                                         args=args)
+        failed = harness_instance.run()
+        if failed > 0:
+            sys.exit(10)
+    except Exception:
+        logger.error('Failure during harness execution', exc_info=True)
+        sys.exit(1)
+    sys.exit(0)
+
+if __name__ == "__main__":
+    cli()

--- a/integration/test_installation.py
+++ b/integration/test_installation.py
@@ -1,0 +1,79 @@
+import time
+import os
+import unittest
+
+from mozlog import get_default_logger
+
+from marionette import Marionette
+from marionette_driver import Actions, Wait
+from marionette_driver.by import By
+from marionette_driver.addons import Addons
+from marionette_driver.errors import NoSuchElementException
+
+from firefox_puppeteer.api.prefs import Preferences
+from firefox_puppeteer.api.software_update import SoftwareUpdate
+from firefox_puppeteer.ui.update_wizard import UpdateWizardDialog
+from firefox_puppeteer.ui.browser.notifications import (
+    AddOnInstallBlockedNotification,
+    AddOnInstallFailedNotification,
+    AddOnInstallConfirmationNotification,
+    AddOnInstallCompleteNotification,
+)
+
+from __init__ import FirefoxTestCase
+
+
+SITE_URL = 'http://testpilot.dev:8000/'
+TOOLBAR_BUTTON_ID = 'toggle-button--testpilot-addon-testpilot-link'
+
+
+class TestAddonInstallation(FirefoxTestCase):
+
+    def setUp(self):
+        FirefoxTestCase.setUp(self)
+
+    def test_initial_installation(self):
+        m = self.marionette
+        b = self.browser
+
+        # Navigate to the site and click the install button
+        with m.using_context(m.CONTEXT_CONTENT):
+            m.navigate(SITE_URL)
+            m.find_element(By.CSS_SELECTOR,
+                           'button[data-hook=install]').click()
+            w = Wait(m, ignored_exceptions=NoSuchElementException)
+            w.until(lambda m: m.find_element(By.CSS_SELECTOR,
+                                             'button[data-hook=install].state-change'))
+
+        # Click through the blocked notification
+        b.wait_for_notification(AddOnInstallBlockedNotification)
+        # HACK: Things seem to fail intermittently here if we don't wait a tick
+        time.sleep(0.5)
+        b.notification.allow_button.click()
+
+        # Click through the installation notification
+        b.wait_for_notification(AddOnInstallConfirmationNotification)
+        b.notification.install_button().click()
+
+        # Wait for and close the completion notification
+        b.wait_for_notification(AddOnInstallCompleteNotification, timeout=60)
+        b.notification.close()
+
+        # The toolbar button should show up soon after installation
+        with m.using_context(m.CONTEXT_CHROME):
+            w = Wait(m, ignored_exceptions=NoSuchElementException)
+            w.until(lambda m: m.find_element('id', target=TOOLBAR_BUTTON_ID))
+
+        # And the add-on should open up an onboarding tab...
+        Wait(m).until(lambda m: len(b.tabbar.tabs) > 1)
+        self.assertTrue(b.tabbar.tabs[1].location.endswith('/onboarding'))
+        b.tabbar.close_tab(b.tabbar.tabs[1])
+
+        # The frontend should redirect to /experiments after it contacts the add-on
+        Wait(m).until(lambda m: b.tabbar.tabs[0].location.endswith('/experiments'))
+
+        # Clean up by uninstalling the add-on
+        Addons(m).uninstall('@testpilot-addon')
+
+    def tearDown(self):
+        FirefoxTestCase.tearDown(self)


### PR DESCRIPTION
- Add integration testing framework using Marionette
- Test to exercise add-on installation flow
- Refactor circle.yml into small shell scripts to make the main file
  simpler to read
- Upgrade to Node v6.2.0 to match frontend watcher
- Update jpm to 1.1.3 for add-on

Fixes #352
