### PR TITLE
only build version.json if missing

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -31,8 +31,8 @@ TYPE="\"x-content-type-options\": \"nosniff\""
 FRAME="\"x-frame-options\": \"DENY\""
 XSS="\"x-xss-protection\": \"1; mode=block\""
 
-# build version.json
-$(dirname $0)/build-version-json.sh
+# build version.json if it isn't provided
+[ -e version.json ] || $(dirname $0)/build-version-json.sh
 
 if [ -e version.json ]; then
     mv version.json dist/__version__


### PR DESCRIPTION
this is causing an incorrect /**version** in stage

due to technical limitations cloudops builds `dist/` on a separate machine from where it runs deploy.sh. the .git directory is not copied, and any files outside of dist/ have to be manually specified in order to be used.

so cloudops will add bin/build-version-json.sh to our build step, and this script should assume that if version.json exists, then it should not regenerate it.

this shouldn't break a workflow of committing locally and running bin/deploy.sh, because bin/deploy.sh moves version.json to dist/**version**, so bin/deploy.sh will regen version.json on each run.
