### PR TITLE
Improve forced first-run restart behavior

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -334,11 +334,11 @@ exports.main = function(options) {
   ToolbarButton.init(settings);
   ExperimentNotifications.init();
   SharePrompt.init(settings);
-  FirstRun.setup(options.reason, settings);
 
-  if (reason === 'install') {
+  if (reason === 'install' || (reason === 'startup' && FirstRun.isFirstRun())) {
     openOnboardingTab();
   }
+  FirstRun.setup(options.reason, settings);
 
   const installedCount = (store.installedAddons) ? Object.keys(store.installedAddons).length : 0;
   Metrics.sendGAEvent({

--- a/addon/lib/first-run.js
+++ b/addon/lib/first-run.js
@@ -39,7 +39,7 @@ module.exports = {
 
   openTestPilot(settings) {
     tabs.open({
-      url: `${settings.BASE_URL}?${this.utm}`
+      url: `${settings.BASE_URL}/experiments/?${this.utm}`
     });
   },
 

--- a/frontend/src/app/components/ExperimentsListPage.js
+++ b/frontend/src/app/components/ExperimentsListPage.js
@@ -13,7 +13,8 @@ export default class ExperimentsListPage extends React.Component {
     super(props);
 
     let showEmailDialog = false;
-    if (cookies.get('first-run')) {
+    if (cookies.get('first-run') ||
+        window.location.search.indexOf('utm_campaign=restart-required') > -1) {
       cookies.remove('first-run');
       showEmailDialog = true;
     }

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -54,11 +54,10 @@ export function installAddon(store, eventCategory, experimentTitle) {
       }
     });
   } else {
+    cookies.set('first-run', 'true');
     gaEvent.outboundURL = downloadUrl;
     sendToGA('event', gaEvent);
   }
-
-  cookies.set('first-run', 'true');
 }
 
 export function uninstallAddon() {


### PR DESCRIPTION
This does two things: 
- Always show the onboarding tab after a first-run restart (closes #1419).
- Always show the email modal on the tab opened after a first-run restart (closes #1422).

Hoping to find a way to improve upon the existing detection for #1420, but there's a weird timing issue that isn't blocking.
