### PR TITLE
Delete old user accounts from the database

### DIFF
--- a/testpilot/users/migrations/0003_delete_nonstaff_users.py
+++ b/testpilot/users/migrations/0003_delete_nonstaff_users.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+from testpilot.utils import cleanup_nonstaff_users
+
+
+def delete_nonstaff_users_forwards(apps, schema_editor):
+    Experiment = apps.get_model('experiments', 'Experiment')
+    User = apps.get_model('auth', 'User')
+    cleanup_nonstaff_users(User, Experiment.objects.all())
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0002_userprofile_invite_pending'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_nonstaff_users_forwards),
+
+        # Clean up tables left over from FxA removal...
+        migrations.RunSQL('DROP TABLE IF EXISTS account_emailaddress'),
+        migrations.RunSQL('DROP TABLE IF EXISTS account_emailconfirmation'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialaccount'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialapp'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialapp_sites'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialtoken')
+    ]

--- a/testpilot/utils.py
+++ b/testpilot/utils.py
@@ -191,3 +191,14 @@ class TestCase(django.test.TestCase):
         url = reverse(url_name, kwargs=kwargs)
         resp = self.client.get(url)
         return json.loads(str(resp.content, encoding='utf8'))
+
+
+def cleanup_nonstaff_users(User, experiments):
+    # First, ensure all experiment contributors are marked as staff
+    for experiment in experiments:
+        for user in experiment.contributors.all():
+            user.is_staff = True
+            user.save()
+
+    # Now, delete all users who aren't staff or superusers
+    User.objects.exclude(is_staff=True).exclude(is_superuser=True).delete()


### PR DESCRIPTION
- Ensure contributors on experiments are counted as staff
- Delete all user non-staff user accounts
- Drop old tables used by the old Firefox Accounts integration

Fixes #1034
