### PR TITLE
Fix order of DB operations in user account cleanup migration

### DIFF
--- a/testpilot/users/migrations/0003_delete_nonstaff_users.py
+++ b/testpilot/users/migrations/0003_delete_nonstaff_users.py
@@ -18,13 +18,13 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(delete_nonstaff_users_forwards),
-
         # Clean up tables left over from FxA removal...
-        migrations.RunSQL('DROP TABLE IF EXISTS account_emailaddress'),
         migrations.RunSQL('DROP TABLE IF EXISTS account_emailconfirmation'),
-        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialaccount'),
-        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialapp'),
+        migrations.RunSQL('DROP TABLE IF EXISTS account_emailaddress'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialtoken'),
         migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialapp_sites'),
-        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialtoken')
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialapp'),
+        migrations.RunSQL('DROP TABLE IF EXISTS socialaccount_socialaccount'),
+
+        migrations.RunPython(delete_nonstaff_users_forwards)
     ]


### PR DESCRIPTION
Ugh. Checked on how the user account cleanup migration did on dev, and noticed that it failed. Turns out the tables had to be deleted in a different order thanks to key dependencies. But, I didn't notice because those tables were already gone from my local machine. Tweaked things and re-ran on dev manually. This seems to work.
