### PR TITLE
Add No Resource URI add-on as an incompatible add-on (Page Shot)

### DIFF
--- a/content-src/experiments/page-shot.yaml
+++ b/content-src/experiments/page-shot.yaml
@@ -107,3 +107,5 @@ installation_count: 1
 created: '2016-09-22T00:07:28.847430Z'
 modified: '2016-09-22T16:51:12.188781Z'
 order: 0
+incompatible:
+    '@no-resource-uri-leak': 'No Resource URI Leak'


### PR DESCRIPTION
Incompatible per the report in https://github.com/mozilla-services/pageshot/issues/1700
