### PR TITLE
'Completed Experiment' addon changes

### DIFF
--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -23,7 +23,7 @@ module.exports = {init, destroy, launchSurvey};
 
 // set timecheck flags for initial run.
 if (store.surveyChecks === undefined) store.surveyChecks = {};
-['twoDaysSent', 'oneWeekSent', 'threeWeeksSent', 'monthAndAHalfSent'].forEach(k => {
+['twoDaysSent', 'oneWeekSent', 'threeWeeksSent', 'monthAndAHalfSent', 'eol'].forEach(k => {
   if (store.surveyChecks[k] === undefined) store.surveyChecks[k] = {};
 });
 

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -7,7 +7,7 @@
 module.exports.experimentList = `
 <div class="experiment-list">
   {{#experiments}}
-    <a class="experiment-item {{#active}}active{{/active}} {{#isNew}}is-new{{/isNew}}" href="{{base_url}}/experiments/{{slug}}?{{params}}">
+    <a class="experiment-item {{#active}}active{{/active}} {{#isNew}}is-new{{/isNew}}" href="{{link}}?{{params}}">
       <div class="icon-wrapper"
            style="background-color:{{gradient_start}}; background-image: linear-gradient(300deg, {{gradient_start}}, {{gradient_stop}})">
         <div class="icon" style="background-image:url('{{thumbnail}}');"></div>


### PR DESCRIPTION
This is a pretty hacktastic implementation of #1303

I made this survey a bit more persistent than the other ones. Since it pops up on a new tab it's got some `persistence` so it stays visible after navigating and it doesn't mark the survey as "done" if it times out and dismisses itself so that the panel will continue to link to the survey.

Tests?  `¯\_(ツ)_/¯`
