### PR TITLE
Disable tracking protection while blok is enabled

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -15,6 +15,7 @@ const { PrefsTarget } = require('sdk/preferences/event-target');
 const URL = require('sdk/url').URL;
 
 const { App } = require('./lib/app');
+const ExperimentHacks = require('./lib/experiment-hacks');
 const ExperimentNotifications = require('./lib/experiment-notifications');
 const FirstRun = require('./lib/first-run');
 const Metrics = require('./lib/metrics');
@@ -157,6 +158,11 @@ function experimentsLoaded(experiments) {
 function setAddonActiveState(addon) {
   const xp = store.availableExperiments[addon.id];
   if (xp) { delete xp.active; }
+  if (addon.isActive) {
+    ExperimentHacks.enabled(addon.id);
+  } else {
+    ExperimentHacks.disabled(addon.id);
+  }
   store.installedAddons[addon.id] = Object.assign({
     active: addon.isActive,
     installDate: addon.installDate
@@ -180,11 +186,6 @@ function installExperiment(experiment) {
 }
 
 function uninstallSelf() {
-  // First, kick out all the experiment add-ons
-  Object.keys(store.installedAddons).forEach(id => {
-    uninstallExperiment({addon_id: id});
-  });
-  // Then, uninstall ourselves
   AddonManager.getAddonByID(self.id, a => a.uninstall());
 }
 
@@ -253,6 +254,7 @@ const addonListener = {
         name: addon.name,
         version: addon.version
       });
+      ExperimentHacks.uninstalling(addon.id);
     }
   },
   onUninstalled: function(addon) {
@@ -361,6 +363,7 @@ exports.onUnload = function(reason) {
     if (store.installedAddons) {
       Object.keys(store.installedAddons).forEach(id => {
         uninstallExperiment({addon_id: id});
+        ExperimentHacks.uninstalled(id);
       });
       delete store.installedAddons;
     }

--- a/addon/lib/experiment-hacks.js
+++ b/addon/lib/experiment-hacks.js
@@ -1,0 +1,47 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the 'License'). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+const PrefsService = require('sdk/preferences/service');
+const store = require('sdk/simple-storage').storage;
+
+const BLOK_ID = 'blok@mozilla.org';
+const TP_PREFS = [
+  'privacy.trackingprotection.enabled',
+  'privacy.trackingprotection.pbmode.enabled',
+  'services.sync.prefs.sync.privacy.trackingprotection.enabled',
+  'services.sync.prefs.sync.privacy.trackingprotection.pbmode.enabled'
+];
+
+function enableBlok(id) {
+  if (id !== BLOK_ID) { return; }
+  if (!store.tpPrefs) {
+    store.tpPrefs = TP_PREFS.map(name => [name, PrefsService.get(name)]);
+  }
+  TP_PREFS.forEach(name => { PrefsService.set(name, false); });
+}
+
+function disableBlok(id) {
+  if (id !== BLOK_ID) { return; }
+  if (store.tpPrefs) {
+    store.tpPrefs.forEach(pair => { PrefsService.set(pair[0], pair[1]); });
+    delete store.tpPrefs;
+  }
+}
+
+module.exports = {
+  enabled(id) {
+    enableBlok(id);
+  },
+  disabled(id) {
+    disableBlok(id);
+  },
+  uninstalling(id) {
+    disableBlok(id);
+  },
+  uninstalled(id) {
+    disableBlok(id);
+  }
+};

--- a/addon/test/test-experiment-hacks.js
+++ b/addon/test/test-experiment-hacks.js
@@ -1,0 +1,123 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the "License"). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+const { before } = require('sdk/test/utils');
+const MockUtils = require('./lib/mock-utils');
+
+// TODO: Remove this / switch based on --verbose switch?
+MockUtils.setDebug(true);
+
+const BLOK_ID = 'blok@mozilla.org';
+const mocks = {
+  store: {},
+  callbacks: MockUtils.callbacks({
+    PrefsService: ['get', 'set']
+  })
+};
+const TP_PREFS = [
+  'privacy.trackingprotection.enabled',
+  'privacy.trackingprotection.pbmode.enabled',
+  'services.sync.prefs.sync.privacy.trackingprotection.enabled',
+  'services.sync.prefs.sync.privacy.trackingprotection.pbmode.enabled'
+];
+
+const mockLoader = MockUtils.loader(module, './lib/experiment-hacks.js', {
+  'sdk/simple-storage': { storage: mocks.store },
+  'sdk/preferences/service': mocks.callbacks.PrefsService
+});
+
+const hacks = mockLoader.require('../lib/experiment-hacks');
+
+exports['test fresh enabled with blok id'] = assert => {
+  const expected = TP_PREFS.map(p => [p, true]);
+  mocks.callbacks.PrefsService.get.implement(() => true);
+
+  hacks.enabled(BLOK_ID);
+
+  const gets = mocks.callbacks.PrefsService.get.calls();
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(gets.length, 4, 'got original prefs');
+  assert.equal(sets.length, 4, 'set prefs');
+  sets.forEach((set, i) => {
+    assert.equal(set[0], TP_PREFS[i]);
+    assert.equal(set[1], false, `${set[0]} set to false`);
+  });
+  assert.deepEqual(mocks.store.tpPrefs, expected, 'prefs set as expected');
+};
+
+exports['test enabled with blok id when already set'] = assert => {
+  const expected = TP_PREFS.map(p => [p, true]);
+  mocks.callbacks.PrefsService.get.implement(() => true);
+  // once to set
+  hacks.enabled(BLOK_ID);
+  MockUtils.resetCallbacks(mocks.callbacks);
+  // another to test
+  hacks.enabled(BLOK_ID);
+  const gets = mocks.callbacks.PrefsService.get.calls();
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(gets.length, 0, 'no gets called');
+  assert.equal(sets.length, 4, 'set prefs');
+  sets.forEach((set, i) => {
+    assert.equal(set[0], TP_PREFS[i]);
+    assert.equal(set[1], false, `${set[0]} set to false`);
+  });
+  assert.deepEqual(mocks.store.tpPrefs, expected, 'prefs set as expected');
+};
+
+exports['test enabled with non-blok id'] = assert => {
+  hacks.enabled('foo');
+
+  const gets = mocks.callbacks.PrefsService.get.calls();
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(gets.length, 0, 'got original prefs');
+  assert.equal(sets.length, 0, 'set prefs');
+  assert.equal(mocks.store.tpPrefs, undefined);
+};
+
+exports['test disabled after enabled with blok id'] = assert => {
+  mocks.callbacks.PrefsService.get.implement(() => true);
+
+  hacks.enabled(BLOK_ID);
+  MockUtils.resetCallbacks(mocks.callbacks);
+  hacks.disabled(BLOK_ID);
+
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(sets.length, 4, 'set prefs');
+  sets.forEach((set, i) => {
+    assert.equal(set[0], TP_PREFS[i]);
+    assert.equal(set[1], true, `${set[0]} set to true`);
+  });
+  assert.equal(mocks.store.tpPrefs, undefined, 'tpPrefs was cleared');
+};
+
+exports['test disabled without enabled'] = assert => {
+  hacks.disabled(BLOK_ID);
+
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(sets.length, 0, 'no set prefs');
+  assert.equal(mocks.store.tpPrefs, undefined);
+};
+
+exports['test disabled non-blok id'] = assert => {
+  const expected = TP_PREFS.map(p => [p, true]);
+  mocks.callbacks.PrefsService.get.implement(() => true);
+
+  hacks.enabled(BLOK_ID);
+  MockUtils.resetCallbacks(mocks.callbacks);
+  hacks.disabled('foo');
+
+  const sets = mocks.callbacks.PrefsService.set.calls();
+  assert.equal(sets.length, 0, 'no set prefs');
+  assert.deepEqual(mocks.store.tpPrefs, expected);
+};
+
+before(module.exports, function(name, assert, done) {
+  MockUtils.resetCallbacks(mocks.callbacks);
+  delete mocks.store.tpPrefs;
+  done();
+});
+
+require('sdk/test').run(module.exports);


### PR DESCRIPTION
Fixes #1333

This doesn't cover the edge cases where a user disables Test Pilot from about:addons then disables or removes Blok.
