### PR TITLE
If necessary, prompt user to restart after add-on installation when using mozAddonManager (closes #1360).

### DIFF
--- a/frontend/src/app/actions/addon.js
+++ b/frontend/src/app/actions/addon.js
@@ -3,5 +3,6 @@ import { createActions } from 'redux-actions';
 export default createActions(
   {},
   'setHasAddon', 'setInstalled', 'setClientUuid',
-  'enableExperiment', 'disableExperiment'
+  'enableExperiment', 'disableExperiment',
+  'requireRestart'
 );

--- a/frontend/src/app/components/App.js
+++ b/frontend/src/app/components/App.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+
+
+class App extends Component {
+  render() {
+    const { addon } = this.props;
+    if (addon.restartRequired) {
+      return <p>Restart Required</p>;
+    }
+    return this.props.children;
+  }
+}
+
+
+export default connect(
+  state => ({
+    addon: state.addon
+  })
+)(App);

--- a/frontend/src/app/components/App.js
+++ b/frontend/src/app/components/App.js
@@ -1,12 +1,14 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import Restart from '../containers/Restart';
+
 
 class App extends Component {
   render() {
-    const { addon } = this.props;
-    if (addon.restartRequired) {
-      return <p>Restart Required</p>;
+    const { restart } = this.props.addon;
+    if (restart.isRequired) {
+      return <Restart experimentTitle={ restart.forExperiment }/>;
     }
     return this.props.children;
   }

--- a/frontend/src/app/components/ExperimentPage.js
+++ b/frontend/src/app/components/ExperimentPage.js
@@ -149,7 +149,8 @@ export default class ExperimentPage extends React.Component {
                 </h2>
                 <p data-l10n-id="experimentPromoSubheader">We're building next-generation features for Firefox. Install Test Pilot to try them!</p>
                 <MainInstallButton hasAddon={hasAddon} isFirefox={isFirefox}
-                                   eventCategory="HomePage Interactions" />
+                                   eventCategory="HomePage Interactions"
+                                   experimentTitle={title} />
               </div>
             </div>
           </div>

--- a/frontend/src/app/components/Header.js
+++ b/frontend/src/app/components/Header.js
@@ -22,8 +22,15 @@ export default class Header extends React.Component {
     };
   }
 
+  showSettings() {
+    if (this.props.forceHideSettings === false) {
+      return true;
+    }
+    return this.state.showSettings;
+  }
+
   render() {
-    const { showSettings, showRetireDialog, showDiscussDialog } = this.state;
+    const { showRetireDialog, showDiscussDialog } = this.state;
     const { hasAddon } = this.props;
 
     return (
@@ -43,10 +50,10 @@ export default class Header extends React.Component {
         {hasAddon &&
         <div data-hook="settings">
           <div className="settings-contain" data-hook="active-user">
-             <div className={classnames(['button', 'outline', 'settings-button'], { active: showSettings })}
+             <div className={classnames(['button', 'outline', 'settings-button'], { active: this.showSettings() })}
                   onClick={e => this.toggleSettings(e)}
                   data-hook="settings-button" data-l10n-id="menuTitle">Settings</div>
-               {showSettings && <div className="settings-menu" onClick={e => this.settingsClick(e)}>
+               {this.showSettings() && <div className="settings-menu" onClick={e => this.settingsClick(e)}>
                <ul>
                  <li><a onClickCapture={e => this.wiki(e)} data-l10n-id="menuWiki" data-hook="wiki"
                     href="https://wiki.mozilla.org/Test_Pilot" target="_blank">Test Pilot Wiki</a></li>
@@ -145,5 +152,6 @@ export default class Header extends React.Component {
 }
 
 Header.propTypes = {
-  hasAddon: React.PropTypes.bool
+  hasAddon: React.PropTypes.bool,
+  forceHideSettings: React.PropTypes.bool
 };

--- a/frontend/src/app/components/MainInstallButton.js
+++ b/frontend/src/app/components/MainInstallButton.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 
 import { installAddon } from '../lib/addon';
@@ -10,6 +10,13 @@ export default class MainInstallButton extends React.Component {
     this.state = {
       isInstalling: false
     };
+  }
+
+  install() {
+    const { eventCategory, hasAddon } = this.props;
+    if (hasAddon) { return; }
+    this.setState({ isInstalling: true });
+    installAddon(this.context.store, eventCategory);
   }
 
   render() {
@@ -49,11 +56,8 @@ export default class MainInstallButton extends React.Component {
       </div>
     );
   }
-
-  install() {
-    const { eventCategory, hasAddon } = this.props;
-    if (hasAddon) { return; }
-    this.setState({ isInstalling: true });
-    installAddon(eventCategory);
-  }
 }
+
+MainInstallButton.contextTypes = {
+  store: PropTypes.object.isRequired
+};

--- a/frontend/src/app/components/MainInstallButton.js
+++ b/frontend/src/app/components/MainInstallButton.js
@@ -12,16 +12,18 @@ export default class MainInstallButton extends React.Component {
     };
   }
 
-  install() {
+  install(evt, experimentTitle) {
     const { eventCategory, hasAddon } = this.props;
     if (hasAddon) { return; }
     this.setState({ isInstalling: true });
-    installAddon(this.context.store, eventCategory);
+    installAddon(this.context.store, eventCategory, experimentTitle);
   }
 
   render() {
     const { isFirefox, hasAddon } = this.props;
     const isInstalling = this.state.isInstalling && !hasAddon;
+    const experimentTitle = ('experimentTitle' in this.props &&
+                             this.props.experimentTitle);
 
     return (
       <div>
@@ -40,7 +42,7 @@ export default class MainInstallButton extends React.Component {
           </div>
         ) : (
           <div>
-            <button onClick={e => this.install(e)} data-hook="install"
+            <button onClick={e => this.install(e, experimentTitle)} data-hook="install"
                     className={classnames('button extra-large primary install', { 'state-change': isInstalling })}>
               {hasAddon && <span className="progress-btn-msg" data-l10n-id="landingInstallingButton">Installed</span>}
               {!hasAddon && !isInstalling &&

--- a/frontend/src/app/containers/Restart.js
+++ b/frontend/src/app/containers/Restart.js
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import Header from '../components/Header';
+import Footer from '../components/Footer';
+
+export default class Restart extends React.Component {
+  renderSubtitle() {
+    const { experimentTitle } = this.props;
+    if (experimentTitle) {
+      return (
+        <p data-l10n-id="restartRequiredFromExperiment">
+           data-l10n-args={JSON.stringify({ experimentTitle })}
+          Restart Firefox to enable { experimentTitle }.
+        </p>
+      );
+    }
+    return (
+      <p data-l10n-id="restartRequiredFromLanding">
+        Restart Firefox to choose your features.
+      </p>
+    );
+  }
+
+  render() {
+    return (
+      <div className="full-page-wrapper space-between">
+        <Header forceHideSettings={ false } />
+        <div className="centered-banner restart-message">
+          <h2 data-l10n-id="restartRequiredHeader">Test Pilot Installed!</h2>
+          { this.renderSubtitle() }
+        </div>
+        <footer id="main-footer" className="content-wrapper">
+          <Footer />
+        </footer>
+      </div>
+    );
+  }
+}

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -10,7 +10,7 @@ import { createHistory } from 'history';
 import { useRouterHistory } from 'react-router';
 import { syncHistoryWithStore, routerReducer, routerMiddleware } from 'react-router-redux';
 import { Provider } from 'react-redux';
-import { combineReducers, createStore, applyMiddleware } from 'redux';
+import { compose, combineReducers, createStore, applyMiddleware } from 'redux';
 
 import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
@@ -41,11 +41,14 @@ const store = createStore(
     addon: addonReducer
   }),
   {},
-  applyMiddleware(
-    thunk,
-    promise,
-    routerMiddleware(browserHistory),
-    createLogger()
+  compose(
+    applyMiddleware(
+      thunk,
+      promise,
+      routerMiddleware(browserHistory),
+      createLogger()
+    ),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
   )
 );
 

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -28,7 +28,7 @@ function mozAddonManagerInstall(url) {
   });
 }
 
-export function installAddon(store, eventCategory) {
+export function installAddon(store, eventCategory, experimentTitle) {
   const { protocol, hostname, port } = window.location;
   const path = '/static/addon/addon.xpi';
   const downloadUrl = `${protocol}//${hostname}${port ? ':' + port : ''}${path}`;
@@ -48,9 +48,8 @@ export function installAddon(store, eventCategory) {
   if (useMozAddonManager) {
     sendToGA('event', gaEvent);
     mozAddonManagerInstall(downloadUrl).then(() => {
-      console.log('Installed extension via mozAddonManager');
       if (RESTART_NEEDED) {
-        store.dispatch(addonActions.requireRestart());
+        store.dispatch(addonActions.requireRestart(experimentTitle));
       }
     });
   } else {
@@ -93,7 +92,6 @@ function watchForAddonInstallStateChange(store) {
 }
 
 export function sendMessage(type, data) {
-  console.log('TO ADDON', type, data);
   document.documentElement.dispatchEvent(new CustomEvent('from-web-to-addon', {
     bubbles: true,
     detail: { type, data }
@@ -112,8 +110,6 @@ export function disableExperiment(dispatch, experiment) {
 
 function messageReceived(store, evt) {
   const { type, data } = evt.detail;
-
-  console.log('FROM ADDON', type, data);
 
   const experimentsState = store.getState().experiments;
 

--- a/frontend/src/app/lib/router.js
+++ b/frontend/src/app/lib/router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Router, Route } from 'react-router';
+import { Router, Route, IndexRoute } from 'react-router';
 import { push as routerPush } from 'react-router-redux';
 import { connect } from 'react-redux';
 
@@ -8,6 +8,7 @@ import ExperimentsListPage from '../containers/ExperimentsListPage';
 import ExperimentPage from '../containers/ExperimentPage';
 import RetirePage from '../containers/RetirePage';
 
+import App from '../components/App';
 import LegacyPage from '../components/LegacyPage';
 import NotFoundPage from '../components/NotFoundPage';
 import SharePage from '../components/SharePage';
@@ -16,16 +17,18 @@ import OnboardingPage from '../components/OnboardingPage';
 
 const AppRouter = ({ history }) => (
   <Router history={history}>
-    <Route path="/" component={LandingPage} />
-    <Route path="/experiments/" component={ExperimentsListPage} />
-    <Route path="/experiments/:slug" component={ExperimentPage} />
-    <Route path="/legacy" component={LegacyPage} />
-    <Route path="/404" component={NotFoundPage} />
-    <Route path="/share" component={SharePage} />
-    <Route path="/error" component={ErrorPage} />
-    <Route path="/onboarding" component={OnboardingPage} />
-    <Route path="/retire" component={RetirePage} />
-    <Route path="*" component={NotFoundPage} />
+    <Route path="/" component={App}>
+      <IndexRoute component={LandingPage} />
+      <Route path="/experiments/" component={ExperimentsListPage} />
+      <Route path="/experiments/:slug" component={ExperimentPage} />
+      <Route path="/legacy" component={LegacyPage} />
+      <Route path="/404" component={NotFoundPage} />
+      <Route path="/share" component={SharePage} />
+      <Route path="/error" component={ErrorPage} />
+      <Route path="/onboarding" component={OnboardingPage} />
+      <Route path="/retire" component={RetirePage} />
+      <Route path="*" component={NotFoundPage} />
+    </Route>
   </Router>
 );
 

--- a/frontend/src/app/lib/router.js
+++ b/frontend/src/app/lib/router.js
@@ -7,6 +7,7 @@ import LandingPage from '../containers/LandingPage';
 import ExperimentsListPage from '../containers/ExperimentsListPage';
 import ExperimentPage from '../containers/ExperimentPage';
 import RetirePage from '../containers/RetirePage';
+import Restart from '../containers/Restart';
 
 import App from '../components/App';
 import LegacyPage from '../components/LegacyPage';
@@ -24,6 +25,7 @@ const AppRouter = ({ history }) => (
       <Route path="/legacy" component={LegacyPage} />
       <Route path="/404" component={NotFoundPage} />
       <Route path="/share" component={SharePage} />
+      <Route path="/restart" component={Restart} />
       <Route path="/error" component={ErrorPage} />
       <Route path="/onboarding" component={OnboardingPage} />
       <Route path="/retire" component={RetirePage} />

--- a/frontend/src/app/reducers/addon.js
+++ b/frontend/src/app/reducers/addon.js
@@ -19,7 +19,15 @@ const disableExperiment = (state, { payload: experiment }) => {
   return { ...state, installed: newInstalled };
 };
 
-const requireRestart = state => ({ ...state, restartRequired: true });
+const requireRestart = (state, { payload: experimentTitle }) => {
+  return {
+    ...state,
+    restart: {
+      isRequired: true,
+      forExperiment: experimentTitle || null
+    }
+  };
+};
 
 export const getInstalled = (state) => state.installed;
 
@@ -37,5 +45,8 @@ export default handleActions({
   hasAddon: false,
   installed: {},
   clientUUID: '',
-  restartRequired: false
+  restart: {
+    isRequired: false,
+    forExperiment: null
+  }
 });

--- a/frontend/src/app/reducers/addon.js
+++ b/frontend/src/app/reducers/addon.js
@@ -19,6 +19,8 @@ const disableExperiment = (state, { payload: experiment }) => {
   return { ...state, installed: newInstalled };
 };
 
+const requireRestart = state => ({ ...state, restartRequired: true });
+
 export const getInstalled = (state) => state.installed;
 
 export const isExperimentEnabled = (state, experiment) =>
@@ -29,9 +31,11 @@ export default handleActions({
   setInstalled,
   setClientUuid,
   enableExperiment,
-  disableExperiment
+  disableExperiment,
+  requireRestart
 }, {
   hasAddon: false,
   installed: {},
-  clientUUID: ''
+  clientUUID: '',
+  restartRequired: false
 });

--- a/frontend/src/styles/modules/_banners.scss
+++ b/frontend/src/styles/modules/_banners.scss
@@ -133,3 +133,23 @@
     }
   }
 }
+
+.restart-message {
+  h2 {
+    @include respond-to('not-small') {
+      font-size: $font-unit * 4;
+      margin-bottom: $grid-unit * .5;
+    }
+
+    font-style: italic;
+    margin: 0;
+  }
+
+  p {
+    @include respond-to('not-small') {
+      font-size: $font-unit * 1.75;
+    }
+
+    margin: 0;
+  }
+}

--- a/frontend/tasks/server.js
+++ b/frontend/tasks/server.js
@@ -2,12 +2,14 @@ const gulp = require('gulp');
 const config = require('../config.js');
 
 const connect = require('gulp-connect');
+const historyApiFallback = require('connect-history-api-fallback');
 
 gulp.task('server', () => {
   connect.server({
     root: config.DEST_PATH,
     livereload: false,
     host: '0.0.0.0',
-    port: config.SERVER_PORT
+    port: config.SERVER_PORT,
+    middleware: (connect, ops) => [historyApiFallback({})]
   });
 });

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -143,6 +143,10 @@ shareCopy = Copy
 
 eolMessage = <strong>This experiment is ending on {$completedDate}</strong>.<br/><br/>After then you will still be able to use {$title} but we will no longer be providing updates or support.
 
+restartRequiredHeader = Test Pilot Installed!
+restartRequiredFromLanding = Restart Firefox to choose your features.
+restartRequiredFromExperiment = Restart Firefox to enable {$experimentTitle}.
+
 # TODO: these strings are not currently localized.
 # They are served by the python static dir
 # and will need python-l20n implementation for coverage

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babelify": "^7.3.0",
     "browserify": "^11.0.1",
     "budo": "^7.1.0",
+    "connect-history-api-fallback": "^1.3.0",
     "coverify": "^1.4.1",
     "del": "2.0.2",
     "doctoc": "1.0.0",


### PR DESCRIPTION
~~This is WIP, getting it out there so it's easy to follow progress.~~
## Screencaps

As of ab498de, here's what the e10s experience looks like:
- [In 49 with e10s, where a restart is required](https://vid.me/rrPw)
- [In 50 with e10s, where a restart is not required](https://vid.me/LLC8)

As of d1cced6, showing the two reboot flows:
- [When installing from the landing page](https://vid.me/4Mq9)
- [When installing from an experiment page](https://vid.me/Wm3N)
## TODO
- [x] Detect necessary post-install restarts.
- [x] Prompt user for restart if necessary.
- [x] Make the prompt look [like this](https://cloud.githubusercontent.com/assets/3323249/18564740/3965abe2-7b8d-11e6-95fe-1e62d07c0930.png).
- ~~On add-on first run, if there are no open test Test Pilot tabs, open one.~~ (#1374)
- ~~Instrument this process (TBD @johngruen @ckprice)~~ (#1375)
## Testing this

To test this flow locally, you'll need a few things:
- Firefox === 49
- New profile
- No add-ons installed
- `browser.tabs.remote.force-enable` set to `false`
- `browser.tabs.remote.autostart` set to `true`
- You must use a signed copy of the add-on. Download the XPI from the production site, and move it to `/frontend/build/static/addon/addon.xpi`. You may need to do this multiple times as the gulp task rebuilds the site.
- The [full SSL proxy setup from the `mozAddonManager` PR](https://github.com/mozilla/testpilot/pull/1330#issuecomment-245821762).

You can verify that e10s is enabled by going to about:support and looking for the `Multiprocess Windows` value; you want it to be greater than 0.
