### PR TITLE
add a comment about 3rd party API access

### DIFF
--- a/frontend/tasks/content.js
+++ b/frontend/tasks/content.js
@@ -57,6 +57,9 @@ function buildExperimentsJSON() {
   }
 
   function endStream(cb) {
+    // These files are being consumed by 3rd parties (at a minimum, the Mozilla
+    // Measurements Team).  Before changing them, please consult with the
+    // appropriate folks!
     this.push(new gutil.File({
       path: 'experiments.json',
       contents: new Buffer(JSON.stringify(index, null, 2))


### PR DESCRIPTION
These URLs changed with our static file conversion and broke our stats.  I'm adding a comment reminding people that they are in use elsewhere.  I think this is the best place for it, but feedback welcome.
