### PR TITLE
Add public experiment detail page (closes #419, #1237).

### DIFF
--- a/docs/README-GOOGLE-ANALYTICS.md
+++ b/docs/README-GOOGLE-ANALYTICS.md
@@ -98,14 +98,14 @@ We use custom dimensions to refine our pageviews on Test Pilot ([docs from Googl
 
 Here is a list of dimensions we are currently using
 
-| Page                   | Description                                       | dimension | values |
-|------------------------|---------------------------------------------------|-----------|--------|
-| Home Page              | Does the user have the add-on installed           | 1         | {0,1}  |
-| Home Page              | Does the user have any experiments installed      | 2         | {0,1}  |
-| Home Page              | How many experiments does the user have installed | 3         | {n}    |
-| Experiment Detail Page | Is the experiment enabled                         | 4         | {0,1}  |
-| Experiment Detail Page | Experiment title                                  | 5         | "xyz"  |
-| Experiment Detail Page | Installation count                                | 6         | {n}    |
+| Page                              | Description                                       | dimension | values |
+|-----------------------------------|---------------------------------------------------|-----------|--------|
+| Home Page, Experiment Detail Page | Does the user have the add-on installed           | 1         | {0,1}  |
+| Home Page                         | Does the user have any experiments installed      | 2         | {0,1}  |
+| Home Page                         | How many experiments does the user have installed | 3         | {n}    |
+| Experiment Detail Page            | Is the experiment enabled                         | 4         | {0,1}  |
+| Experiment Detail Page            | Experiment title                                  | 5         | "xyz"  |
+| Experiment Detail Page            | Installation count                                | 6         | {n}    |
 
 # Tagged Links
 

--- a/docs/README-GOOGLE-ANALYTICS.md
+++ b/docs/README-GOOGLE-ANALYTICS.md
@@ -49,25 +49,26 @@ app.sendToGA('event', {
 
 Here are the current events on the website as of this writing
 
-| Description                           | eventCategory                      | eventAction       | eventLabel           |
-|---------------------------------------|------------------------------------|-------------------|----------------------|
-| Toggle settings menu                  | Menu Interactions                  | drop-down menu    | Toggle Menu          |
-| Click Leave from settings             | Menu Interactions                  | drop-down menu    | Retire               |
-| Click Discuss from settings           | Menu Interactions                  | drop-down menu    | Discuss              |
-| Click Wiki from settings              | Menu Interactions                  | drop-down menu    | wiki                 |
-| Click File Issue from settings        | Menu Interactions                  | drop-down menu    | File Issue           |
-| Click on experiment from landing page | ExperimentsPage Interactions       | Open details page | `{experiment title}` |
-| Click Enable Experiment               | ExperimentDetailsPage Interactions | button click      | Enable Experiment    |
-| Click Disable Experiment              | ExperimentDetailsPage Interactions | button click      | Disable Experiment   |
-| Click Give Feedback for experiment    | ExperimentDetailsPage Interactions | button click      | Give Feedback        |
-| Click Take Survey after disable       | ExperimentDetailsPage Interactions | button click      | exit survey disabled |
-| Click Cancel on tour dialogue         | ExperimentDetailsPage Interactions | button click      | cancel tour          |
-| Complete the tour                     | ExperimentDetailsPage Interactions | button click      | complete tour        |
-| Click Take Tour on tour dialogue      | ExperimentDetailsPage Interactions | button click      | take tour            |
-| Click next during Tour                | ExperimentDetailsPage Interactions | button click      | forward to step `n`  |
-| Click back during Tour                | ExperimentDetailsPage Interactions | button click      | back to step `n`     |
-| Click on Install from landing page    | HomePage Interactions              | button click      | Install the Add-on   |
-| Click take survey after Leave         | RetirePage Interactions            | button click      | take survey          |
+| Description                                   | eventCategory                      | eventAction       | eventLabel           |
+|-----------------------------------------------|------------------------------------|-------------------|----------------------|
+| Toggle settings menu                          | Menu Interactions                  | drop-down menu    | Toggle Menu          |
+| Click Leave from settings                     | Menu Interactions                  | drop-down menu    | Retire               |
+| Click Discuss from settings                   | Menu Interactions                  | drop-down menu    | Discuss              |
+| Click Wiki from settings                      | Menu Interactions                  | drop-down menu    | wiki                 |
+| Click File Issue from settings                | Menu Interactions                  | drop-down menu    | File Issue           |
+| Click on experiment from landing page         | ExperimentsPage Interactions       | Open details page | `{experiment title}` |
+| Click on Install from experiment details page | ExperimentDetailsPage Interactions | button click | Install the Add-on |
+| Click Enable Experiment                       | ExperimentDetailsPage Interactions | button click      | Enable Experiment    |
+| Click Disable Experiment                      | ExperimentDetailsPage Interactions | button click      | Disable Experiment   |
+| Click Give Feedback for experiment            | ExperimentDetailsPage Interactions | button click      | Give Feedback        |
+| Click Take Survey after disable               | ExperimentDetailsPage Interactions | button click      | exit survey disabled |
+| Click Cancel on tour dialogue                 | ExperimentDetailsPage Interactions | button click      | cancel tour          |
+| Complete the tour                             | ExperimentDetailsPage Interactions | button click      | complete tour        |
+| Click Take Tour on tour dialogue              | ExperimentDetailsPage Interactions | button click      | take tour            |
+| Click next during Tour                        | ExperimentDetailsPage Interactions | button click      | forward to step `n`  |
+| Click back during Tour                        | ExperimentDetailsPage Interactions | button click      | back to step `n`     |
+| Click on Install from landing page            | HomePage Interactions              | button click      | Install the Add-on   |
+| Click take survey after Leave                 | RetirePage Interactions            | button click      | take survey          |
 
 # Pageviews
 

--- a/docs/README-GOOGLE-ANALYTICS.md
+++ b/docs/README-GOOGLE-ANALYTICS.md
@@ -49,26 +49,28 @@ app.sendToGA('event', {
 
 Here are the current events on the website as of this writing
 
-| Description                                   | eventCategory                      | eventAction       | eventLabel           |
-|-----------------------------------------------|------------------------------------|-------------------|----------------------|
-| Toggle settings menu                          | Menu Interactions                  | drop-down menu    | Toggle Menu          |
-| Click Leave from settings                     | Menu Interactions                  | drop-down menu    | Retire               |
-| Click Discuss from settings                   | Menu Interactions                  | drop-down menu    | Discuss              |
-| Click Wiki from settings                      | Menu Interactions                  | drop-down menu    | wiki                 |
-| Click File Issue from settings                | Menu Interactions                  | drop-down menu    | File Issue           |
-| Click on experiment from landing page         | ExperimentsPage Interactions       | Open details page | `{experiment title}` |
-| Click on Install from experiment details page | ExperimentDetailsPage Interactions | button click | Install the Add-on |
-| Click Enable Experiment                       | ExperimentDetailsPage Interactions | button click      | Enable Experiment    |
-| Click Disable Experiment                      | ExperimentDetailsPage Interactions | button click      | Disable Experiment   |
-| Click Give Feedback for experiment            | ExperimentDetailsPage Interactions | button click      | Give Feedback        |
-| Click Take Survey after disable               | ExperimentDetailsPage Interactions | button click      | exit survey disabled |
-| Click Cancel on tour dialogue                 | ExperimentDetailsPage Interactions | button click      | cancel tour          |
-| Complete the tour                             | ExperimentDetailsPage Interactions | button click      | complete tour        |
-| Click Take Tour on tour dialogue              | ExperimentDetailsPage Interactions | button click      | take tour            |
-| Click next during Tour                        | ExperimentDetailsPage Interactions | button click      | forward to step `n`  |
-| Click back during Tour                        | ExperimentDetailsPage Interactions | button click      | back to step `n`     |
-| Click on Install from landing page            | HomePage Interactions              | button click      | Install the Add-on   |
-| Click take survey after Leave                 | RetirePage Interactions            | button click      | take survey          |
+| Description                                              | eventCategory                      | eventAction       | eventLabel                   |
+|----------------------------------------------------------|------------------------------------|-------------------|------------------------------|
+| Toggle settings menu                                     | Menu Interactions                  | drop-down menu    | Toggle Menu                  |
+| Click Leave from settings                                | Menu Interactions                  | drop-down menu    | Retire                       |
+| Click Discuss from settings                              | Menu Interactions                  | drop-down menu    | Discuss                      |
+| Click Wiki from settings                                 | Menu Interactions                  | drop-down menu    | wiki                         |
+| Click File Issue from settings                           | Menu Interactions                  | drop-down menu    | File Issue                   |
+| Click on experiment from landing page                    | ExperimentsPage Interactions       | Open details page | `{experiment title}`         |
+| Click on Install from experiment details page            | ExperimentDetailsPage Interactions | button click | Install the Add-on                |
+| Click on the "Try out these experiments as well" section | ExperimentsDetailPage Interactions | Open details page | try out `{experiment title}` |
+| Click Enable Experiment                                  | ExperimentDetailsPage Interactions | button click      | Enable Experiment            |
+| Click Disable Experiment                                 | ExperimentDetailsPage Interactions | button click      | Disable Experiment           |
+| Click Give Feedback for experiment                       | ExperimentDetailsPage Interactions | button click      | Give Feedback                |
+| Click Take Survey after disable                          | ExperimentDetailsPage Interactions | button click      | exit survey disabled         |
+| Click Cancel on tour dialogue                            | ExperimentDetailsPage Interactions | button click      | cancel tour                  |
+| Complete the tour                                        | ExperimentDetailsPage Interactions | button click      | complete tour                |
+| Click Take Tour on tour dialogue                         | ExperimentDetailsPage Interactions | button click      | take tour                    |
+| Click next during Tour                                   | ExperimentDetailsPage Interactions | button click      | forward to step `n`          |
+| Click back during Tour                                   | ExperimentDetailsPage Interactions | button click      | back to step `n`             |
+| Click on Install from landing page                       | HomePage Interactions              | button click      | Install the Add-on           |
+| Click on experiment from landing page                    | HomePage Interactions              | Open details page | `{experiment title}`         |
+| Click take survey after Leave                            | RetirePage Interactions            | button click      | take survey                  |
 
 # Pageviews
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -71,6 +71,11 @@ isEnabledStatusMessage = {$title} is enabled.
 installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.
 participantCount = <span>{$installation_count}</span> participants
 
+experimentPromoHeader = Ready for Takeoff?
+experimentPromoSubheader = We're building next-generation features for Firefox. Install Test Pilot to try them!
+
+otherExperiments = Try out these experiments as well
+
 giveFeedback = Give Feedback
 
 disableExperiment = Disable {$title}

--- a/testpilot/frontend/static-src/app/lib/install-addon.js
+++ b/testpilot/frontend/static-src/app/lib/install-addon.js
@@ -1,0 +1,35 @@
+import app from 'ampersand-app';
+import cookies from 'js-cookie';
+
+
+export default function installAddon(view, eventCategory, callback) {
+  const downloadUrl = '/static/addon/addon.xpi';
+
+  view.query('[data-hook=install]').classList.add('state-change');
+  view.query('.default-btn-msg').classList.add('no-display');
+  view.query('.progress-btn-msg').classList.remove('no-display');
+
+  app.sendToGA('event', {
+    eventCategory: eventCategory,
+    eventAction: 'button click',
+    eventLabel: 'Install the Add-on',
+    outboundURL: downloadUrl
+  });
+
+  cookies.set('first-run', 'true');
+
+  // Wait for the add-on to be installed.
+  // TODO: Should we have a timeout here, give up after a few intervals? If
+  // user cancels add-on install, this will never stop spinning.
+  const interval = setInterval(() => {
+    if (!window.navigator.testpilotAddon) { return; }
+    clearInterval(interval);
+    app.me.fetch().then(() => {
+      callback();
+    }).catch(() => {
+      // HACK (for Issue #1075): Timed out while waiting for the initial sync
+      // message, so just reload the page to stop waiting.
+      window.location.reload();
+    });
+  }, 1000);
+}

--- a/testpilot/frontend/static-src/app/lib/router.js
+++ b/testpilot/frontend/static-src/app/lib/router.js
@@ -38,19 +38,15 @@ export default Router.extend({
 
   // 'experiment' is a URL slug: for example, 'universal-search'
   experimentDetail(experiment) {
-    if (!app.me.hasAddon) {
-      this.redirectTo('');
+    if (app.experiments.get(experiment, 'slug')) {
+      app.trigger('router:new-page', {
+        page: 'experimentDetail',
+        opts: {
+          slug: experiment
+        }
+      });
     } else {
-      if (app.experiments.get(experiment, 'slug')) {
-        app.trigger('router:new-page', {
-          page: 'experimentDetail',
-          opts: {
-            slug: experiment
-          }
-        });
-      } else {
-        this.redirectTo('404');
-      }
+      this.redirectTo('404');
     }
   },
 

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -17,8 +17,8 @@ export default `
 
             <a data-hook="highlight-privacy" class="highlight-privacy" data-l10n-id=highlightPrivacy>Your privacy</a>
             <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default" target="_blank">Give Feedback</a>
-            <button data-hook="uninstall" id="uninstall-button" class="button secondary"><span class="state-change-inner"></span><span data-l10n-id="disableExperimentTransition" class="transition-text">Disabling...</span><span data-l10n-id="disableExperiment" class="default-text">Disable <span data-hook="title"></span></span></button>
-            <button data-hook="install" id="install-button" class="button default"><span class="state-change-inner"></span><span data-l10n-id="enableExperimentTransition" class="transition-text">Enabling...</span><span data-l10n-id="enableExperiment" class="default-text">Enable <span data-hook="title"></span></span></button>
+            <button data-hook="uninstall-experiment" id="uninstall-button" class="button secondary"><span class="state-change-inner"></span><span data-l10n-id="disableExperimentTransition" class="transition-text">Disabling...</span><span data-l10n-id="disableExperiment" class="default-text">Disable <span data-hook="title"></span></span></button>
+            <button data-hook="install-experiment" id="install-button" class="button default"><span class="state-change-inner"></span><span data-l10n-id="enableExperimentTransition" class="transition-text">Enabling...</span><span data-l10n-id="enableExperiment" class="default-text">Enable <span data-hook="title"></span></span></button>
           </div>
         </div>
       </div>

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -1,8 +1,7 @@
 export default `
   <section id="details" data-hook="experiment-page">
-    <div class="shifted-stars">
-      <header data-hook="header-view"></header>
-    </div>
+    <header data-hook="header-view"></header>
+    <section data-hook="testpilot-promo"></section>
     <div class="default-background">
       <div class="details-header-wrapper" data-hook="has-status">
         <div class="status-bar" data-hook="status-type">
@@ -14,7 +13,7 @@ export default `
             <h1 data-hook="title"></h1>
             <h4 data-hook="subtitle" class="subtitle"></h4>
           </header>
-            <div class="experiment-controls">
+            <div class="experiment-controls" data-hook="active-user">
 
             <a data-hook="highlight-privacy" class="highlight-privacy" data-l10n-id=highlightPrivacy>Your privacy</a>
             <a data-l10n-id="giveFeedback" data-hook="feedback" id="feedback-button" class="button default" target="_blank">Give Feedback</a>
@@ -23,6 +22,7 @@ export default `
           </div>
         </div>
       </div>
+      <div class="sticky-header-sibling"></div>
 
       <div data-hook="details">
           <div class="details-content content-wrapper">
@@ -35,7 +35,12 @@ export default `
                   <span data-l10n-id="userCountContainer">There are <span data-l10n-id="userCount" class="bold" data-hook="install-count"></span>
                   people trying <span data-hook="title"></span> right now!</span>
                 </section>
-                <section>
+                <div data-hook="inactive-user">
+                  <section data-hook="introduction-container">
+                    <div data-hook="introduction-html"></div>
+                  </section>
+                </div>
+                <section data-hook="active-user">
                   <table class="stats">
                     <tr data-hook="version-container">
                       <td data-l10n-id="version">Version</td>
@@ -68,25 +73,33 @@ export default `
                   <h3 data-l10n-id="contributorsHeading">Brought to you by</h3>
                   <ul class="contributors"></ul>
                 </section>
-                <section data-hook="measurements-container" class="measurements">
-                  <h3 data-l10n-id="measurements">Your privacy</h3>
-                  <div data-hook="measurements-html" class="measurement"></div>
-                  <a class="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-hook="privacy-notice-url">You can learn more about the data collection for <span data-hook="title"></span> here.</a>
-                </section>
+                <div data-hook="active-user">
+                  <section data-hook="measurements-container" class="measurements">
+                    <h3 data-l10n-id="measurements">Your privacy</h3>
+                    <div data-hook="measurements-html" class="measurement"></div>
+                    <a class="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-hook="privacy-notice-url">You can learn more about the data collection for <span data-hook="title"></span> here.</a>
+                  </section>
+                </div>
               </div>
             </div>
 
             <div class="details-description">
-              <section data-hook="introduction-container" class="introduction">
-                <div data-hook="introduction-html"></div>
-              </section>
+              <div data-hook="active-user">
+                <section data-hook="introduction-container" class="introduction">
+                  <div data-hook="introduction-html"></div>
+                </section>
+              </div>
               <div class="details-list"></div>
             </div>
           </div>
         </div>
-        <footer id="main-footer" class="content-wrapper">
-          <div data-hook="footer-view"></div>
-        </footer>
       </div>
+      <div data-hook="inactive-user">
+        <h2 class="card-list-header" data-l10n-id="otherExperiments">Try out these experiments as well</h2>
+        <div class="responsive-content-wrapper delayed-fade-in" data-hook="experiment-list"></div>
+      </div>
+      <footer id="main-footer" class="content-wrapper">
+        <div data-hook="footer-view"></div>
+      </footer>
   </section>
 `;

--- a/testpilot/frontend/static-src/app/templates/header-view.js
+++ b/testpilot/frontend/static-src/app/templates/header-view.js
@@ -1,5 +1,5 @@
 export default `
-  <header id="main-header" class="responsive-content-wrapper" data-hook="active-user">
+  <header id="main-header" class="responsive-content-wrapper">
     <h1>
       <a href="/" class="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
     </h1>

--- a/testpilot/frontend/static-src/app/views/experiment-list-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-list-page.js
@@ -14,8 +14,10 @@ export default PageView.extend({
   render() {
     this.hasAddon = app.me.hasAddon;
     PageView.prototype.render.apply(this, arguments);
-    this.renderSubview(new ExperimentListView({hasAddon: this.hasAddon}),
-      '[data-hook="experiment-list"]');
+    this.renderSubview(new ExperimentListView({
+      hasAddon: this.hasAddon,
+      eventCategory: 'ExperimentsPage Interactions'
+    }), '[data-hook="experiment-list"]');
 
     if (cookies.get('first-run')) {
       cookies.remove('first-run');

--- a/testpilot/frontend/static-src/app/views/experiment-list-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-list-view.js
@@ -1,19 +1,31 @@
 import app from 'ampersand-app';
 import BaseView from './base-view';
 import ExperimentRowView from './experiment-row-view';
-
+import ExperimentsCollection from '../collections/experiments';
 
 export default BaseView.extend({
   template: `<div class="card-list experiments"></div>`,
 
   props: {
-    hasAddon: 'boolean'
+    hasAddon: 'boolean',
+    except: { type: 'string', required: false }
   },
 
   render() {
     BaseView.prototype.render.apply(this, arguments);
+
+    const filteredExperiments = () => {
+      if (this.except) {
+        const filtered = app.experiments.models.filter(experiment => {
+          return experiment.slug !== this.except;
+        });
+        return new ExperimentsCollection(filtered);
+      }
+      return app.experiments;
+    }();
+
     this.experimentList = this.renderCollection(
-      app.experiments,
+      filteredExperiments,
       ExperimentRowView,
       this.query('.experiments'), {
         viewOptions: {

--- a/testpilot/frontend/static-src/app/views/experiment-list-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-list-view.js
@@ -8,7 +8,8 @@ export default BaseView.extend({
 
   props: {
     hasAddon: 'boolean',
-    except: { type: 'string', required: false }
+    except: { type: 'string', required: false },
+    eventCategory: 'string'
   },
 
   render() {
@@ -29,7 +30,8 @@ export default BaseView.extend({
       ExperimentRowView,
       this.query('.experiments'), {
         viewOptions: {
-          hasAddon: this.hasAddon
+          hasAddon: this.hasAddon,
+          eventCategory: this.eventCategory
         }
       }
     );

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -28,8 +28,8 @@ export default PageView.extend({
   headerScroll: true,
 
   events: {
-    'click [data-hook=install]': 'install',
-    'click [data-hook=uninstall]': 'renderUninstallSurvey',
+    'click [data-hook=install-experiment]': 'installExperiment',
+    'click [data-hook=uninstall-experiment]': 'renderUninstallSurvey',
     'click [data-hook=feedback]': 'feedback',
     'click [data-hook=highlight-privacy]': 'highlightPrivacy'
   },
@@ -64,8 +64,8 @@ export default PageView.extend({
 
     'model.enabled': [{
       type: 'toggle',
-      yes: '[data-hook=uninstall]',
-      no: '[data-hook=install]'
+      yes: '[data-hook=uninstall-experiment]',
+      no: '[data-hook=install-experiment]'
     },
     {
       type: 'toggle',
@@ -239,7 +239,8 @@ export default PageView.extend({
 
     if (!this.activeUser) {
       this.renderSubview(new TestpilotPromoView({
-        isFirefox: this.isFirefox
+        isFirefox: this.isFirefox,
+        parentView: this
       }), '[data-hook="testpilot-promo"]');
 
       this.renderSubview(new ExperimentListView({
@@ -282,19 +283,14 @@ export default PageView.extend({
 
   // isInstall is a boolean: true if we are installing, false if uninstalling
   updateAddon(isInstall, model) {
-    let eventType = 'install-experiment';
-
-    if (!isInstall) {
-      eventType = 'uninstall-experiment';
-    }
-
-    app.webChannel.sendMessage(eventType, {
+    const evtType = isInstall ? 'install-experiment' : 'uninstall-experiment';
+    app.webChannel.sendMessage(evtType, {
       addon_id: model.addon_id,
       xpi_url: model.xpi_url
     });
   },
 
-  install(evt) {
+  installExperiment(evt) {
     evt.preventDefault();
 
     if (evt.target.disabled) { return; }
@@ -343,7 +339,7 @@ export default PageView.extend({
     });
   },
 
-  uninstall(evt) {
+  uninstallExperiment(evt) {
     evt.preventDefault();
     const width = evt.target.offsetWidth;
     evt.target.style.width = width + 'px';
@@ -370,7 +366,7 @@ export default PageView.extend({
       eventLabel: 'Disable Experiment'
     });
 
-    this.uninstall(evt);
+    this.uninstallExperiment(evt);
 
     this.renderSubview(new DisableDialogView({
       id: 'disabled-feedback',

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -247,7 +247,7 @@ export default PageView.extend({
         hasAddon: this.activeUser,
         isFirefox: this.isFirefox,
         except: this.model.slug,
-        title: true
+        eventCategory: 'ExperimentsDetailPage Interactions'
       }), '[data-hook="experiment-list"]');
     }
 

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -252,6 +252,7 @@ export default PageView.extend({
     }
 
     app.sendToGA('pageview', {
+      'dimension1': this.activeUser,
       'dimension4': this.model.enabled,
       'dimension5': this.model.title,
       'dimension6': this.model.installation_count

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -26,12 +26,13 @@ export default BaseView.extend({
              </div>`,
 
   props: {
-    hasAddon: {type: 'boolean', default: 'false'}
+    hasAddon: {type: 'boolean', default: 'false'},
+    eventCategory: 'string'
   },
   derived: {
     justUpdated: {
       deps: ['model.enabled', 'model.modified', 'model.lastSeen'],
-      fn: function justUpdated() {
+      fn: function() {
         // Enabled trumps launched.
         if (this.model.enabled) { return false; }
 
@@ -49,7 +50,7 @@ export default BaseView.extend({
     },
     justLaunched: {
       deps: ['model.enabled', 'model.created', 'model.lastSeen'],
-      fn: function justLaunched() {
+      fn: function() {
         // Enabled & updated trumps launched.
         if (this.model.enabled || this.justUpdated) { return false; }
 
@@ -145,7 +146,7 @@ export default BaseView.extend({
   openDetailPage(evt) {
     evt.preventDefault();
     app.sendToGA('event', {
-      eventCategory: 'ExperimentsPage Interactions',
+      eventCategory: this.eventCategory,
       eventAction: 'Open detail page',
       eventLabel: this.model.title
     });

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -135,7 +135,7 @@ export default BaseView.extend({
   },
 
   events: {
-    'click [data-hook=show-detail].has-addon': 'openDetailPage'
+    'click [data-hook=show-detail]': 'openDetailPage'
   },
 
   initialize(opts) {

--- a/testpilot/frontend/static-src/app/views/header-view.js
+++ b/testpilot/frontend/static-src/app/views/header-view.js
@@ -9,17 +9,11 @@ export default BaseView.extend({
 
   props: {
     title: {type: 'string', default: 'Firefox Test Pilot'},
-    isInstalled: {type: 'boolean', default: false},
-    activeUser: {type: 'boolean', required: true, default: false}
+    isInstalled: {type: 'boolean', default: false}
   },
 
   bindings: {
     'title': '[data-hook=title]',
-    'activeUser': {
-      type: 'toggle',
-      yes: '[data-hook=active-user]',
-      no: '[data-hook=inactive-user]'
-    },
     'isInstalled': {
       type: 'toggle',
       yes: '[data-hook=uninstall]',
@@ -45,9 +39,6 @@ export default BaseView.extend({
   },
 
   beforeRender() {
-    // an active user has an addon
-    this.activeUser = app.me.hasAddon;
-
     if (this.experiment) {
       this.isInstalled = !!this.experiment.isInstalled;
     }

--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -27,7 +27,8 @@ export default PageView.extend({
     if (!this.hasAddon) {
       this.renderSubview(new ExperimentListView({
         hasAddon: this.hasAddon,
-        isFirefox: this.isFirefox
+        isFirefox: this.isFirefox,
+        eventCategory: 'HomePage Interactions'
       }), '[data-hook="experiment-list"]');
     }
 

--- a/testpilot/frontend/static-src/app/views/landing-page.js
+++ b/testpilot/frontend/static-src/app/views/landing-page.js
@@ -1,8 +1,10 @@
 import app from 'ampersand-app';
-import cookies from 'js-cookie';
-import PageView from './page-view';
-import template from '../templates/landing-page';
+
 import ExperimentListView from './experiment-list-view';
+import installAddon from '../lib/install-addon';
+import template from '../templates/landing-page';
+import PageView from './page-view';
+
 
 export default PageView.extend({
   _template: template,
@@ -41,41 +43,9 @@ export default PageView.extend({
   },
 
   installClicked() {
-    const downloadUrl = '/static/addon/addon.xpi';
-    const installButton = document.getElementsByClassName('install');
-    const defaultMessage = document.getElementsByClassName('default-btn-msg');
-    const progressMessage = document.getElementsByClassName('progress-btn-msg');
-
-    for (let i = 0; i < installButton.length; i++) {
-      installButton[i].classList.add('state-change');
-      installButton[i].setAttribute('disabled', 'true');
-      defaultMessage[i].classList.add('no-display');
-      progressMessage[i].classList.remove('no-display');
-    }
-
-    app.sendToGA('event', {
-      eventCategory: 'HomePage Interactions',
-      eventAction: 'button click',
-      eventLabel: 'Install the Add-on',
-      outboundURL: downloadUrl
+    installAddon(this, 'HomePage Interactions', () => {
+      app.router.redirectTo('experiments');
     });
-
-    cookies.set('first-run', 'true');
-
-    // Wait for the add-on to be installed.
-    // TODO: Should we have a timeout here, give up after a few intervals? If
-    // user cancels add-on install, this will never stop spinning.
-    const interval = setInterval(() => {
-      if (!window.navigator.testpilotAddon) { return; }
-      clearInterval(interval);
-      app.me.fetch().then(() => {
-        app.router.redirectTo('experiments');
-      }).catch(() => {
-        // HACK (for Issue #1075): Timed out while waiting for the initial sync
-        // message, so just reload the page to stop waiting.
-        window.location.reload();
-      });
-    }, 1000);
   },
 
   remove() {

--- a/testpilot/frontend/static-src/app/views/settings-menu-view.js
+++ b/testpilot/frontend/static-src/app/views/settings-menu-view.js
@@ -5,7 +5,7 @@ import RetireDialogView from './retire-dialog-view';
 import DiscussNotifyView from './discuss-notification-view';
 
 export default BaseView.extend({
-  template: `<div class="settings-contain">
+  template: `<div class="settings-contain" data-hook="active-user">
                <div class="button outline settings-button" data-hook="settings-button" data-l10n-id="menuTitle">Settings</div>
                <div class="settings-menu no-display">
                  <ul>
@@ -24,6 +24,27 @@ export default BaseView.extend({
     'click [data-hook=issue]': 'fileIssue',
     'click [data-hook=retire]': 'retire',
     'click [data-hook=settings-button]': 'toggleSettings'
+  },
+
+  props: {
+    activeUser: {type: 'boolean', required: true, default: false}
+  },
+
+  bindings: {
+    'activeUser': {
+      type: 'toggle',
+      yes: '[data-hook=active-user]',
+      no: '[data-hook=inactive-user]'
+    }
+  },
+
+  initialize() {
+    app.me.on('change:hasAddon', this.render, this);
+    BaseView.prototype.initialize.apply(this, arguments);
+  },
+
+  beforeRender() {
+    this.activeUser = app.me.hasAddon;
   },
 
   afterRender() {

--- a/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
+++ b/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
@@ -1,4 +1,5 @@
 import BaseView from './base-view';
+import installAddon from '../lib/install-addon';
 
 
 export default BaseView.extend({
@@ -38,7 +39,18 @@ export default BaseView.extend({
     </div>
   `,
 
+  events: {
+    'click [data-hook=install]': 'installClicked'
+  },
+
   props: {
-    isFirefox: 'boolean'
+    isFirefox: 'boolean',
+    parentView: 'object'
+  },
+
+  installClicked() {
+    installAddon(this, 'ExperimentDetailsPage Interactions', () => {
+      this.parentView.render();
+    });
   }
 });

--- a/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
+++ b/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
@@ -1,0 +1,44 @@
+import BaseView from './base-view';
+
+
+export default BaseView.extend({
+  _template: `
+    <div class="experiment-promo">
+      <div class="reverse-split-banner responsive-git content-wrapper">
+        <div class="copter-wrapper fly-up">
+          <div class="copter"></div>
+        </div>
+        <div class="intro-text">
+          <h2 class="banner">
+            <span data-l10n-id="experimentPromoHeader" class="block">Ready for Takeoff?</span>
+          </h2>
+          <p data-l10n-id="experimentPromoSubheader">We're building next-generation features for Firefox. Install Test Pilot to try them!</p>
+          {{^isFirefox}}
+            <span data-l10n-id="landingDownloadFirefoxDesc" class="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
+            <a href="https://www.mozilla.org/firefox" class="button primary download-firefox">
+              <div class="button-icon">
+                <div class="button-icon-badge"></div>
+              </div>
+              <div class="button-copy">
+                <div data-l10n-id="landingDownloadFirefoxTitle" class="button-title">Firefox</div>
+                <div data-l10n-id="landingDownloadFirefoxSubTitle" class="button-description">Free Download</div>
+              </div>
+            </a>
+          {{/isFirefox}}
+          {{#isFirefox}}
+          <button data-hook="install" class="button extra-large primary">
+            <span class="default-btn-msg" data-l10n-id="landingInstallButton">Install the Test Pilot Add-on</span>
+            <span class="no-display progress-btn-msg" data-l10n-id="landingInstallingButton">Installing...</span>
+            <div class="state-change-inner"></div>
+          </button>
+          <p data-l10n-id="landingLegalNotice" class="legal-information">By proceeding, you agree to the <a href="/terms">Terms of Use</a> and <a href="/privacy">Privacy Notice</a> of Test Pilot</p>
+          {{/isFirefox}}
+        </div>
+      </div>
+    </div>
+  `,
+
+  props: {
+    isFirefox: 'boolean'
+  }
+});

--- a/testpilot/frontend/static-src/styles/_modules.scss
+++ b/testpilot/frontend/static-src/styles/_modules.scss
@@ -5,6 +5,7 @@
 @import 'modules/copter';
 @import 'modules/experiment-details';
 @import 'modules/experiment-list';
+@import 'modules/experiment-promo';
 @import 'modules/footer';
 @import 'modules/legal-information';
 @import 'modules/main-header';

--- a/testpilot/frontend/static-src/styles/modules/_banners.scss
+++ b/testpilot/frontend/static-src/styles/modules/_banners.scss
@@ -22,6 +22,12 @@
     font-weight: 500;
     line-height: 2.7 * $line-unit;
   }
+
+  .lead-out {
+    font-size: 2.2 * $font-unit;
+    font-weight: 400;
+    line-height: 3.3 * $font-unit;
+  }
 }
 
 .centered-banner,
@@ -57,6 +63,11 @@
 
       margin: 0;
       position: relative;
+    }
+
+    .legal-information {
+      font-size: $font-unit;
+      line-height: $line-unit;
     }
   }
 }

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -17,10 +17,6 @@
     top: 0;
     width: 100%;
     z-index: 999;
-
-    + div {
-      margin-top: $grid-unit * 4.8;
-    }
   }
 }
 
@@ -107,7 +103,6 @@
 
 .details-content {
   @include flex-container(row, space-between, flex-start);
-  margin-top: $grid-unit;
 }
 
 .details-overview {
@@ -118,6 +113,8 @@
   @include respond-to('medium') {
     flex: 0 0 $grid-unit * 14;
   }
+
+  padding-top: $grid-unit * .5;
 }
 
 .details-description {
@@ -128,7 +125,6 @@
       height: auto;
       width: $grid-unit * 32;
     }
-
   }
 
   @include respond-to('medium') {
@@ -139,6 +135,8 @@
       width: $grid-unit * 22;
     }
   }
+
+  padding-top: $grid-unit * .5;
 
   :first-child {
     margin-top: 0;

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -26,6 +26,7 @@
   border-radius: $small-border-radius + 1;
   box-shadow: 0 0 0 1px $transparent-black-1, 0 1px 0 1px $transparent-black-1;
   color: $black;
+  cursor: pointer;
   margin: 0 0 ($grid-unit * 1.75) ($grid-unit * 2);
   position: relative;
   z-index: 1;
@@ -66,23 +67,15 @@
     margin: 0;
   }
 
-  &.has-addon {
-    cursor: pointer;
+  &.enabled {
+    box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green;
 
     &:hover {
-      box-shadow: 0 0 0 3px $transparent-white-1;
-    }
-
-    &.enabled {
-      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green;
-
-      &:hover {
-        box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green, 0 0 0 9px $transparent-white-1;
-      }
+      box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-green, 0 0 0 9px $transparent-white-1;
     }
   }
 
-  &.has-addon:hover {
+  &:hover {
     box-shadow: 0 1px 0 0 $transparent-white-2, 0 0 0 5px $transparent-white-2;
     transition: box-shadow 150ms;
 

--- a/testpilot/frontend/static-src/styles/modules/_experiment-promo.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-promo.scss
@@ -1,0 +1,35 @@
+.experiment-promo {
+
+  .intro-text {
+
+    .button.extra-large {
+      margin-top: $grid-unit * 1.5;
+    }
+
+    .parens {
+      display: inline-block;
+      margin-top: $grid-unit;
+    }
+
+    .download-firefox {
+      @include respond-to(not-small) {
+        margin-left: 0;
+      }
+
+      margin-bottom: $grid-unit * 1.5;
+    }
+
+    .legal-information {
+      @include respond-to(small) {
+        text-align: center;
+      }
+
+      @include respond-to(not-small) {
+        text-align: left;
+      }
+
+      margin-top: $grid-unit * 1.5;
+      padding: 0;
+    }
+  }
+}

--- a/testpilot/frontend/static-src/test/views/page-view.js
+++ b/testpilot/frontend/static-src/test/views/page-view.js
@@ -34,10 +34,16 @@ test('Page view renders', t => {
 });
 
 test('header is present', t => {
-  t.plan(1);
+  t.plan(2);
   const view = new MyView({headerScroll: true});
+
+  app.me.hasAddon = true;
   view.render();
-  t.ok(view.query('#main-header'));
+  t.ok(view.query('#main-header'), 'Header present for user with add-on.');
+
+  app.me.hasAddon = false;
+  view.render();
+  t.ok(view.query('#main-header'), 'Header present for user without add-on.');
 });
 
 test('footer is present', t => {


### PR DESCRIPTION
Throwing this out there for some early review, because I'm faking it 'til I make it with Ampersand and would appreciate any course-correction.
# Screenshots
## Firefox, with add-on installed

![with](https://cloud.githubusercontent.com/assets/23885/17564147/b1012ef2-5eef-11e6-8130-8e01a3062e8d.png)
## Firefox, without add-on installed

![without](https://cloud.githubusercontent.com/assets/23885/17564149/b416d8e4-5eef-11e6-943e-2d32877bf752.png)
## Chrome

![chrome](https://cloud.githubusercontent.com/assets/23885/17564303/3de065ea-5ef0-11e6-9bdf-5a53baa672ce.png)
# TODO
- [x] Dynamically determine the y-position at which to fix the header.
- [x] Add listing of additional experiments at the bottom of page for users without the add-on.
- [x] Handle non-ff cases
- [x] Get metrics changes defined, implement them.
- [x] Fix/remove old/broken tests.
- [x] Write new tests for all the introduced variations.
