### PR TITLE
Add missing GA metric pings

### DIFF
--- a/frontend/src/app/actions/addon.js
+++ b/frontend/src/app/actions/addon.js
@@ -1,8 +1,13 @@
 import { createActions } from 'redux-actions';
 
 export default createActions(
-  {},
-  'setHasAddon', 'setInstalled', 'setClientUuid',
+  {
+    setInstalled: installed => ({
+      installed: installed || {},
+      installedLoaded: !!installed
+    })
+  },
+  'setHasAddon', 'setClientUuid',
   'enableExperiment', 'disableExperiment',
   'requireRestart'
 );

--- a/frontend/src/app/actions/experiments.js
+++ b/frontend/src/app/actions/experiments.js
@@ -15,6 +15,7 @@ export default createActions({
       .then(response => response.json())
       .then(counts => ({
         lastFetched: Date.now(),
+        experimentsLoaded: true,
         experiments: experiments.map(experiment => ({
           ...experiment,
           installation_count: counts[experiment.addon_id]

--- a/frontend/src/app/components/ExperimentPage.js
+++ b/frontend/src/app/components/ExperimentPage.js
@@ -21,8 +21,8 @@ export default class ExperimentPage extends React.Component {
   constructor(props) {
     super(props);
 
-    const { isExperimentEnabled } = this.props;
-    const experiment = this.findCurrentExperiment(props);
+    const { isExperimentEnabled, getExperimentBySlug } = this.props;
+    const experiment = getExperimentBySlug(this.props.params.slug);
 
     this.state = {
       experiment,
@@ -44,12 +44,12 @@ export default class ExperimentPage extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     const { shouldShowTourDialog, enabled: prevEnabled } = this.state;
-    const { isExperimentEnabled } = nextProps;
+    const { isExperimentEnabled, getExperimentBySlug } = nextProps;
 
-    const prevExperiment = this.findCurrentExperiment(this.props);
+    const prevExperiment = getExperimentBySlug(this.props.params.slug);
     const prevInProgress = prevExperiment && prevExperiment.inProgress;
 
-    const nextExperiment = this.findCurrentExperiment(nextProps);
+    const nextExperiment = getExperimentBySlug(nextProps.params.slug);
     const nextInProgress = nextExperiment && nextExperiment.inProgress;
     const nextEnabled = nextExperiment && isExperimentEnabled(nextExperiment);
 
@@ -76,18 +76,6 @@ export default class ExperimentPage extends React.Component {
         showTourDialog
       });
     }
-  }
-
-  findCurrentExperiment(props) {
-    const { params, experiments } = props;
-
-    if (experiments.length === 0) { return null; }
-
-    const currentExperiment = experiments
-      .filter(experiment => experiment.slug === params.slug);
-
-    // Grab the matched experiment.
-    return currentExperiment[0];
   }
 
   isValidVersion(min) {

--- a/frontend/src/app/components/RetireConfirmationDialog.js
+++ b/frontend/src/app/components/RetireConfirmationDialog.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { uninstallAddon } from '../lib/addon';
+import { sendToGA } from '../lib/utils';
 
 export default class RetireConfirmationDialog extends React.Component {
   render() {
@@ -28,6 +29,11 @@ export default class RetireConfirmationDialog extends React.Component {
   proceed(e) {
     e.preventDefault();
     uninstallAddon();
+    sendToGA('event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'Retire'
+    });
     this.props.navigateTo('/retire');
   }
 

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -4,7 +4,7 @@ import { push as routerPush } from 'react-router-redux';
 import ExperimentPage from '../components/ExperimentPage';
 
 import { getInstalled, isExperimentEnabled } from '../reducers/addon';
-import { getExperiments } from '../reducers/experiments';
+import { getExperiments, getExperimentBySlug } from '../reducers/experiments';
 import { enableExperiment, disableExperiment } from '../lib/addon';
 
 export default connect(
@@ -13,6 +13,8 @@ export default connect(
     isFirefox: state.browser.isFirefox,
     hasAddon: state.addon.hasAddon,
     installed: getInstalled(state.addon),
+    getExperimentBySlug: slug =>
+      getExperimentBySlug(state.experiments, slug),
     isExperimentEnabled: experiment =>
       isExperimentEnabled(state.addon, experiment)
   }),

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -39,7 +39,18 @@ const store = createStore(
     browser: browserReducer,
     addon: addonReducer
   }),
-  {},
+  {
+    addon: {
+      hasAddon: !!window.navigator.testpilotAddon,
+      installed: {},
+      installedLoaded: false,
+      clientUUID: '',
+      restart: {
+        isRequired: false,
+        forExperiment: null
+      }
+    }
+  },
   compose(
     applyMiddleware(
       thunk,

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -76,7 +76,7 @@ export function setupAddonConnection(store) {
 // Periodically check window.navigator.testpilotAddon and keep store in sync
 let installStateWatcherTimer = null;
 function watchForAddonInstallStateChange(store) {
-  store.dispatch(addonActions.setHasAddon(window.navigator.testpilotAddon));
+  store.dispatch(addonActions.setHasAddon(!!window.navigator.testpilotAddon));
 
   if (installStateWatcherTimer) {
     clearInterval(installStateWatcherTimer);

--- a/frontend/src/app/lib/router.js
+++ b/frontend/src/app/lib/router.js
@@ -3,6 +3,10 @@ import { Router, Route, IndexRoute } from 'react-router';
 import { push as routerPush } from 'react-router-redux';
 import { connect } from 'react-redux';
 
+import { sendToGA } from '../lib/utils';
+import { getInstalled, isExperimentEnabled, isInstalledLoaded } from '../reducers/addon';
+import { getExperimentBySlug, isExperimentsLoaded } from '../reducers/experiments';
+
 import LandingPage from '../containers/LandingPage';
 import ExperimentsListPage from '../containers/ExperimentsListPage';
 import ExperimentPage from '../containers/ExperimentPage';
@@ -38,29 +42,88 @@ const AppRouter = ({ history }) => (
 class BaseAppRedirector extends React.Component {
 
   performRedirects() {
-    const { dispatch, routing, hasAddon, isFirefox } = this.props;
+    const { routing, hasAddon, isFirefox, navigateTo } = this.props;
     const location = routing.locationBeforeTransitions;
     if (location.pathname === '/' && (hasAddon && isFirefox)) {
-      dispatch(routerPush('/experiments/'));
+      navigateTo('/experiments/');
     }
     if (location.pathname === 'experiments/' && (!hasAddon || !isFirefox)) {
-      dispatch(routerPush('/'));
+      navigateTo('/');
     }
+  }
+
+  measurePageview() {
+    const { routing, hasAddon, installed, installedLoaded, experimentsLoaded } = this.props;
+
+    // Wait until experiments are loaded
+    if (!experimentsLoaded) { return; }
+
+    // If we have an addon, wait until the installed experiments are loaded
+    if (hasAddon && !installedLoaded) { return; }
+
+    const { pathname } = routing.locationBeforeTransitions;
+
+    const experimentsPath = 'experiments/';
+
+    if (pathname === '/') {
+      const installedCount = Object.keys(installed).length;
+      const anyInstalled = installedCount > 0;
+      this.debounceSendToGA(pathname, 'pageview', {
+        dimension1: hasAddon,
+        dimension2: anyInstalled,
+        dimension3: installedCount
+      });
+    } else if (pathname === experimentsPath) {
+      this.debounceSendToGA(pathname, 'pageview', {
+        dimension1: hasAddon
+      });
+    } else if (pathname.indexOf(experimentsPath) === 0) {
+      const slug = pathname.substring(experimentsPath.length);
+      const experiment = this.props.getExperimentBySlug(slug);
+      this.debounceSendToGA(pathname, 'pageview', {
+        dimension1: hasAddon,
+        dimension4: isExperimentEnabled(experiment),
+        dimension5: experiment.title,
+        dimension6: experiment.installation_count
+      });
+    }
+  }
+
+  debounceSendToGA(pathname, type, data) {
+    if (this.lastPingPathname === pathname) { return; }
+    this.lastPingPathname = pathname;
+    sendToGA(type, data);
   }
 
   constructor(props) {
     super(props);
     // Static router created at construction, because it does not accept prop updates.
     this.router = <AppRouter history={props.history} />;
+    this.lastPingPathname = null;
   }
+
   render() { return this.router; }
-  componentDidUpdate() { this.performRedirects(); }
+
+  componentDidUpdate() {
+    this.performRedirects();
+    this.measurePageview();
+  }
 }
 
 export default connect(
   state => ({
     routing: state.routing,
+    experimentsLoaded: isExperimentsLoaded(state.experiments),
     isFirefox: state.browser.isFirefox,
-    hasAddon: state.addon.hasAddon
+    hasAddon: state.addon.hasAddon,
+    installed: getInstalled(state.addon),
+    installedLoaded: isInstalledLoaded(state.addon),
+    getExperimentBySlug: slug =>
+      getExperimentBySlug(state.experiments, slug),
+    isExperimentEnabled: experiment =>
+      isExperimentEnabled(state.addon, experiment)
+  }),
+  dispatch => ({
+    navigateTo: path => dispatch(routerPush(path))
   })
 )((props) => <BaseAppRedirector {...props} />);

--- a/frontend/src/app/reducers/addon.js
+++ b/frontend/src/app/reducers/addon.js
@@ -2,8 +2,8 @@ import { handleActions } from 'redux-actions';
 
 const setHasAddon = (state, { payload: hasAddon }) => ({ ...state, hasAddon });
 
-const setInstalled = (state, { payload: installed }) =>
-  ({ ...state, installed: (installed || {}) });
+const setInstalled = (state, { payload: { installed, installedLoaded } }) =>
+  ({ ...state, installed, installedLoaded });
 
 const setClientUuid = (state, { payload: clientUUID }) => ({ ...state, clientUUID });
 
@@ -32,7 +32,9 @@ const requireRestart = (state, { payload: experimentTitle }) => {
 export const getInstalled = (state) => state.installed;
 
 export const isExperimentEnabled = (state, experiment) =>
-  (experiment && experiment.addon_id in state.installed);
+  !!(experiment && experiment.addon_id in state.installed);
+
+export const isInstalledLoaded = (state) => state.installedLoaded;
 
 export default handleActions({
   setHasAddon,
@@ -44,6 +46,7 @@ export default handleActions({
 }, {
   hasAddon: false,
   installed: {},
+  installedLoaded: false,
   clientUUID: '',
   restart: {
     isRequired: false,

--- a/frontend/src/app/reducers/experiments.js
+++ b/frontend/src/app/reducers/experiments.js
@@ -1,7 +1,7 @@
 import { handleActions } from 'redux-actions';
 
-const fetchExperiments = (state, { payload: { lastFetched, experiments } }) =>
-  ({ ...state, lastFetched, experiments });
+const fetchExperiments = (state, { payload: { lastFetched, experimentsLoaded, experiments } }) =>
+  ({ ...state, lastFetched, experimentsLoaded, experiments });
 
 const updateExperiment = (state, { payload: { addonID, data } }) => ({
   ...state,
@@ -16,16 +16,22 @@ export const getExperimentsLastFetched = (state) => state.lastFetched;
 export const getExperimentByID = (state, addonID) =>
   state.experiments.filter(e => e.addon_id === addonID)[0];
 
+export const getExperimentBySlug = (state, filter) =>
+  state.experiments.filter(e => e.slug === filter)[0];
+
 export const getExperimentByURL = (state, url) =>
   state.experiments.filter(e => e.xpi_url === url)[0];
 
 export const getExperimentInProgress = (state) =>
   state.experiments.filter(e => e.inProgress)[0];
 
+export const isExperimentsLoaded = (state) => state.experimentsLoaded;
+
 export default handleActions({
   fetchExperiments,
   updateExperiment
 }, {
   experiments: [],
+  experimentsLoaded: false,
   lastFetched: null
 });


### PR DESCRIPTION
- send event for "Proceed" clicked in Retire dialog
- for landing page, experiments list, and experiments page
- add flags in store to indicate whether experiments list and and
  installed status are loaded
- isInstalledLoaded, isExperimentsLoaded, getExperimentBySlug selectors

Issue #1346
