### PR TITLE
send pings from message-bridge to webpage as a keep-alive

### DIFF
--- a/addon/data/message-bridge.js
+++ b/addon/data/message-bridge.js
@@ -18,3 +18,10 @@ self.port.on('from-addon-to-web', function(data) {
     'from-addon-to-web', { bubbles: true, detail: clonedData }
   ));
 });
+
+setInterval(function() {
+  const detail = cloneInto({ type: 'ping' }, document.defaultView);
+  document.documentElement.dispatchEvent(new CustomEvent(
+    'from-addon-to-web', { bubbles: true, detail }
+  ));
+}, 1000);

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -6,6 +6,7 @@ import experimentActions from '../actions/experiments';
 import { getExperimentByID, getExperimentByURL, getExperimentInProgress } from '../reducers/experiments';
 
 const INSTALL_STATE_WATCH_PERIOD = 2000;
+const DISCONNECT_TIMEOUT = 3333;
 const MOZADDONMANAGER_ALLOWED_HOSTNAMES = [
   'testpilot.firefox.com',
   'testpilot.stage.mozaws.net',
@@ -74,6 +75,12 @@ export function setupAddonConnection(store) {
   pollAddon();
 }
 
+let disconnectTimer = 0;
+function addonDisconnected(store) {
+  store.dispatch(addonActions.setHasAddon(false));
+  pollAddon();
+}
+
 let pollTimer = 0;
 export function pollAddon() {
   sendMessage('sync-installed');
@@ -102,6 +109,8 @@ function messageReceived(store, evt) {
     clearTimeout(pollTimer);
     pollTimer = 0;
   }
+  clearTimeout(disconnectTimer);
+  disconnectTimer = setTimeout(addonDisconnected.bind(null, store), DISCONNECT_TIMEOUT);
 
   const { type, data } = evt.detail;
   const { experiments, addon } = store.getState();


### PR DESCRIPTION
@lmorchard here's a sketch of something for #1627 

I imagine we'd want to deploy this in two parts to give version mismatches time to settle. First to get deployed would be the message-bridge change to begin pinging (the current webapp will receive them but do nothing with them), then the webapp change (next deploy) to begin disconnecting.
