### PR TITLE
added a static site build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 build/
 tmp/
 *.log

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -424,16 +424,27 @@ gulp.task('watch', function watchTask() {
   gulp.watch('gulpfile.js', () => process.exit());
 });
 
+let serverPort = 8000;
+
 // Set up a webserver for the static assets
 gulp.task('connect', function connectTask() {
   connect.server({
     root: DIST_PATH,
     livereload: false,
-    port: 8000
+    port: serverPort
   });
 });
 
 gulp.task('server', function() {
+  serverPort = 9988;
+  return runSequence(
+    'static',
+    'connect',
+    'watch'
+  );
+});
+
+gulp.task('static-only-server', function() {
   return runSequence(
     'static',
     'connect',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,12 @@ const gulp = require('gulp');
 const gulpif = require('gulp-if');
 const gutil = require('gulp-util');
 // const imagemin = require('gulp-imagemin');
+const merge = require('merge-stream');
 const minifycss = require('gulp-cssnano');
+const multiDest = require('gulp-multi-dest');
 const normalize = require('node-normalize-scss');
+const rename = require('gulp-rename');
+const RevAll = require('gulp-rev-all');
 const runSequence = require('run-sequence');
 const sass = require('gulp-sass');
 const sassLint = require('gulp-sass-lint');
@@ -35,8 +39,10 @@ const IS_DEBUG = (process.env.NODE_ENV === 'development');
 
 const SRC_PATH = './testpilot/frontend/static-src/';
 const DEST_PATH = './testpilot/frontend/static/';
+const STAGE_PATH = './stage/';
+const DIST_PATH = './dist/';
 
-const CONTENT_SRC_PATH = 'content-src/experiments';
+const CONTENT_SRC_PATH = 'content-src/';
 const PRODUCTION_EXPERIMENTS_URL = 'https://testpilot.firefox.com/api/experiments';
 const IMAGE_NEW_BASE_PATH = 'testpilot/frontend/static-src/images/experiments/';
 const IMAGE_NEW_BASE_URL = '/static/images/experiments/';
@@ -80,7 +86,9 @@ gulp.task('selfie', function selfieTask() {
 
 gulp.task('clean', function cleanTask() {
   return del([
-    DEST_PATH
+    DEST_PATH,
+    STAGE_PATH,
+    DIST_PATH
   ]);
 });
 
@@ -267,13 +275,13 @@ function downloadURL(item) {
 
 function writeExperimentYAML(experiment) {
   const out = YAML.stringify(experiment, 4, 2);
-  const path = `${CONTENT_SRC_PATH}/${experiment.slug}.yaml`;
+  const path = `${CONTENT_SRC_PATH}experiments/${experiment.slug}.yaml`;
   if (IS_DEBUG) { console.log(`Generated ${path}`); }
   return writeFile(path, out);
 }
 
 gulp.task('experiments-json', function generateStaticAPITask() {
-  return gulp.src(CONTENT_SRC_PATH + '/*.yaml')
+  return gulp.src(CONTENT_SRC_PATH + 'experiments/*.yaml')
     .pipe(buildExperimentsJSON('experiments'))
     .pipe(gulp.dest(DEST_PATH + 'api'));
 });
@@ -313,8 +321,82 @@ function buildExperimentsJSON(path) {
   return through.obj(collectEntry, endStream);
 }
 
+gulp.task('stage-assets', function() {
+  return gulp.src(DEST_PATH + '**')
+      .pipe(gulp.dest(STAGE_PATH + 'static'));
+});
+
+gulp.task('move-api', function() {
+  return new Promise((resolve, reject) => {
+    gulp.src(STAGE_PATH + 'static/api/**', { base: STAGE_PATH + 'static' })
+    .pipe(gulp.dest(STAGE_PATH))
+    .on('end', () => {
+      del(STAGE_PATH + 'static/api').then(resolve).catch(reject);
+    });
+  });
+});
+
+gulp.task('copy-html', function() {
+  const paths = fs.readdirSync(CONTENT_SRC_PATH + 'experiments')
+    .map(f => `${STAGE_PATH}experiments/${f.replace('.yaml', '')}`)
+    .concat([
+      STAGE_PATH,
+      STAGE_PATH + 'experiments',
+      STAGE_PATH + 'onboarding',
+      STAGE_PATH + 'home',
+      STAGE_PATH + 'share',
+      STAGE_PATH + 'legacy',
+      STAGE_PATH + 'error'
+    ]);
+  return merge(
+    gulp.src(SRC_PATH + 'index.html')
+      .pipe(multiDest(paths)),
+    gulp.src('./legal-copy/privacy-notice.html')
+      .pipe(rename('index.html'))
+      .pipe(gulp.dest(STAGE_PATH + '/privacy')),
+    gulp.src('./legal-copy/terms-of-use.html')
+      .pipe(rename('index.html'))
+      .pipe(gulp.dest(STAGE_PATH + '/terms'))
+  );
+});
+
+gulp.task('rev-assets', function() {
+  const revAll = new RevAll({
+    dontRenameFile: [
+      '.json',
+      'favicon.ico',
+      /static\/addon\/*/,
+      /static\/locales\/*/,
+      '.html'
+    ],
+    dontUpdateReference: [
+      /.*\.json/,
+      'favicon.ico'
+    ]
+  });
+  return gulp.src(STAGE_PATH + '**')
+    .pipe(revAll.revision())
+    .pipe(gulp.dest(DIST_PATH));
+});
+
+gulp.task('clean-stage', function() {
+  return del(STAGE_PATH);
+});
+
+gulp.task('static', function staticTask(done) {
+  return runSequence(
+    'build',
+    'stage-assets',
+    'move-api',
+    'copy-html',
+    'rev-assets',
+    'clean-stage',
+    done
+  );
+});
+
 gulp.task('build', function buildTask(done) {
-  runSequence(
+  return runSequence(
     'clean',
     'app-vendor',
     'app-main',
@@ -329,7 +411,7 @@ gulp.task('build', function buildTask(done) {
   );
 });
 
-gulp.task('watch', ['build'], function watchTask() {
+gulp.task('watch', function watchTask() {
   gulp.watch(SRC_PATH + 'styles/**/*', ['styles']);
   gulp.watch(SRC_PATH + 'images/**/*', ['images']);
   gulp.watch(SRC_PATH + 'app/**/*.js', ['app-main']);
@@ -345,12 +427,18 @@ gulp.task('watch', ['build'], function watchTask() {
 // Set up a webserver for the static assets
 gulp.task('connect', function connectTask() {
   connect.server({
-    root: DEST_PATH,
+    root: DIST_PATH,
     livereload: false,
-    port: 9988
+    port: 8000
   });
 });
 
-gulp.task('server', ['build', 'connect', 'watch']);
+gulp.task('server', function() {
+  return runSequence(
+    'static',
+    'connect',
+    'watch'
+  );
+});
 
 gulp.task('default', ['build', 'watch']);

--- a/package.json
+++ b/package.json
@@ -48,11 +48,15 @@
     "gulp-cssnano": "2.1.0",
     "gulp-eslint": "^1.0.0",
     "gulp-if": "^1.2.5",
+    "gulp-multi-dest": "0.0.4",
+    "gulp-rename": "^1.2.2",
+    "gulp-rev-all": "^0.8.24",
     "gulp-sass": "^2.0.4",
     "gulp-sass-lint": "^1.1.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "gulp-util": "^3.0.6",
+    "merge-stream": "^1.0.0",
     "node-normalize-scss": "1.1.1",
     "node-sass": "3.4.2",
     "remarkable": "1.6.2",
@@ -81,6 +85,7 @@
     "url": "git+https://github.com/mozilla/testpilot.git"
   },
   "scripts": {
+    "start": "gulp server",
     "build": "gulp build",
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "gulp lint sass-lint",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "url": "git+https://github.com/mozilla/testpilot.git"
   },
   "scripts": {
-    "start": "gulp server",
+    "start": "gulp static-only-server",
     "build": "gulp build",
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "gulp lint sass-lint",

--- a/testpilot/frontend/static-src/index.html
+++ b/testpilot/frontend/static-src/index.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <link rel="shortcut icon" href="/static/images/favicon.ico">
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
+    <link rel="stylesheet" href="/static/styles/main.css">
+    <meta name="defaultLanguage" content="en-US">
+    <meta name="availableLanguages" content="en-US">
+    <meta name="viewport" content="width=device-width">
+    <link rel="localization" href="/static/locales/{locale}/app.ftl">
+
+    <title>Firefox Test Pilot</title>
+
+    <link rel="canonical" href="http://testpilot.firefox.com/">
+    <meta name="description" content="Test new Features. Give us feedback. Help build Firefox." />
+    <meta property="og:description" content="Test new Features. Give us feedback. Help build Firefox." />
+    <meta property="og:image" content="http://testpilot.firefox.com/static/images/thumbnail-facebook.1a45270b.png" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:title" content="Firefox Test Pilot" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="http://testpilot.firefox.com/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:description" content="Test new Features. Give us feedback. Help build Firefox." />
+    <meta name="twitter:image" content="http://testpilot.firefox.com/static/images/thumbnail-twitter.19ccbdd2.png" />
+    <meta name="twitter:site" content="@FxTestPilot" />
+    <meta name="twitter:title" content="Firefox Test Pilot" />
+</head>
+<body class="blue">
+  <div class="stars"></div>
+  <div data-hook="page-container">
+    <noscript>
+      <div class="full-page-wrapper centered">
+        <div class="centered-banner">
+          <div id="four-oh-four" class="modal delayed-fade-in">
+            <h1 data-l10n-id="noScriptHeading" class="title">Uh oh...</h1>
+            <div class="modal-content">
+              <p data-l10n-id="noScriptMessage">Test Pilot requires JavaScript.<br>Sorry about that.</p>
+            </div>
+            <div class="modal-actions">
+              <a data-l10n-id="noScriptLink" class="button default large" href="https://github.com/mozilla/testpilot/blob/master/docs/FAQs.md">Find out why</a>
+            </div>
+          </div>
+          <div class="copter-wrapper">
+            <div class="copter fade-in-fly-up"></div>
+          </div>
+        </div>
+      </div>
+    </noscript>
+
+    <div class="full-page-wrapper centered overflow-hidden">
+      <div class="loader">
+        <div class="loader-bar"></div>
+        <div class="loader-bar"></div>
+        <div class="loader-bar"></div>
+        <div class="loader-bar"></div>
+      </div>
+    </div>
+  </div>
+  <script src="/static/app/vendor.js"></script>
+  <script src="/static/app/app.js"></script>
+  <script src="https://pontoon.mozilla.org/pontoon.js"></script>
+
+</body>
+</html>


### PR DESCRIPTION
This adds the `static` gulp task which builds a static version of the site into the `/dist` directory. The build for the django assets remains the same.

`npm start` will build the static site and host a server on port 8000.
