### PR TITLE
add launch date to yaml (closes #1393)

### DIFF
--- a/content-src/experiments/activity-stream.yaml
+++ b/content-src/experiments/activity-stream.yaml
@@ -86,4 +86,5 @@ contributors:
 installation_count: 46732
 created: '2016-03-11T21:05:59.363520Z'
 modified: '2016-09-06T18:30:42.286466Z'
+launch_date: '2016-03-11T21:05:59.363520Z'
 order: 1

--- a/content-src/experiments/no-more-404s.yaml
+++ b/content-src/experiments/no-more-404s.yaml
@@ -61,4 +61,5 @@ contributors:
 installation_count: 20377
 created: '2016-08-03T17:25:54.612365Z'
 modified: '2016-08-30T21:59:49.015500Z'
+launch_date: '2016-08-03T17:25:54.612365Z'
 order: 0

--- a/content-src/experiments/tab-center.yaml
+++ b/content-src/experiments/tab-center.yaml
@@ -65,4 +65,5 @@ contributors:
 installation_count: 29870
 created: '2016-04-28T00:07:28.847430Z'
 modified: '2016-08-19T16:51:12.188781Z'
+launch_date: '2016-04-28T00:07:28.847430Z'
 order: 2

--- a/content-src/experiments/universal-search.yaml
+++ b/content-src/experiments/universal-search.yaml
@@ -58,4 +58,5 @@ contributors:
 installation_count: 39943
 created: '2016-04-28T03:57:32.270681Z'
 modified: '2016-07-20T15:42:28.873321Z'
+launch_date: '2016-04-28T03:57:32.270681Z'
 order: 3

--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -1,4 +1,6 @@
 export default {
   experimentsURL: '/api/experiments.json',
-  usageCountsURL: 'https://analysis-output.telemetry.mozilla.org/testpilot/data/installation-counts/latest.json'
+  usageCountsURL: 'https://analysis-output.telemetry.mozilla.org/testpilot/data/installation-counts/latest.json',
+  productionURL: 'https://testpilot.firefox.com',
+  stagingURL: 'dev'
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "js-cookie": "2.1.1",
     "l20n": "4.0.0-alpha.3",
     "micro-email-validator": "0.0.1",
+    "moment": "^2.15.1",
     "mustache": "^2.1.3",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",


### PR DESCRIPTION
this adds a utc time stamped `launch_date` key to experiment data. 

if you're working on dev or local, this is ignored...on stage and prod, pre-launch experiments are filtered out of `experiments.fetch`
