### PR TITLE
update min-vid xpi url

### DIFF
--- a/content-src/experiments/min-vid.yaml
+++ b/content-src/experiments/min-vid.yaml
@@ -14,7 +14,7 @@ bug_report_url: 'https://github.com/meandavejustice/min-vid/issues'
 discourse_url: 'https://discourse.mozilla-community.org/c/test-pilot/min-vid'
 privacy_notice_url: 'https://github.com/meandavejustice/min-vid/blob/master/docs/metrics.md'
 measurements: "<p>In addition to the <a href=\"/privacy\">data</a> collected by all Test Pilot experiments, here are the key things you should know about what is happening when you use Min Vid:</p>\n<ul>\n<li>We collect usage data when you engage with the context menu, experiment icon and player controls.</li>\n<li>We also collect data on the number of times you encounter a playable video, the number of times you played the video and the video service that provided the video. This helps us understand how useful our users are finding the experiment.</li>\n<li>We do not collect information about the specific videos you encounter.</li>\n</ul>"
-xpi_url: 'https://testpilot.firefox.com/files/min-vid/min-vid-0.2.0-fx.xpi'
+xpi_url: 'https://testpilot.firefox.com/files/min-vid/min-vid-0.3.0-fx.xpi'
 addon_id: @min-vid
 gradient_start: '#FED66F'
 gradient_stop: '#FD667B'


### PR DESCRIPTION
The 0.2.0 .xpi is at that URL right now, just so this doesn't 404.  I'll update the .xpi as soon as we have another one.
