### PR TITLE
'Ending Soon' UI

### DIFF
--- a/addon/data/panel.css
+++ b/addon/data/panel.css
@@ -169,6 +169,12 @@ a {
     font-size: 14px;
 }
 
+.eol-span {
+    display: block;
+    color: #f46323;
+    font-size: 14px;
+}
+
 .installed-message {
     background: #fff;
     display: flex;
@@ -239,4 +245,3 @@ a {
     transform: scale(1);
   }
 }
-

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -13,8 +13,9 @@ module.exports.experimentList = `
         <div class="icon" style="background-image:url('{{thumbnail}}');"></div>
       </div>
       <div class="experiment-title">{{title}}
-        <span class="active-span {{#active}}visible{{/active}}">Enabled</span>
-        <span class="is-new-span {{#isNew}}visible{{/isNew}}">New Experiment</span>
+        <span class="active-span" style="{{#hideActive}}display:none;{{/hideActive}}">Enabled</span>
+        <span class="is-new-span">New Experiment</span>
+        <span class="eol-span {{#showEol}}visible{{/showEol}}">{{eolMessage}}</span>
       </div>
     </a>
   {{/experiments}}

--- a/addon/lib/toolbar-button.js
+++ b/addon/lib/toolbar-button.js
@@ -19,7 +19,9 @@ const FOOTER_HEIGHT = 50;
 const EXPERIMENT_HEIGHT = 80;
 const NEW_BADGE_LABEL = 'New';
 
-const NEW_EXPERIMENT_PERIOD = 14 * 24 * 60 * 60 * 1000; // 2 weeks
+const ONE_DAY = 24 * 60 * 60 * 1000;
+const ONE_WEEK = 7 * ONE_DAY;
+const NEW_EXPERIMENT_PERIOD = 2 * ONE_WEEK;
 
 let settings;
 let button;
@@ -36,6 +38,22 @@ function getExperimentList(availableExperiments, installedAddons) {
     const created = (new Date(experiment.created)).getTime();
     experiment.isNew = (now - created) < NEW_EXPERIMENT_PERIOD && !experiment.active;
     experiment.params = getParams();
+
+    if (experiment.completed) {
+      const completed = (new Date(experiment.completed)).getTime();
+      const delta = completed - Date.now();
+      if (delta < 0) {
+        experiment.eolMessage = 'Experiment Complete';
+      } else if (delta < ONE_DAY) {
+        experiment.eolMessage = 'Ending Tomorrow';
+      } else if (delta < ONE_WEEK) {
+        experiment.eolMessage = 'Ending Soon';
+      }
+      if (experiment.eolMessage) {
+        experiment.showEol = true;
+        experiment.hideActive = true;
+      }
+    }
     return experiment;
   });
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -141,6 +141,8 @@ shareSecondary = or just copy and paste this link...
 shareEmail = E-mail
 shareCopy = Copy
 
+eolMessage = <strong>This experiment is ending on {$completedDate}</strong>.<br/><br/>After then you will still be able to use {$title} but we will no longer be providing updates or support.
+
 # TODO: these strings are not currently localized.
 # They are served by the python static dir
 # and will need python-l20n implementation for coverage

--- a/testpilot/frontend/static-src/app/collections/experiments.js
+++ b/testpilot/frontend/static-src/app/collections/experiments.js
@@ -6,7 +6,7 @@ import Experiment from '../models/experiment';
 export default Collection.extend({
   model: Experiment,
   indexes: ['slug'],
-  url: '/api/experiments',
+  url: '/api/experiments.json',
   comparator: 'order',
 
   // Ampersand.sync doesn't seem to pass correct Accept headers by default.

--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -84,6 +84,7 @@ export default `
             </div>
 
             <div class="details-description">
+              <div data-hook="eol-message"></div>
               <div data-hook="active-user">
                 <section data-hook="introduction-container" class="introduction">
                   <div data-hook="introduction-html"></div>

--- a/testpilot/frontend/static-src/app/views/eol-view.js
+++ b/testpilot/frontend/static-src/app/views/eol-view.js
@@ -1,0 +1,22 @@
+import BaseView from './base-view';
+
+export default BaseView.extend({
+  template: `<div class="eol-block"><div data-hook="ending-soon" data-l10n-id="eolMessage">
+<strong>This experiment is ending on <span data-hook="completedDate"></span></strong>.<br/><br/>
+After then you will still be able to use <span data-hook="title"></span> but we will no longer be providing updates or support.</div>
+</div>`,
+  props: {
+    completedDate: 'string',
+    title: 'string'
+  },
+  bindings: {
+    completedDate: '[data-hook=completedDate]',
+    title: '[data-hook=title]'
+  },
+  getL10nArgs: function() {
+    return {
+      title: this.title,
+      completedDate: this.completedDate
+    };
+  }
+});

--- a/testpilot/frontend/static-src/app/views/experiment-page.js
+++ b/testpilot/frontend/static-src/app/views/experiment-page.js
@@ -12,6 +12,7 @@ import DisableDialogView from './disable-dialog-view';
 import ExperimentListView from './experiment-list-view';
 import ExperimentTourDialogView from './experiment-tour-dialog-view';
 import TestpilotPromoView from './testpilot-promo-view';
+import EolView from './eol-view';
 
 function changeHeaderOn() {
   const mainHeader = document.getElementById('main-header');
@@ -251,6 +252,13 @@ export default PageView.extend({
         except: this.model.slug,
         eventCategory: 'ExperimentsDetailPage Interactions'
       }), '[data-hook="experiment-list"]');
+    }
+
+    if (this.model.completed) {
+      this.renderSubview(new EolView({
+        completedDate: new Date(this.model.completed).toLocaleDateString(),
+        title: this.model.title
+      }), '[data-hook="eol-message"]');
     }
 
     postInstallModal(this);

--- a/testpilot/frontend/static-src/app/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/app/views/experiment-row-view.js
@@ -2,8 +2,10 @@ import app from 'ampersand-app';
 
 import BaseView from './base-view';
 
-const MAX_JUST_LAUNCHED_PERIOD = 14 * 24 * 60 * 60 * 1000; // 2 weeks
-const MAX_JUST_UPDATED_PERIOD = 14 * 24 * 60 * 60 * 1000; // 2 weeks
+const ONE_DAY = 24 * 60 * 60 * 1000;
+const ONE_WEEK = 7 * ONE_DAY;
+const MAX_JUST_LAUNCHED_PERIOD = 2 * ONE_WEEK;
+const MAX_JUST_UPDATED_PERIOD = 2 * ONE_WEEK;
 
 export default BaseView.extend({
   template: `<div data-hook="show-detail" class="experiment-summary">
@@ -19,6 +21,7 @@ export default BaseView.extend({
                 <header>
                   <h3 data-hook="title"></h3>
                   <h4 data-hook="subtitle" class="subtitle"></h4>
+                  <h4 data-hook="status-msg" class="eol-message"></h4>
                 </header>
                 <p data-hook="description"></p>
                 <span class="participant-count" data-l10n-id="participantCount"</span>
@@ -64,6 +67,22 @@ export default BaseView.extend({
 
         // All else fails, don't consider it launched.
         return false;
+      }
+    },
+    statusMsg: {
+      deps: ['model.completed'],
+      fn: function() {
+        if (this.model.completed) {
+          const delta = (new Date(this.model.completed)).getTime() - Date.now();
+          if (delta < 0) {
+            return '';
+          } else if (delta < ONE_DAY) {
+            return 'Ending Tomorrow';
+          } else if (delta < ONE_WEEK) {
+            return 'Ending Soon';
+          }
+        }
+        return '';
       }
     }
   },
@@ -128,6 +147,10 @@ export default BaseView.extend({
       type: 'toggle',
       hook: 'just-updated-tab'
     }],
+    'statusMsg': {
+      type: 'text',
+      hook: 'status-msg'
+    },
     'hasAddon': {
       type: 'booleanClass',
       hook: 'show-detail',

--- a/testpilot/frontend/static-src/styles/_variables.scss
+++ b/testpilot/frontend/static-src/styles/_variables.scss
@@ -82,4 +82,9 @@ $error-red-background: #f3bcb8;
 $error-red-border: #f5570e;
 
 // "Just {Launched,Updated}" blue
-$bright-blue: #1e98f5
+$bright-blue: #1e98f5;
+
+// End-of-life (eol) oranges
+$eol-dark-orange: #f46323;
+$eol-orange: #ff9300;
+$eol-light-orange: rgba($eol-orange, .25);

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -153,6 +153,14 @@
   }
 }
 
+.eol-block {
+  padding: 10px !important;
+  border-radius: 3px;
+  background: $eol-light-orange;
+  border: 1px solid $eol-orange;
+  margin-bottom: 20px;
+}
+
 .details-sections {
 
   section {

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -103,6 +103,10 @@
   }
 }
 
+.eol-message {
+  color: $eol-dark-orange;
+}
+
 .experiment-actions {
   .has-addon:not(.active) &.show-when-inactive {
     display: block;

--- a/testpilot/frontend/static-src/test/views/experiment-page.js
+++ b/testpilot/frontend/static-src/test/views/experiment-page.js
@@ -7,6 +7,9 @@ import Me from '../../app/models/me';
 import Experiments from '../../app/collections/experiments';
 const MyView = View.extend({headerScroll: false});
 
+const NOW = Date.now();
+const THREE_DAYS = 3 * 24 * 60 * 60 * 1000;
+
 tape(`Running Tests for ${__filename}`, a => a.end());
 
 const test = around(tape)
@@ -300,4 +303,17 @@ test('feedback button uses the expected survey URL', t => {
   myView.render();
 
   t.ok(myView.query('[data-hook=feedback]').href === expectedURL);
+});
+
+test('eol-block only shows when the experiment has a completed date', t => {
+  t.plan(2);
+  const myView = new MyView({headerScroll: false, slug: 'slsk'});
+  const model = app.experiments.get('slsk', 'slug');
+
+  myView.render();
+  t.ok(!myView.query('.eol-block'));
+
+  model.completed = NOW + THREE_DAYS;
+  myView.render();
+  t.ok(myView.query('.eol-block'));
 });

--- a/testpilot/frontend/static-src/test/views/experiment-row-view.js
+++ b/testpilot/frontend/static-src/test/views/experiment-row-view.js
@@ -126,3 +126,33 @@ test('Experiment row card displays "Just Updated" when experiment is updated sin
   t.ok(!view.query('.experiment-summary.just-updated'),
        'should not appear when too old');
 });
+
+test('Experiment card shows "Ending Soon" when experiment is nearly completed', t => {
+  t.plan(2);
+  const model = new Experiment({
+    slug: 'test',
+    title: 'just a test',
+    created: NOW - THREE_DAYS,
+    completed: NOW + THREE_DAYS
+  });
+
+  const view = new View({model: model});
+  view.render();
+  t.equal(view.query('.eol-message').innerHTML, 'Ending Soon');
+
+  model.completed = NOW + ONE_DAY;
+  view.render();
+  t.equal(view.query('.eol-message').innerHTML, 'Ending Tomorrow');
+});
+
+test('Experiment card does not show an EOL message with no completed date', t => {
+  t.plan(1);
+  const model = new Experiment({
+    slug: 'test',
+    title: 'just a test',
+    created: NOW - THREE_DAYS
+  });
+
+  const view = new View({model: model}).render();
+  t.equal(view.query('.eol-message').innerHTML, '');
+});


### PR DESCRIPTION
closes #1271 

This includes the "Ending Soon" messaging in the addon, experiment page, and experiment card.

It depends on a new `completed` date field in the experiment data. I haven't tried to add it to the database here since I'm hoping we'll be db-free before we need it. If not, I'll have to figure that out :)

Screenshots:

<img width="311" alt="screen shot 2016-08-24 at 11 37 31 am" src="https://cloud.githubusercontent.com/assets/87619/17943512/92ae0810-69f0-11e6-9297-581cae7c0e81.png">

<img width="1054" alt="screen shot 2016-08-24 at 11 39 47 am" src="https://cloud.githubusercontent.com/assets/87619/17943519/98f4f6fc-69f0-11e6-8e66-9390794a7075.png">

<img width="958" alt="screen shot 2016-08-24 at 11 40 40 am" src="https://cloud.githubusercontent.com/assets/87619/17943524/9d5208a2-69f0-11e6-93b2-eee1e737c37c.png">
