### PR TITLE
1305 static deploy

### DIFF
--- a/bin/circleci/build-frontend.sh
+++ b/bin/circleci/build-frontend.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -ex
 npm install
-npm run build
+if [[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
+    npm run static
+else
+    npm run build
+fi
 npm test

--- a/bin/circleci/run-integration-tests.sh
+++ b/bin/circleci/run-integration-tests.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-# Fire up an instance of the site configured for integration testing
-docker run \
-    --name integration \
-    --detach \
-    --net=host \
-    -p 127.0.0.1:8000:8000 \
-    -e 'DEBUG=False' \
-    -e 'SECRET_KEY=Foo' \
-    -e 'ALLOWED_HOSTS=testpilot.dev' \
-    -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test' \
-    app:build \
-    bin/circleci/run-integration-test-server.sh
+if [[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
+    npm start &
+    STATIC_SERVER_PID=$!
+else
+    # Fire up an instance of the site configured for integration testing
+    docker run \
+        --name integration \
+        --detach \
+        --net=host \
+        -p 127.0.0.1:8000:8000 \
+        -e 'DEBUG=False' \
+        -e 'SECRET_KEY=Foo' \
+        -e 'ALLOWED_HOSTS=testpilot.dev' \
+        -e 'DATABASE_URL=postgres://ubuntu@localhost/circle_test' \
+        app:build \
+        bin/circleci/run-integration-test-server.sh
+fi
 
 # Wait until the server is available...
 until $(curl --output /dev/null --silent --head --fail http://testpilot.dev:8000); do
@@ -25,9 +30,13 @@ python integration/runtests.py \
     integration
 TEST_STATUS=$?
 
-# Clean up - these commands will sometimes produce errors, but ignore them
-docker kill integration
-docker rm integration
+if [[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
+    kill $STATIC_SERVER_PID
+else
+    # Clean up - these commands will sometimes produce errors, but ignore them
+    docker kill integration
+    docker rm integration
+fi
 
 # Report what happened
 if [ $TEST_STATUS -eq 0 ]

--- a/circle.yml
+++ b/circle.yml
@@ -12,9 +12,10 @@ machine:
     testpilot.dev: 127.0.0.1
   services:
     - docker
-
   node:
     version: 6.2.0
+  environment:
+    TESTPILOT_STATIC_BRANCHES: development-static 1305-static-deploy
 
 dependencies:
 
@@ -37,11 +38,11 @@ dependencies:
     - ./bin/circleci/build-version-json.sh
     - ./bin/circleci/build-addon.sh
     - ./bin/circleci/build-frontend.sh
-    - ./bin/circleci/build-server.sh
+    - '[[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]] || ./bin/circleci/build-server.sh'
 
 test:
   override:
-    - ./bin/circleci/run-server-unit-tests.sh
+    - '[[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]] || ./bin/circleci/run-server-unit-tests.sh'
     - ./bin/circleci/run-integration-tests.sh
 
 # appropriately tag and push the container to dockerhub
@@ -65,6 +66,18 @@ deployment:
       - "docker tag app:build ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
       - "docker images"
       - "docker push ${DOCKERHUB_REPO}:${CIRCLE_TAG}"
+
+  static_development:
+    branch:
+      - development-static
+    commands:
+      - aws s3 sync dist s3://testpilot-static.dev.mozaws.net --delete --acl public-read
+
+  static_development_lorchard:
+    branch:
+      - 1305-static-deploy
+    commands:
+      - aws s3 sync dist s3://testpilot-static.lorchard.mozaws.net --delete --acl public-read
 
 # Only notify of builds on master branch.
 experimental:

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -379,6 +379,7 @@ gulp.task('rev-assets', function() {
       '.html'
     ],
     dontUpdateReference: [
+      /static\/addon\/*/,
       /.*\.json/,
       'favicon.ico'
     ]
@@ -440,6 +441,7 @@ gulp.task('connect', function connectTask() {
   connect.server({
     root: DIST_PATH,
     livereload: false,
+    host: '0.0.0.0',
     port: serverPort
   });
 });

--- a/integration/test_installation.py
+++ b/integration/test_installation.py
@@ -66,7 +66,9 @@ class TestAddonInstallation(FirefoxTestCase):
 
         # And the add-on should open up an onboarding tab...
         Wait(m).until(lambda m: len(b.tabbar.tabs) > 1)
-        self.assertTrue(b.tabbar.tabs[1].location.endswith('/onboarding'))
+        next_tab_loc = b.tabbar.tabs[1].location
+        self.assertTrue(next_tab_loc.endswith('/onboarding') or
+                        next_tab_loc.endswith('/onboarding/'))
         b.tabbar.close_tab(b.tabbar.tabs[1])
 
         # The frontend should redirect to /experiments after it contacts the add-on

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
   },
   "scripts": {
     "start": "gulp static-only-server",
+    "static": "gulp static",
     "build": "gulp build",
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "gulp lint sass-lint",

--- a/testpilot/experiments/tests.py
+++ b/testpilot/experiments/tests.py
@@ -121,6 +121,15 @@ class ExperimentViewTests(BaseTestCase):
             }
         )
 
+    def test_usage_counts(self):
+        expected = dict(
+            (x.addon_id, x.installation_count)
+            for x in self.experiments.values()
+        )
+        url = reverse('experiment-usage-counts')
+        resp = self.client.get(url)
+        self.assertJSONEqual(str(resp.content, encoding='utf8'), expected)
+
     def test_tour_steps(self):
         # lang = 'en-US'
         experiment = self.experiments['test-1']

--- a/testpilot/experiments/views.py
+++ b/testpilot/experiments/views.py
@@ -2,7 +2,7 @@ import json
 
 from rest_framework import viewsets, status
 from rest_framework.response import Response
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import detail_route, list_route
 
 from django.shortcuts import get_object_or_404
 from django.contrib.staticfiles.views import serve
@@ -61,6 +61,13 @@ class ExperimentViewSet(viewsets.ModelViewSet):
             queryset, many=True,
             context=self.get_serializer_context())
         return Response(serializer.data)
+
+    @list_route()
+    def usage_counts(self, request, *args, **kwargs):
+        return Response(dict(
+            (x.addon_id, x.installation_count)
+            for x in self.get_queryset()
+        ))
 
 
 @csrf_exempt


### PR DESCRIPTION
This piggybacks on PR #1313, so review / merge that one first. But, this could use some eyes now. 
- circle.yml changes to support both Docker and static build branches
- bugfix to static build to exclude rewriting references to addon
- integration test tweak to accept trailing slash on /onboarding URL

Basically, this supports the usual Docker build for most branches. But, it adds static-only build & deploy to S3 for pre-defined static branches. 

So far, the static branches are `1305-static-deploy` (for this PR) and `development-static`. Results of deployment are found here:
- http://testpilot-static.lmorchard.mozaws.net.s3-website-us-east-1.amazonaws.com/
- http://testpilot-static.dev.mozaws.net.s3-website-us-east-1.amazonaws.com/

Still have some work to do here, including setting up CloudFront for SSL & a better hostname on development and also adding new environments to the main add-on so it supports these new hosts.
