### PR TITLE
Make experiment details page responsive (closes #1251).

### DIFF
--- a/testpilot/frontend/static-src/app/templates/experiment-page.js
+++ b/testpilot/frontend/static-src/app/templates/experiment-page.js
@@ -8,7 +8,7 @@ export default `
           <span data-hook="enabled-msg" data-l10n-id="isEnabledStatusMessage"><span data-hook="title"></span> is enabled.</span>
           <span data-hook="error-msg" data-l10n-id="installErrorMessage">Uh oh. <span data-hook="title"></span> could not be enabled. Try again later.</span>
         </div>
-        <div class="details-header content-wrapper">
+        <div class="details-header responsive-content-wrapper">
           <header>
             <h1 data-hook="title"></h1>
             <h4 data-hook="subtitle" class="subtitle"></h4>
@@ -25,7 +25,7 @@ export default `
       <div class="sticky-header-sibling"></div>
 
       <div data-hook="details">
-          <div class="details-content content-wrapper">
+          <div class="details-content responsive-content-wrapper">
             <div class="details-overview">
               <div class="experiment-icon-wrapper" data-hook="bg">
                 <img class="experiment-icon" data-hook="thumbnail"></img>
@@ -40,7 +40,7 @@ export default `
                     <div data-hook="introduction-html"></div>
                   </section>
                 </div>
-                <section data-hook="active-user">
+                <section class="stats-section" data-hook="active-user">
                   <table class="stats">
                     <tr data-hook="version-container">
                       <td data-l10n-id="version">Version</td>
@@ -98,7 +98,7 @@ export default `
         <h2 class="card-list-header" data-l10n-id="otherExperiments">Try out these experiments as well</h2>
         <div class="responsive-content-wrapper delayed-fade-in" data-hook="experiment-list"></div>
       </div>
-      <footer id="main-footer" class="content-wrapper">
+      <footer id="main-footer" class="responsive-content-wrapper">
         <div data-hook="footer-view"></div>
       </footer>
   </section>

--- a/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
+++ b/testpilot/frontend/static-src/app/views/testpilot-promo-view.js
@@ -5,7 +5,7 @@ import installAddon from '../lib/install-addon';
 export default BaseView.extend({
   _template: `
     <div class="experiment-promo">
-      <div class="reverse-split-banner responsive-git content-wrapper">
+      <div class="reverse-split-banner responsive-content-wrapper">
         <div class="copter-wrapper fly-up">
           <div class="copter"></div>
         </div>

--- a/testpilot/frontend/static-src/styles/modules/_banners.scss
+++ b/testpilot/frontend/static-src/styles/modules/_banners.scss
@@ -49,16 +49,15 @@
     }
 
     p {
-      @include respond-to('big') {
+      @include respond-to('not-small') {
         font-size: $font-unit * 2.3;
         line-height: $line-unit * 2.3;
         max-width: $grid-unit * 25;
       }
 
-      @include respond-to('medium') {
+      @include respond-to('small') {
         font-size: $font-unit * 1.6;
         line-height: $line-unit * 1.6;
-        max-width: $grid-unit * 19.5;
       }
 
       margin: 0;

--- a/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-details.scss
@@ -8,15 +8,23 @@
     }
   }
 
-  &.stick {
-    background: $transparent-white-96;
-    box-shadow: 0 0 5px $transparent-black-5;
-    left: 0;
-    padding-top: 0;
-    position: fixed;
-    top: 0;
-    width: 100%;
-    z-index: 999;
+  @include respond-to('not-small') {
+    &.stick {
+      background: $transparent-white-96;
+      box-shadow: 0 0 5px $transparent-black-5;
+      left: 0;
+      padding-top: 0;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 999;
+    }
+  }
+}
+
+@include respond-to('small') {
+  .sticky-header-sibling {
+    display: none;
   }
 }
 
@@ -46,7 +54,11 @@
 }
 
 .experiment-controls {
-  @include flex-container(row, flex-end, center);
+  @include respond-to('not-small') {
+    @include flex-container(row, flex-end, center);
+  }
+
+  display: none;
   flex: 1;
   position: relative;
   transition: top 200ms;
@@ -69,8 +81,12 @@
 }
 
 .details-header {
+  @include respond-to('not-small') {
+    height: $grid-unit * 4.5;
+    margin-bottom: 0;
+  }
   @include flex-container(row, space-between, center);
-  height: $grid-unit * 4.5;
+  margin-bottom: $grid-unit;
   position: relative;
 
   h1 {
@@ -102,7 +118,11 @@
 
 
 .details-content {
-  @include flex-container(row, space-between, flex-start);
+  @include flex-container(column, space-between, stretch);
+
+  @include respond-to('not-small') {
+    flex-direction: row;
+  }
 }
 
 .details-overview {
@@ -124,15 +144,6 @@
     img {
       height: auto;
       width: $grid-unit * 32;
-    }
-  }
-
-  @include respond-to('medium') {
-    flex: 0 0 $grid-unit * 22;
-
-    img {
-      height: auto;
-      width: $grid-unit * 22;
     }
   }
 
@@ -266,14 +277,52 @@
   margin-bottom: $grid-unit * 1.5;
 
   img {
+    @include respond-to('not-small') {
+      max-width: auto;
+    }
+
     border-radius: 3px;
+    max-width: 100%;
     overflow: hidden;
   }
 
   .caption {
     color: $transparent-black-7;
     font-size: $font-unit;
+    line-height: $font-unit * 1.5;
     margin-top: $grid-unit * .5;
     padding: 0 $grid-unit * .25;
+  }
+}
+
+.contributors-section,
+.stats-section,
+.measurements {
+  @include respond-to('not-small') {
+    display: block;
+  }
+
+  display: none;
+}
+
+@include respond-to('small') {
+  [data-hook='experiment-page'] {
+    .card-list {
+      margin: 0 0 $grid-unit;
+    }
+
+    .experiment-summary:last-child {
+      margin-bottom: 0;
+    }
+
+    .card-list-header {
+      font-size: $font-unit * 1.5;
+      line-height: $font-unit * 2;
+      margin: ($grid-unit * 1.5) 0;
+    }
+
+    #footer-links {
+      padding-top: 0;
+    }
   }
 }

--- a/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
+++ b/testpilot/frontend/static-src/styles/modules/_experiment-list.scss
@@ -16,10 +16,10 @@
   }
 
   @include respond-to('small') {
-    flex: 0 1 96%;
-    margin-left: auto;
-    margin-right: auto;
-    max-width: $grid-unit * 20;
+    flex: 0 1 98%;
+    margin-left: 0;
+    margin-right: 0;
+    max-width: 100%;
   }
 
   background-color: $white;

--- a/testpilot/frontend/static-src/styles/modules/_main-header.scss
+++ b/testpilot/frontend/static-src/styles/modules/_main-header.scss
@@ -6,11 +6,16 @@
     text-indent: -9999px;
 
     .wordmark {
-      @include hidpi-background-image('wordmark', 296px 64px);
+      @include respond-to('not-small') {
+        @include hidpi-background-image('wordmark', 296px 64px);
+        height: 64px;
+        width: 296px;
+      }
+      @include hidpi-background-image('wordmark', 190px 41px);
       display: block;
-      height: 64px;
+      height: 41px;
       position: relative;
-      width: 296px;
+      width: 190px;
     }
   }
 }

--- a/testpilot/frontend/static-src/styles/modules/_settings.scss
+++ b/testpilot/frontend/static-src/styles/modules/_settings.scss
@@ -1,4 +1,9 @@
 .settings-contain {
+  @include respond-to('not-small') {
+    display: block;
+  }
+
+  display: none;
   position: relative;
 }
 


### PR DESCRIPTION
r? @johngruen @lmorchard 
## Screenshots

With add-on: [360px](https://cloud.githubusercontent.com/assets/23885/17941650/798be752-69f1-11e6-8004-5b7741bd0daa.png), [768px](https://cloud.githubusercontent.com/assets/23885/17941655/8526f660-69f1-11e6-98d8-f910d2b6d4ba.png)
Without add-on: [360px](https://cloud.githubusercontent.com/assets/23885/17941664/90fd5ede-69f1-11e6-83cb-11b9d5188a45.png), [768px](https://cloud.githubusercontent.com/assets/23885/17941675/979d870a-69f1-11e6-8cb6-b13c2063440a.png)
Non-Firefox: [360px](https://cloud.githubusercontent.com/assets/23885/17941788/07550cd0-69f2-11e6-9273-1a760a626275.png), [768px](https://cloud.githubusercontent.com/assets/23885/17941794/0e964464-69f2-11e6-9ad8-92765ec6b6da.png) (everything else is the same as the no-addon shots)
