### PR TITLE
[fixes #839] Set GA page explicitly, and update event labels *needs review*

### DIFF
--- a/docs/metrics/ga.md
+++ b/docs/metrics/ga.md
@@ -59,9 +59,10 @@ Here are the current events on the website as of this writing
 | Click on experiment from landing page                    | ExperimentsPage Interactions       | Open details page        | `{experiment title}`          |            
 | Click on Install from experiment details page            | ExperimentDetailsPage Interactions | button click             | Install the Add-on            |
 | Click on the "Try out these experiments as well" section | ExperimentsDetailPage Interactions | Open details page        | try out `{experiment title}`  |            
-| Click Enable Experiment                                  | ExperimentDetailsPage Interactions | button click             | Enable Experiment             |            
-| Click Disable Experiment                                 | ExperimentDetailsPage Interactions | button click             | Disable Experiment            |            
-| Click Give Feedback for experiment                       | ExperimentDetailsPage Interactions | button click             | Give Feedback                 |            
+| Click Enable Experiment                                  | ExperimentDetailsPage Interactions | Enable Experiment        | `{experiment title}`          |            
+| Click Disable Experiment                                 | ExperimentDetailsPage Interactions | Disable Experiment       | `{experiment title}`          |            
+| Click Give Feedback for experiment                       | ExperimentDetailsPage Interactions | Give Feedback            | `{experiment title}`          |
+| Click upgrade notice                                     | ExperimentDetailsPage Interactions | Upgrade Notice           | `{experiment title}`          |             
 | Click Take Survey after disable                          | ExperimentDetailsPage Interactions | button click             | exit survey disabled          |            
 | Click Cancel on tour dialogue                            | ExperimentDetailsPage Interactions | button click             | cancel tour                   |            
 | Complete the tour                                        | ExperimentDetailsPage Interactions | button click             | complete tour                 |            
@@ -133,7 +134,7 @@ We should maintain a consistent convention when using campaign parameters.
 
 | Description                                                            | utm_source                    | utm_medium      | utm_campaign         | utm_content            |
 |------------------------------------------------------------------------|-------------------------------|-----------------|----------------------|------------------------|
-| Clicking on an experiment (or "view all") from the doorhanger          | testpilot-addon               | firefox-browser | testpilot-doorhanger | {badged|not badged} \* |
+| Clicking on an experiment (or "view all") from the doorhanger          | testpilot-addon               | firefox-browser | testpilot-doorhanger | {'badged','not badged'}|
 | Clicking on an experiment from the in-product messaging                | testpilot-addon               | firefox-browser | push notification    | {messageID}            |
 | Tab opens after user has tried an experiment for n days (#1292)        | testpilot-addon               | firefox-browser | share-page           |                        |
 | Links that get shared from /share                                      | {facebook,twitter,email,copy} | social          | share-page           |                        |

--- a/frontend/src/app/components/ExperimentPage.js
+++ b/frontend/src/app/components/ExperimentPage.js
@@ -429,19 +429,21 @@ export class ExperimentDetail extends React.Component {
   }
 
   clickUpgradeNotice() {
+    const { experiment } = this.props;
     // If a user goes to the upgrade SUMO
     this.props.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'button click',
-      eventLabel: 'Upgrade Notice'
+      eventAction: 'Upgrade Notice',
+      eventLabel: experiment.title
     });
   }
 
   feedback(evt) {
+    const { experiment } = this.props;
     this.props.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'button click',
-      eventLabel: 'Give Feedback',
+      eventAction: 'Give Feedback',
+      eventLabel: experiment.title,
       outboundURL: evt.target.getAttribute('href')
     });
   }
@@ -482,8 +484,8 @@ export class ExperimentDetail extends React.Component {
 
     sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'button click',
-      eventLabel: 'Enable Experiment'
+      eventAction: 'Enable Experiment',
+      eventLabel: experiment.title
     });
   }
 
@@ -506,12 +508,13 @@ export class ExperimentDetail extends React.Component {
   }
 
   renderUninstallSurvey(evt) {
+    const { experiment } = this.props;
     evt.preventDefault();
 
     this.props.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'button click',
-      eventLabel: 'Disable Experiment'
+      eventAction: 'Disable Experiment',
+      eventLabel: experiment.title
     });
 
     this.uninstallExperiment(evt);

--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -70,6 +70,7 @@ class App extends Component {
     if (window.ga && ga.loaded) {
       const data = dataIn || {};
       data.hitType = type;
+      data.page = (pathname === '/') ? pathname : '/' + pathname;
       ga('send', data);
     }
   }

--- a/frontend/test/app/components/ExperimentPage-test.js
+++ b/frontend/test/app/components/ExperimentPage-test.js
@@ -251,13 +251,13 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
           .to.equal(mockClickEvent.target.offsetWidth);
         expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
           eventCategory: 'ExperimentDetailsPage Interactions',
-          eventAction: 'button click',
-          eventLabel: 'Enable Experiment'
+          eventAction: 'Enable Experiment',
+          eventLabel: experiment.title
         }]);
       });
 
       it('should display a warning only if userAgent does not meet minimum version', () => {
-        setExperiment({ ...mockExperiment, min_release: 50 });
+        const experiment = setExperiment({ ...mockExperiment, min_release: 50 });
 
         const userAgentPre = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:51.0) Gecko/20100101 Firefox/';
 
@@ -268,8 +268,8 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
         findByL10nID('upgradeNoticeLink').simulate('click', mockClickEvent);
         expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
           eventCategory: 'ExperimentDetailsPage Interactions',
-          eventAction: 'button click',
-          eventLabel: 'Upgrade Notice'
+          eventAction: 'Upgrade Notice',
+          eventLabel: experiment.title
         }]);
 
         subject.setProps({ userAgent: `${userAgentPre}50.0` });
@@ -375,8 +375,8 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
             .to.equal(mockClickEvent.target.offsetWidth);
           expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
             eventCategory: 'ExperimentDetailsPage Interactions',
-            eventAction: 'button click',
-            eventLabel: 'Disable Experiment'
+            eventAction: 'Disable Experiment',
+            eventLabel: experiment.title
           }]);
         });
 
@@ -388,6 +388,7 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
         });
 
         it('should navigate to survey URL when "Give Feedback" clicked', () => {
+          const experiment = setExperiment(mockExperiment);
           const button = subject.find('#feedback-button');
           const expectedHref = button.prop('href');
           mockClickEvent.target.getAttribute = name => expectedHref;
@@ -395,8 +396,8 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
 
           expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
             eventCategory: 'ExperimentDetailsPage Interactions',
-            eventAction: 'button click',
-            eventLabel: 'Give Feedback',
+            eventAction: 'Give Feedback',
+            eventLabel: experiment.title,
             outboundURL: expectedHref
           }]);
         });


### PR DESCRIPTION
- explicitly set the `page` param in `pageview` calls ([ref](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#tracking_virtual_pageviews)).
- per recommendation from Peter, modify the action/labels for a few event calls

Fixes #839.
