### PR TITLE
Fix canonical & social image URL paths for static experiment pages

### DIFF
--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -11,7 +11,7 @@
     <meta name="viewport" content="width=device-width">
     <link rel="localization" href="/static/locales/{locale}/app.ftl">
 
-    <link rel="canonical" href="https://testpilot.firefox.com/">
+    <link rel="canonical" href="https://testpilot.firefox.com/{{{ canonical_path }}}">
 
     <title>{{ meta_title }}</title>
     <meta property="og:title" content="{{ meta_title }}" />
@@ -20,8 +20,8 @@
     <meta property="og:description" content="{{ meta_description }}" />
     <meta name="twitter:description" content="{{ meta_description }}" />
     <meta name="twitter:card" content="summary" />
-    <meta property="og:image" content="{{ image_facebook }}" />
-    <meta name="twitter:image" content="{{ image_twitter }}" />
+    <meta property="og:image" content="{{{ image_facebook }}}" />
+    <meta name="twitter:image" content="{{{ image_twitter }}}" />
 </head>
 <body class="blue">
   <div class="stars"></div>

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -59,6 +59,7 @@ function buildLandingPage() {
     const pageContent = Mustache.render(template, {
       meta_title: 'Firefox Test Pilot',
       meta_description: 'Test new Features. Give us feedback. Help build Firefox.',
+      canonical_path: '',
       image_facebook: THUMBNAIL_FACEBOOK,
       image_twitter: THUMBNAIL_TWITTER,
       enable_pontoon: config.ENABLE_PONTOON
@@ -78,6 +79,7 @@ function buildExperimentPage() {
     const pageContent = Mustache.render(indexTemplate, {
       meta_title: 'Firefox Test Pilot - ' + experiment.title,
       meta_description: experiment.description,
+      canonical_path: 'experiments/' + experiment.slug + '/',
       image_facebook: experiment.image_facebook || THUMBNAIL_FACEBOOK,
       image_twitter: experiment.image_twitter || THUMBNAIL_TWITTER,
       enable_pontoon: config.ENABLE_PONTOON


### PR DESCRIPTION
- Point canonical header link to prod experiment page path
- Un-escape canonical and social image paths
