### PR TITLE
added a 'rated' ping

### DIFF
--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -10,6 +10,7 @@
  *   & https://dxr.mozilla.org/mozilla-central/source/browser/components/uitour/UITour.jsm
  */
 
+const Metrics = require('./metrics');
 const { Services } = require('resource://gre/modules/Services.jsm');
 const { setTimeout, clearTimeout } = require('sdk/timers');
 const tabs = require('sdk/tabs');
@@ -114,7 +115,7 @@ function launchSurvey(options) {
     .then(
       rating => {
         if (!rating) { return Promise.resolve(); }
-        // TODO: add telemetry ping for rating
+        Metrics.pingTelemetry(experiment.addon_id, `rated_${rating}`);
         return showSurveyButton(options)
           .then(clicked => {
             if (clicked) {

--- a/addon/test/test-survey.js
+++ b/addon/test/test-survey.js
@@ -15,6 +15,7 @@ MockUtils.setDebug(true);
 const mocks = {
   store: {},
   callbacks: MockUtils.callbacks({
+    Metrics: ['pingTelemetry'],
     Request: ['get'],
     timers: ['setTimeout', 'clearTimeout'],
     Tabs: ['open']
@@ -28,7 +29,8 @@ const mockLoader = MockUtils.loader(module, './lib/survey.js', {
   'sdk/simple-storage': {storage: mocks.store},
   'sdk/request': {Request},
   'sdk/tabs': mocks.callbacks.Tabs,
-  'sdk/timers': mocks.callbacks.timers
+  'sdk/timers': mocks.callbacks.timers,
+  './lib/metrics.js': mocks.callbacks.Metrics
 });
 
 const Survey = mockLoader.require('../lib/survey');


### PR DESCRIPTION
Looking at the way data is sent to and presented in telemetry and GA using these values for the `object` and `eventName` parameters seems like a good first step to get this stat flowing. Encoding the rating value in the name isn't the most satisfying method from a "purity" standpoint, but it's less disruptive than making deeper changes and will still be easy to work with on the other end.
