### PR TITLE
Use parent HomePage component.

### DIFF
--- a/frontend/src/app/components/HomePage.js
+++ b/frontend/src/app/components/HomePage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import HomePageNoAddon from './HomePageNoAddon';
+import HomePageWithAddon from './HomePageWithAddon';
+
+export default class HomePage extends React.Component {
+  render() {
+    if (this.props.hasAddon) {
+      return <HomePageWithAddon {...this.props} />;
+    }
+    return <HomePageNoAddon {...this.props} />;
+  }
+}
+
+HomePage.propTypes = {
+  hasAddon: React.PropTypes.bool
+};

--- a/frontend/src/app/components/HomePageNoAddon.js
+++ b/frontend/src/app/components/HomePageNoAddon.js
@@ -5,7 +5,8 @@ import MainInstallButton from '../components/MainInstallButton';
 import ExperimentCardList from '../components/ExperimentCardList';
 import LoadingPage from './LoadingPage';
 
-export default class LandingPage extends React.Component {
+
+export default class HomePageNoAddon extends React.Component {
 
   render() {
     const { experiments } = this.props;
@@ -19,6 +20,7 @@ export default class LandingPage extends React.Component {
             <a href="/" className="wordmark" data-l10n-id="siteName">Firefox Test Pilot</a>
           </h1>
         </header>
+
         <div className="split-banner responsive-content-wrapper">
           <div className="copter-wrapper fly-up">
             <div className="copter"></div>
@@ -39,13 +41,13 @@ export default class LandingPage extends React.Component {
 
         <div className="transparent-container">
           <div className="responsive-content-wrapper delayed-fade-in">
-              <h2 className="card-list-header" data-l10n-id="landingExperimentsTitle">Try out the latest experimental features</h2>
-              <div data-hook="experiment-list">
-                <ExperimentCardList {...this.props}
-                                    eventCategory="HomePage Interactions" />
-              </div>
+            <h2 className="card-list-header" data-l10n-id="landingExperimentsTitle">Try out the latest experimental features</h2>
+            <div data-hook="experiment-list">
+              <ExperimentCardList {...this.props} eventCategory="HomePage Interactions" />
+            </div>
           </div>
         </div>
+
         <div className="responsive-content-wrapper delayed-fade-in">
           <h2 className="card-list-header" data-l10n-id="landingCardListTitle">Get started in 3 easy steps</h2>
           <div id="how-to" className="card-list">
@@ -77,8 +79,9 @@ export default class LandingPage extends React.Component {
 
 }
 
-LandingPage.propTypes = {
+HomePageNoAddon.propTypes = {
   hasAddon: React.PropTypes.bool,
   isFirefox: React.PropTypes.bool,
   experiments: React.PropTypes.array
 };
+

--- a/frontend/src/app/components/HomePageWithAddon.js
+++ b/frontend/src/app/components/HomePageWithAddon.js
@@ -6,7 +6,8 @@ import EmailDialog from '../components/EmailDialog';
 import ExperimentCardList from '../components/ExperimentCardList';
 import LoadingPage from './LoadingPage';
 
-export default class ExperimentsListPage extends React.Component {
+
+export default class HomePageWithAddon extends React.Component {
 
   constructor(props) {
     super(props);
@@ -58,7 +59,7 @@ export default class ExperimentsListPage extends React.Component {
   }
 }
 
-ExperimentsListPage.propTypes = {
+HomePageWithAddon.propTypes = {
   hasAddon: React.PropTypes.bool,
   getCookie: React.PropTypes.func,
   removeCookie: React.PropTypes.func,

--- a/frontend/src/app/lib/router.js
+++ b/frontend/src/app/lib/router.js
@@ -1,6 +1,6 @@
 /* global ga */
 import React from 'react';
-import { Router, Route, IndexRoute } from 'react-router';
+import { IndexRoute, Redirect, Route, Router } from 'react-router';
 import { push as routerPush } from 'react-router-redux';
 import { connect } from 'react-redux';
 
@@ -9,22 +9,22 @@ import { getExperimentBySlug, isExperimentsLoaded } from '../reducers/experiment
 
 import App from '../containers/App';
 
-import LandingPage from '../components/LandingPage';
-import ExperimentsListPage from '../components/ExperimentsListPage';
+import ErrorPage from '../components/ErrorPage';
 import ExperimentPage from '../components/ExperimentPage';
-import RetirePage from '../components/RetirePage';
-import Restart from '../components/Restart';
+import HomePage from '../components/HomePage';
 import LegacyPage from '../components/LegacyPage';
 import NotFoundPage from '../components/NotFoundPage';
-import SharePage from '../components/SharePage';
-import ErrorPage from '../components/ErrorPage';
 import OnboardingPage from '../components/OnboardingPage';
+import Restart from '../components/Restart';
+import RetirePage from '../components/RetirePage';
+import SharePage from '../components/SharePage';
+
 
 const AppRouter = ({ history }) => (
   <Router history={history}>
     <Route path="/" component={App}>
-      <IndexRoute component={LandingPage} />
-      <Route path="/experiments(/)" component={ExperimentsListPage} />
+      <IndexRoute component={HomePage} />
+      <Redirect from="/experiments(/)" to="/" />
       <Route path="/experiments/:slug" component={props => <ExperimentPage {...props} experiment={props.getExperimentBySlug(props.params.slug)} />} />
       <Route path="/legacy" component={LegacyPage} />
       <Route path="/404" component={NotFoundPage} />
@@ -41,17 +41,6 @@ const AppRouter = ({ history }) => (
 // Wrapper for <Router> that handles state-based redirection logic
 // TODO: Move all of this into the App container?
 class BaseAppRedirector extends React.Component {
-
-  performRedirects() {
-    const { routing, hasAddon, isFirefox, navigateTo } = this.props;
-    const location = routing.locationBeforeTransitions;
-    if (location.pathname === '/' && (hasAddon && isFirefox)) {
-      navigateTo('/experiments/');
-    }
-    if (location.pathname === 'experiments/' && (!hasAddon || !isFirefox)) {
-      navigateTo('/');
-    }
-  }
 
   measurePageview() {
     const { routing, hasAddon, installed, installedLoaded, experimentsLoaded } = this.props;
@@ -110,7 +99,6 @@ class BaseAppRedirector extends React.Component {
   render() { return this.router; }
 
   componentDidUpdate() {
-    this.performRedirects();
     this.measurePageview();
   }
 }

--- a/frontend/test/app/components/HomePage-test.js
+++ b/frontend/test/app/components/HomePage-test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+
+import HomePage from '../../../src/app/components/HomePage';
+
+
+describe('app/components/HomePage', () => {
+  it('should show experiment list if the add-on is installed', () => {
+    const wrapper = shallow(<HomePage hasAddon={true} />);
+    expect(wrapper.find('HomePageNoAddon')).to.have.property('length', 0);
+    expect(wrapper.find('HomePageWithAddon')).to.have.property('length', 1);
+  });
+
+  it('should prompt to install the add-on if not already installed', () => {
+    const wrapper = shallow(<HomePage hasAddon={false} />);
+    expect(wrapper.find('HomePageNoAddon')).to.have.property('length', 1);
+    expect(wrapper.find('HomePageWithAddon')).to.have.property('length', 0);
+  });
+});

--- a/frontend/test/app/components/HomePageNoAddon-test.js
+++ b/frontend/test/app/components/HomePageNoAddon-test.js
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import LandingPage from '../../../src/app/components/LandingPage';
+import HomePageNoAddon from '../../../src/app/components/HomePageNoAddon';
 
-describe('app/components/LandingPage', () => {
+describe('app/components/HomePageNoAddon', () => {
   let props, subject, experiments;
   beforeEach(function() {
     props = {
@@ -15,7 +15,7 @@ describe('app/components/LandingPage', () => {
       uninstallAddon: sinon.spy(),
       sendToGA: sinon.spy(),
     };
-    subject = shallow(<LandingPage {...props} />);
+    subject = shallow(<HomePageNoAddon {...props} />);
   });
 
   const findByL10nID = (id) => subject.findWhere(el => id === el.props()['data-l10n-id']);

--- a/frontend/test/app/components/HomePageWithAddon-test.js
+++ b/frontend/test/app/components/HomePageWithAddon-test.js
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import ExperimentsListPage from '../../../src/app/components/ExperimentsListPage';
+import HomePageWithAddon from '../../../src/app/components/HomePageWithAddon';
 
-describe('app/components/ExperimentsListPage', () => {
+describe('app/components/HomePageWithAddon', () => {
   let props, experiments, subject;
   beforeEach(function() {
     props = {
@@ -21,7 +21,7 @@ describe('app/components/ExperimentsListPage', () => {
       sendToGA: sinon.spy(),
       openWindow: sinon.spy()
     };
-    subject = shallow(<ExperimentsListPage {...props} />);
+    subject = shallow(<HomePageWithAddon {...props} />);
   });
 
   it('should render expected content', () => {


### PR DESCRIPTION
- Redirects `/experiments` to `/`
- Renames `LandingPage` as `HomePageNoAddon`
- Renames `ExperimentsListPage` as `HomePageWithAddon`
- Creates a new `HomePage` component to negotiate which component to render.
- Removes redirection logic from `BaseAppRedirector`

Ultimately I'd prefer that we have all the `HomePage*` components in a single file (e.g.:

``` js
export class HomePageNoAddon {};
export class HomePageWithAddon {};
export default class HomePage {};
```

), but `HomePageNoAddon` is still gnarly enough that it probably belongs in its own file.

Closes #1372, #1467
