### PR TITLE
add nosniff headers to all file types

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -48,7 +48,7 @@ aws s3 sync \
   --content-type "application/json" \
   --exclude "*" \
   --include "*.json" \
-  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
@@ -59,7 +59,7 @@ aws s3 sync \
   --content-type "application/x-xpinstall" \
   --exclude "*" \
   --include "*.xpi" \
-  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
@@ -70,7 +70,7 @@ aws s3 sync \
   --content-type "text/rdf" \
   --exclude "*" \
   --include "*.rdf" \
-  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
@@ -80,7 +80,7 @@ aws s3 sync \
   --content-type "image/svg+xml" \
   --exclude "*" \
   --include "*.svg" \
-  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
@@ -88,7 +88,7 @@ aws s3 sync \
 # Everything else; cache forever, because it has hashes in the filenames
 aws s3 sync \
   --delete \
-  --metadata "{${HPKP}, ${HSTS}}" \
+  --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/


### PR DESCRIPTION
Add no-sniff headers to all the files.  For most we specify the file type, so it should work fine.  For the "everything else" bucket, amazon attempts to auto-detect the file type and put the right Content-Type header on it.  I spot checked png, ico, js, and css.  They were all correct.  If we find a filetype amazon doesn't detect correctly it's just a matter of setting it ourselves, so let me know if anyone sees one.
