### PR TITLE
Fix error on removing add-on built after signing

### DIFF
--- a/addon/bin/sign
+++ b/addon/bin/sign
@@ -111,7 +111,7 @@ function distAddonSigned() {
 }
 
 function removeGeneratedXpi() {
-  var generatedXpi = '@testpilot-addon-' + version + '.xpi';
+  var generatedXpi = 'testpilot-addon.xpi';
 
   fs.unlink(generatedXpi, function(err) {
     if (err) console.error(err);


### PR DESCRIPTION
The add-on build in CircleCI completes with an error during clean up. Doesn't break the build, but this PR should fix the error. Not urgent at all for this sprint.
