### PR TITLE
Rewrite local dev requests for /path/foo to /path/foo/index.html without redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "babelify": "^7.3.0",
     "browserify": "^11.0.1",
     "chai": "^3.5.0",
-    "connect-history-api-fallback": "^1.3.0",
     "del": "2.0.2",
     "doctoc": "1.0.0",
     "enzyme": "^2.4.1",


### PR DESCRIPTION
Fixes #1636

Has the bonus of serving up the real index.html for experiment pages. For example: If you click to one, there will be no change in page title (#1518). But, if you refresh the page, you'll see the static page title appear in the tab. This wasn't working before.

Also, this will result in real 404s if pages are missing from the build process - a good thing IMO. Otherwise, that would be masked by the history fallback middleware and we'd discover the issue on merge & deploy to dev / stage / prod
