### PR TITLE
Correctly handle 4xx errors from Basket (closes #1650).

### DIFF
--- a/frontend/src/app/actions/newsletter-form.js
+++ b/frontend/src/app/actions/newsletter-form.js
@@ -21,7 +21,13 @@ const subscribeActions = createActions({
       },
       body: `newsletters=test-pilot&email=${encodeURIComponent(email)}`
     })
-      .then(() => dispatch(actions.newsletterFormSetSucceeded()))
+      .then(response => {
+        if (response.ok) {
+          dispatch(actions.newsletterFormSetSucceeded());
+        } else {
+          dispatch(actions.newsletterFormSetFailed());
+        }
+      })
       .catch(() => dispatch(actions.newsletterFormSetFailed()));
   }
 });


### PR DESCRIPTION
Hm, I thought that `fetch` would reject a `429` response, but that seems not to be the case. Regardless, this is a good change.
