### PR TITLE
added 'active' addon ids to 'sync-installed-result'

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -102,16 +102,7 @@ function changeApp(env) {
     .on('uninstall-self', uninstallSelf)
     .on('install-experiment', installExperiment)
     .on('uninstall-experiment', uninstallExperiment)
-    .on('sync-installed', () => {
-      app.send(
-        'sync-installed-result',
-        {
-          clientUUID: store.clientUUID,
-          installed: store.installedAddons
-        }
-      );
-      syncInstalled();
-    });
+    .on('sync-installed', syncInstalled);
 }
 
 function updatePrefs(environment) {
@@ -230,12 +221,18 @@ function isTestpilotAddonID(id) {
 
 function syncInstalled() {
   AddonManager.getAllAddons(addons => {
-    const activeAddons = addons.filter(addon => (
-      addon.isActive && !addon.appDisabled && !addon.userDisabled
-    ));
-    app.send('sync-installed-addons', {
-      installedAddons: activeAddons.map(addon => addon.id)
-    });
+    const activeAddonIds = addons
+      .filter(a => (a.isActive && !a.appDisabled && !a.userDisabled))
+      .map(a => a.id);
+
+    app.send(
+      'sync-installed-result',
+      {
+        clientUUID: store.clientUUID,
+        installed: store.installedAddons,
+        active: activeAddonIds
+      }
+    );
   });
 }
 

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -128,9 +128,7 @@ function messageReceived(store, evt) {
     case 'sync-installed-result':
       store.dispatch(addonActions.setClientUuid(data.clientUUID));
       store.dispatch(addonActions.setInstalled(data.installed));
-      break;
-    case 'sync-installed-addons':
-      store.dispatch(addonActions.setInstalledAddons(data.installedAddons));
+      store.dispatch(addonActions.setInstalledAddons(data.active));
       break;
     case 'addon-self:uninstalled':
       store.dispatch(addonActions.setHasAddon(false));


### PR DESCRIPTION
fixes #1403 

If this gets deployed in this sprint we won't have to worry about addon <-> webapp version compatibility. Old addon -> new webapp: `active` will be `undefined` and yield `[]` in the reducer. New addon -> old webapp: `active` will be ignored.
