### PR TITLE
switch addon detection to polling

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -10,7 +10,7 @@ import Clipboard from 'clipboard';
 import { getInstalled, isExperimentEnabled, isInstalledLoaded } from '../reducers/addon';
 import { getExperimentBySlug, isExperimentsLoaded } from '../reducers/experiments';
 import experimentSelector from '../selectors/experiment';
-import { uninstallAddon, installAddon, enableExperiment, disableExperiment } from '../lib/addon';
+import { uninstallAddon, installAddon, enableExperiment, disableExperiment, pollAddon } from '../lib/addon';
 import addonActions from '../actions/addon';
 import RestartPage from '../containers/RestartPage';
 
@@ -141,7 +141,11 @@ export default connect(
     enableExperiment: experiment => enableExperiment(dispatch, experiment),
     disableExperiment: experiment => disableExperiment(dispatch, experiment),
     requireRestart: experimentTitle =>
-      dispatch(addonActions.requireRestart(experimentTitle))
+      dispatch(addonActions.requireRestart(experimentTitle)),
+    setHasAddon: installed => {
+      dispatch(addonActions.setHasAddon(installed));
+      if (!installed) { pollAddon(); }
+    }
   }),
   (stateProps, dispatchProps, ownProps) => Object.assign({
     installAddon,
@@ -168,7 +172,6 @@ export default connect(
     },
     getCookie: name => cookies.get(name),
     removeCookie: name => cookies.remove(name),
-    setNavigatorTestpilotAddon: value => window.navigator.testpilotAddon = value,
     getExperimentLastSeen: experiment =>
       parseInt(window.localStorage.getItem(`experiment-last-seen-${experiment.id}`), 10),
     setExperimentLastSeen: (experiment, value) =>

--- a/frontend/src/app/containers/RetirePage.js
+++ b/frontend/src/app/containers/RetirePage.js
@@ -19,7 +19,7 @@ export default class RetirePage extends React.Component {
     // uninstalled, so let's fake it.
     this.fakeUninstallTimer = setTimeout(() => {
       this.setState({ fakeUninstalled: true });
-      this.props.setNavigatorTestpilotAddon(false);
+      this.props.setHasAddon(false);
     }, this.props.fakeUninstallDelay);
   }
 
@@ -73,7 +73,7 @@ export default class RetirePage extends React.Component {
 }
 
 RetirePage.propTypes = {
-  setNavigatorTestpilotAddon: React.PropTypes.func,
+  setHasAddon: React.PropTypes.func,
   fakeUninstallDelay: React.PropTypes.number
 };
 

--- a/frontend/test/app/containers/RetirePage-test.js
+++ b/frontend/test/app/containers/RetirePage-test.js
@@ -28,7 +28,7 @@ describe('app/containers/RetirePage', () => {
     // Switch to mounted component to exercise componentDidMount
     const mountedProps = { ...props,
       fakeUninstallDelay: 10,
-      setNavigatorTestpilotAddon: sinon.spy()
+      setHasAddon: sinon.spy()
     };
     const mountedSubject = mount(<RetirePage {...mountedProps} />);
 
@@ -38,7 +38,7 @@ describe('app/containers/RetirePage', () => {
     setTimeout(() => {
       expect(mountedSubject.state('fakeUninstalled')).to.be.true;
       expect(findByL10nID('retirePageMessage', mountedSubject)).to.have.property('length', 1);
-      expect(mountedProps.setNavigatorTestpilotAddon.called).to.be.true;
+      expect(mountedProps.setHasAddon.called).to.be.true;
       done();
     }, 20);
   });


### PR DESCRIPTION
fixes #1606

As noted in the bug, PageMod is a jerk. We can't rely on changes to `navigator.testpilotAddon` to signal when the addon is removed because it can change at other times too.

This PR has the webapp detect the addon by sending `sync-installed` messages until it gets a response.

There's a case this change breaks: when a page is open to the webapp while the addon is removed or disabled from about:addons it won't detect it. Removing the addon via the webapp _does_ work correctly.
