### PR TITLE
Fixes typo in Facebook image URL (closes #1654).

### DIFF
--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -20,7 +20,7 @@ const compiledPagePaths = {
   'terms-of-use.md': 'terms/index.html'
 };
 
-const THUMBNAIL_FACEBOOK = 'https://testpilot.firefox.com/static/images/thumbnail-facebok.png';
+const THUMBNAIL_FACEBOOK = 'https://testpilot.firefox.com/static/images/thumbnail-facebook.png';
 const THUMBNAIL_TWITTER = 'https://testpilot.firefox.com/static/images/thumbnail-twitter.png';
 
 gulp.task('pages-misc', () => {


### PR DESCRIPTION
However, this is also 404ing: https://testpilot.firefox.com/static/images/thumbnail-facebook.png
