### PR TITLE
Ensure frontend state updates when add-on uninstalled

### DIFF
--- a/addon/data/set-installed-flag.js
+++ b/addon/data/set-installed-flag.js
@@ -10,3 +10,8 @@
 
 unsafeWindow.navigator.testpilotAddon = true;
 unsafeWindow.navigator.testpilotAddonVersion = self.options.version;
+
+self.port.on('detach', function() {
+  delete unsafeWindow.navigator.testpilotAddon;
+  delete unsafeWindow.navigator.testpilotAddonVersion;
+});

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/frontend/src/app/components/RetirePage.js
+++ b/frontend/src/app/components/RetirePage.js
@@ -20,6 +20,7 @@ export default class RetirePage extends React.Component {
   componentDidMount() {
     this.fakeUninstallTimer = setTimeout(() => {
       this.setState({ fakeUninstalled: true });
+      window.navigator.testpilotAddon = false;
     }, FAKE_UNINSTALL_DELAY);
   }
 
@@ -32,6 +33,9 @@ export default class RetirePage extends React.Component {
     const { fakeUninstalled } = this.state;
 
     const uninstalled = !hasAddon || fakeUninstalled;
+    if (uninstalled) {
+      clearTimeout(this.fakeUninstallTimer);
+    }
 
     return (
       <div className="full-page-wrapper centered">


### PR DESCRIPTION
- Set `window.navigator.testpilotAddon` to `false` on add-on uninstall
- Set `window.navigator.testpilotAddon` to `false` in retire dialog if
  add-on hasn't notified of uninstall within 5 seconds

Fixes #1429
