### PR TITLE
Add install error statusbar message

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -68,6 +68,7 @@ experimentListEnabledTab = Enabled
 experimentListJustLaunchedTab = Just Launched
 experimentListJustUpdatedTab = Just Updated
 isEnabledStatusMessage = {$title} is enabled.
+installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.
 participantCount = <span>{$installation_count}</span> participants
 
 giveFeedback = Give Feedback

--- a/testpilot/frontend/static-src/app/models/experiment.js
+++ b/testpilot/frontend/static-src/app/models/experiment.js
@@ -7,8 +7,19 @@ export default Model.extend({
   urlRoot: '/api/experiments',
   extraProperties: 'allow',
   props: {
+    error: {type: 'boolean', default: false},
     enabled: {type: 'boolean', default: false},
     lastSeen: {type: 'number', default: 0}
+  },
+  derived: {
+    statusType: {
+      deps: ['error', 'enabled'],
+      fn: function statusType() {
+        if (this.error) { return 'error'; }
+        if (this.enabled) { return 'enabled'; }
+        return null;
+      }
+    }
   },
 
   // This shouldn't be necessary; see comments in collections/experiments.js

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -4,8 +4,11 @@ export default `
       <header data-hook="header-view"></header>
     </div>
     <div class="default-background">
-      <div class="details-header-wrapper" data-hook="is-enabled">
-        <div class="status-bar enabled" data-l10n-id="isEnabledStatusMessage"><span data-hook="title"></span> is enabled.</div>
+      <div class="details-header-wrapper" data-hook="has-status">
+        <div class="status-bar" data-hook="status-type">
+          <span data-hook="enabled-msg" data-l10n-id="isEnabledStatusMessage"><span data-hook="title"></span> is enabled.</span>
+          <span data-hook="error-msg" data-l10n-id="installErrorMessage">Uh oh. <span data-hook="title"></span> could not be enabled. Try again later.</span>
+        </div>
         <div class="details-header content-wrapper">
           <header>
             <h1 data-hook="title"></h1>

--- a/testpilot/frontend/static-src/styles/_variables.scss
+++ b/testpilot/frontend/static-src/styles/_variables.scss
@@ -77,5 +77,9 @@ $green: #7cd06a;
 $dark-green: #3b9827;
 $bright-green: #65c751;
 
+// Error status-bar reds
+$error-red-background: #f3bcb8;
+$error-red-border: #f5570e;
+
 // "Just {Launched,Updated}" blue
 $bright-blue: #1e98f5

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -1,9 +1,9 @@
 .details-header-wrapper {
 
-  &:not(.is-enabled) {
+  &:not(.has-status) {
     padding-top: $grid-unit * 1.8;
 
-    .enabled {
+    .status-bar {
       display: none;
     }
   }
@@ -37,6 +37,11 @@
     background: $green;
     border-bottom: 1px solid $dark-green;
     color: $white;
+  }
+
+  &.error {
+    background: $error-red-background;
+    border-bottom: 1px solid $error-red-border;
   }
 
   .stick & {

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -68,7 +68,7 @@ test('afterRender attaches detailView and contributorView', t => {
 });
 
 test('indicator bar shows when experiment is enabled', t => {
-  t.plan(2);
+  t.plan(4);
 
   const myView = new MyView({headerScroll: false, slug: 'slsk'});
   myView.render();
@@ -76,13 +76,38 @@ test('indicator bar shows when experiment is enabled', t => {
   const model = app.experiments.get('slsk', 'slug');
 
   model.enabled = true;
-  t.ok(myView.query('.is-enabled'));
+
+  t.ok(myView.query('.details-header-wrapper.has-status'));
+  t.ok(myView.query('.status-bar.enabled'));
 
   model.enabled = false;
   // since the display logic is in CSS,
   // check for the selector pattern that would
   // show the notification
-  t.equal(myView.query('.is-enabled .enabled'), undefined);
+  t.equal(myView.query('.details-header-wrapper.has-status'), undefined);
+  t.equal(myView.query('.status-bar.enabled'), undefined);
+});
+
+test('indicator bar shows when an error occurred', t => {
+  t.plan(4);
+
+  const myView = new MyView({headerScroll: false, slug: 'slsk'});
+  myView.render();
+
+  const model = app.experiments.get('slsk', 'slug');
+  model.enabled = false;
+
+  model.error = true;
+
+  t.ok(myView.query('.details-header-wrapper.has-status'));
+  t.ok(myView.query('.status-bar.error'));
+
+  model.error = false;
+  // since the display logic is in CSS,
+  // check for the selector pattern that would
+  // show the notification
+  t.equal(myView.query('.details-header-wrapper.has-status'), undefined);
+  t.equal(myView.query('.status-bar.error'), undefined);
 });
 
 test('introduction appears in view', t => {


### PR DESCRIPTION
fixes #660 

This covers download and install errors emitted by the `installListener` from the add-on, which should cover the most common errors. It doesn't cover slow or hung downloads like I described [here](https://github.com/mozilla/testpilot/issues/660#issuecomment-238396305).

There's one deviation from the design, I didn't disable the button on an error. Its not harmful to try clicking it again right then and there, and it might work, so it saves a page refresh or whatever, but I'll add it if we really want it.

Testing it top to bottom is a bit convoluted. I don't know a good way to mock it up yet. So, I go to an experiment page, then turn off wifi, then click the enable button. After about 60s the download fails and displays the error. If you just want to see how the banner looks, you can go to the js console and run something like `app.experiments.models[0].error = true`
