### PR TITLE
Disable integration test dependency setup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -32,7 +32,7 @@ dependencies:
     - node --version
     - npm --version
     - google-chrome --version
-    - ./bin/circleci/setup-test-dependencies.sh
+    # - ./bin/circleci/setup-test-dependencies.sh
     - ./bin/circleci/build-version-json.sh
     - ./bin/circleci/build-addon.sh
     - ./bin/circleci/build-frontend.sh


### PR DESCRIPTION
After merging #1612, the CircleCI build [started failing on installing Python dependencies for integration tests](https://circleci.com/gh/mozilla/testpilot/1328). 

Looks like we [dropped the cache for the Python virtualenv](https://github.com/mozilla/testpilot/commit/af610e373e017a492d7ffb2b2e31d8d75fc0ab2a#diff-29944324a3cbf9f4bd0162dfe3975d88L26), which triggered a fresh install of all the modules used by Marionette & friends. That, in turn, appears to have exposed a lurking issue (previously masked by caching) that causes a `InsecurePlatformWarning` and breaks the install.

But, the integration test suite is currently disabled - so this PR also disables installing its dependencies so we can get the build un-broken until/unless we re-enable that suite.
