### PR TITLE
Split usage counts out of experiments JSON API

### DIFF
--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -121,6 +121,15 @@ class ExperimentViewTests(BaseTestCase):
             }
         )
 
+    def test_usage_counts(self):
+        expected = dict(
+            (x.addon_id, x.installation_count)
+            for x in self.experiments.values()
+        )
+        url = reverse('experiment-usage-counts')
+        resp = self.client.get(url)
+        self.assertJSONEqual(str(resp.content, encoding='utf8'), expected)
+
     def test_tour_steps(self):
         # lang = 'en-US'
         experiment = self.experiments['test-1']

--- a/testpilot/experiments/views.py
+++ b/testpilot/experiments/views.py
@@ -2,7 +2,7 @@ import json
 
 from rest_framework import viewsets, status
 from rest_framework.response import Response
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import detail_route, list_route
 
 from django.shortcuts import get_object_or_404
 from django.contrib.staticfiles.views import serve
@@ -61,6 +61,13 @@ class ExperimentViewSet(viewsets.ModelViewSet):
             queryset, many=True,
             context=self.get_serializer_context())
         return Response(serializer.data)
+
+    @list_route()
+    def usage_counts(self, request, *args, **kwargs):
+        return Response(dict(
+            (x.addon_id, x.installation_count)
+            for x in self.get_queryset()
+        ))
 
 
 @csrf_exempt


### PR DESCRIPTION
- Create /api/experiments/usage_count.json server resource
- Switch to using usage counts resource in frontend
- Produce static api/experiments/usage_counts.json

Fixes #1312
