### PR TITLE
Add S3 deploy script with custom headers

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# This file is used to deploy Test Pilot to an S3 bucket.  It expects to be run
+# from the root of the Test Pilot directory and you'll need your S3 bucket name
+# in an environment variable $TESTPILOT_BUCKET
+
+# Questions?  Hit up #testpilot on IRC
+
+if [ ! -d "dist" ]; then
+    echo "Can't find /dist/ directory.  Are you running from the Test Pilot root?"
+    exit 1
+fi
+
+if [ -z "$TESTPILOT_BUCKET" ]; then
+    echo "The S3 bucket is not set. Failing."
+    exit 1
+fi
+
+
+# The basic strategy is to sync all the files that need special attention
+# first, and then sync everything else which will get defaults
+
+
+# For short-lived assets; in seconds
+MAX_AGE="600"
+
+HPKP="\"x-amz-meta-public-key-pins\": \"max-age=300;pin-sha256='WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=';pin-sha256='r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E='\""
+CSP="\"x-amz-meta-content-security-policy\": \"default-src 'self'; connect-src 'self' analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; object-src 'none'; script-src 'self' www.google-analytics.com; style-src 'self' code.cdn.mozilla.net; report-uri /__cspreport__;\""
+HSTS="\"x-amz-meta-strict-transport-security\": \"max-age=31536000; includeSubDomains; preload\""
+TYPE="\"x-amz-meta-x-content-type-options\": \"nosniff\""
+FRAME="\"x-amz-meta-x-frame-options\": \"DENY\""
+XSS="\"x-amz-meta-x-xss-protection\": \"1; mode=block\""
+
+# HTML; 10 minute cache
+aws s3 sync \
+  --cache-control "max-age=${MAX_AGE}" \
+  --content-type "text/html" \
+  --exclude "*" \
+  --include "*.html" \
+  --metadata "{${HPKP}, ${CSP}, ${HSTS}, ${TYPE}, ${FRAME}, ${XSS}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/
+
+# JSON; 10 minute cache
+aws s3 sync \
+  --cache-control "max-age=${MAX_AGE}" \
+  --content-type "application/json" \
+  --exclude "*" \
+  --include "*.json" \
+  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/
+
+# XPI; 10 minute cache; amazon won't detect the content-type correctly
+aws s3 sync \
+  --cache-control "max-age=${MAX_AGE}" \
+  --content-type "application/x-xpinstall" \
+  --exclude "*" \
+  --include "*.xpi" \
+  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/
+
+# RDF; 10 minute cache; amazon won't detect the content-type correctly
+aws s3 sync \
+  --cache-control "max-age=${MAX_AGE}" \
+  --content-type "text/rdf" \
+  --exclude "*" \
+  --include "*.rdf" \
+  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/
+
+# Everything else; cache forever, because it has hashes in the filenames
+aws s3 sync \
+  --delete \
+  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata-directive "REPLACE" \
+  --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/


### PR DESCRIPTION
This script syncs our flat file website up to S3.  A couple of open questions:

1) Do we still need to allow framing on sameorigin or can we deny completely?

2) It looks like all the static files have hashes on them (save favicon.ico, but meh), so I'm letting them have default (read: long) expires times, and timing out html and json every 10 minutes.  Concerns or things I missed?

3) I'm under the impression we only need CSP headers on the HTML files.  Can someone verify that?

4) Do we need any special headers on the API endpoints?  (.json files)

5) Passing in these headers via command line is a bit ridiculous.  The CSP in easy to read format is:

```
default-src 'self'; 
connect-src 'self' analysis-output.telemetry.mozilla.org; 
font-src 'self' code.cdn.mozilla.net; 
script-src 'self' www.google-analytics.com; 
style-src 'self' code.cdn.mozilla.net; 
report-uri /__cspreport__;
```

Am I missing anything there?  Do we need pontoon anymore?

6) Any other feedback or headers I'm missing?

/cc for review/feedback @lmorchard @jvehent @muffinresearch @relud
