### PR TITLE
Trim trailing slash from slug for ExperimentPage pageview GA ping

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -49,7 +49,11 @@ class App extends Component {
         dimension1: hasAddon
       });
     } else if (pathname.indexOf(experimentsPath) === 0) {
-      const slug = pathname.substring(experimentsPath.length);
+      let slug = pathname.substring(experimentsPath.length);
+      // Trim trailing slash, if necessary
+      if (slug.charAt(slug.length - 1) === '/') {
+        slug = slug.substring(0, slug.length - 1);
+      }
       const experiment = this.props.getExperimentBySlug(slug);
       this.debounceSendToGA(pathname, 'pageview', {
         dimension1: hasAddon,


### PR DESCRIPTION
Fixes "TypeError: d is undefined" when experiment page is visited with a
trailing slash.

This patches the issue for now, but maybe #1372 can provide a cleaner solution overall. 😞 
