### PR TITLE
Use mozAddonManager to install Test Pilot extension when available.

### DIFF
--- a/frontend/src/app/lib/install-addon.js
+++ b/frontend/src/app/lib/install-addon.js
@@ -3,19 +3,53 @@ import cookies from 'js-cookie';
 import EmailDialogView from '../views/email-opt-in-dialog-view';
 
 
+const MOZADDONMANAGER_ALLOWED_HOSTNAMES = [
+  'testpilot.firefox.com',
+  'testpilot.stage.mozaws.net',
+  'testpilot.dev.mozaws.net'
+];
+
+
+function mozAddonManagerInstall(url) {
+  return navigator.mozAddonManager.createInstall({ url }).then(install => {
+    return new Promise((resolve, reject) => {
+      install.addEventListener('onInstallEnded', () => resolve());
+      install.addEventListener('onInstallFailed', () => reject());
+      install.install();
+    });
+  });
+}
+
 function installAddon(view, eventCategory, callback) {
-  const downloadUrl = '/static/addon/addon.xpi';
+  const { protocol, hostname, port } = window.location;
+  const path = '/static/addon/addon.xpi';
+  const downloadUrl = `${protocol}//${hostname}${port ? ':' + port : ''}${path}`;
 
   view.query('[data-hook=install]').classList.add('state-change');
   view.query('.default-btn-msg').classList.add('no-display');
   view.query('.progress-btn-msg').classList.remove('no-display');
 
-  app.sendToGA('event', {
+  const useMozAddonManager = (
+    navigator.mozAddonManager &&
+    protocol === 'https:' &&
+    MOZADDONMANAGER_ALLOWED_HOSTNAMES.includes(hostname)
+  );
+
+  const gaEvent = {
     eventCategory: eventCategory,
     eventAction: 'button click',
-    eventLabel: 'Install the Add-on',
-    outboundURL: downloadUrl
-  });
+    eventLabel: 'Install the Add-on'
+  };
+
+  if (useMozAddonManager) {
+    app.sendToGA('event', gaEvent);
+    mozAddonManagerInstall(downloadUrl).then(() => {
+      console.log('Installed extension via mozAddonManager');
+    });
+  } else {
+    gaEvent.outboundURL = downloadUrl;
+    app.sendToGA('event', gaEvent);
+  }
 
   // Wait for the add-on to be installed.
   // TODO: Should we have a timeout here, give up after a few intervals? If


### PR DESCRIPTION
This works great ~~, except for one blocking problem, which is filed here: https://bugzilla.mozilla.org/show_bug.cgi?id=1301609~~. I didn't have `testpilot.env` set appropriately. Works great, no longer WIP.

Testing this locally is...complex. I'll follow up with a comment with full instructions.

Closes #1223 
