### PR TITLE
[fixes #1337] Add GA to addon

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -337,6 +337,14 @@ exports.main = function(options) {
   if (reason === 'install') {
     openOnboardingTab();
   }
+
+  const installedCount = (store.installedAddons) ? Object.keys(store.installedAddons).length : 0;
+  Metrics.sendGAEvent({
+    t: 'event',
+    ec: 'add-on Interactions',
+    ea: 'browser startup',
+    el: installedCount
+  });
 };
 
 exports.onUnload = function(reason) {

--- a/addon/lib/metrics.js
+++ b/addon/lib/metrics.js
@@ -11,6 +11,7 @@ const Events = require('sdk/system/events');
 const PrefsService = require('sdk/preferences/service');
 const self = require('sdk/self');
 const store = require('sdk/simple-storage').storage;
+const request = require('sdk/request').Request;
 
 const seedrandom = require('seedrandom');
 
@@ -119,6 +120,13 @@ const Metrics = module.exports = {
       payload,
       { addClientId: true, addEnvironment: true }
     );
+
+    Metrics.sendGAEvent({
+      t: 'event',
+      ec: 'add-on Interactions',
+      ea: object,
+      el: eventName
+    });
   },
 
   experimentEnabled: function(addonId) {
@@ -142,6 +150,17 @@ const Metrics = module.exports = {
       data: JSON.stringify(dataParsed),
       subject: self.id
     });
+  },
+
+  sendGAEvent: function(data) {
+    data.v = 1; // Version -- https://developers.google.com/analytics/devguides/collection/protocol/v1/
+    data.tid = 'UA-49796218-47';
+    data.cid = store.clientUUID;
+    const req = request({
+      url: 'http://www.google-analytics.com/collect',
+      content: data
+    });
+    req.post();
   },
 
   onExperimentPing: function(ev) {

--- a/addon/test/test-metrics.js
+++ b/addon/test/test-metrics.js
@@ -28,12 +28,18 @@ const mocks = {
     Events: ['on', 'off', 'emit'],
     TelemetryController: ['submitExternalPing'],
     AddonManager: ['getAddonByID'],
+    request: ['post'],
     PrefsService: ['set', 'get']
   })
 };
 
 const mockLoader = MockUtils.loader(module, './lib/metrics.js', {
   './node_modules/seedrandom/index.js': mocks.callbacks.seedrandom.seedrandom,
+  'sdk/request': {
+    Request: function() {
+      return mocks.callbacks.request;
+    }
+  },
   'sdk/simple-storage': {storage: mocks.store},
   'sdk/system/events': mocks.callbacks.Events,
   'sdk/preferences/service': mocks.callbacks.PrefsService,


### PR DESCRIPTION
Couple TODOs
- [x] replace code with new one from @garethcull for the addon sends.
- [x] legal review including usage of `store.clientUUID`. Think we may be clear to  use this since we're no longer incorporating FxA ([Ref](https://github.com/mozilla/testpilot/blob/c401d646af6eb2102e1db4da7342572515638eca/addon/index.js#L344)).

Verification that these pings are coming through my GA test account

![ga proof](https://d3vv6lp55qjaqc.cloudfront.net/items/0T292t0K3s0V3U2q021F/Image%202016-09-15%20at%209.20.04%20AM.png?X-CloudApp-Visitor-Id=1739947&v=5ba80d4d)
