### PR TITLE
open a tab when using the env switcher

### DIFF
--- a/groundcontrol/index.js
+++ b/groundcontrol/index.js
@@ -8,6 +8,14 @@
  const { PrefsTarget } = require('sdk/preferences/event-target');
  const { ToggleButton } = require('sdk/ui/button/toggle');
  const { Panel } = require('sdk/panel');
+ const tabs = require('sdk/tabs');
+
+ const environments = {
+   local: 'http://testpilot.dev:8000',
+   dev: 'http://testpilot.dev.mozaws.net',
+   stage: 'https://testpilot.stage.mozaws.net',
+   production: 'https://testpilot.firefox.com'
+ }
 
  const env = aboutConfig.get('testpilot.env', 'production');
  if (!aboutConfig.has('testpilot.env')) {
@@ -36,6 +44,7 @@
    aboutConfig.set('testpilot.env', newEnv);
    aboutConfig.set('extensions.webapi.testing', newEnv !== 'production');
    panel.hide();
+   tabs.open(environments[newEnv]);
  });
 
  const button = ToggleButton({

--- a/groundcontrol/package.json
+++ b/groundcontrol/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "scripts": {
-    "start": "jpm watchpost --post-url http://127.0.0.1:8888",
+    "start": "jpm post --post-url http://127.0.0.1:8888",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Mozilla (https://mozilla.org/)",


### PR DESCRIPTION
Just a minor tweak to the env switcher addon. I noticed that usually the first thing I'd do after switching envs is go to the webapp, so just do it for me.
