### PR TITLE
set isMinFirefox on ExperimentPage

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -11,6 +11,7 @@ export default connect(
   state => ({
     experiments: getExperiments(state.experiments),
     isFirefox: state.browser.isFirefox,
+    isMinFirefox: state.browser.isMinFirefox,
     isDev: state.browser.isDev,
     hasAddon: state.addon.hasAddon,
     installed: getInstalled(state.addon),


### PR DESCRIPTION
Without this the "Upgrade Firefox" button is always shown on experiment pages when the addon is not installed.
