### PR TITLE
Disable integration test on CircleCI for now

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,7 +44,7 @@ dependencies:
 test:
   override:
     - '[[ " $TESTPILOT_STATIC_BRANCHES " =~ " $CIRCLE_BRANCH " ]] || ./bin/circleci/run-server-unit-tests.sh'
-    - ./bin/circleci/run-integration-tests.sh
+    # - ./bin/circleci/run-integration-tests.sh
 
 # appropriately tag and push the container to dockerhub
 deployment:


### PR DESCRIPTION
The single integration test we have for add-on installation on Firefox 48 seems to be failing intermittently for no real issue that I can reproduce outside of CircleCI. Maybe we should disable it for now and get it out of our way? With the longer timeout, it's just adding 60 seconds before reporting failure.
