### PR TITLE
added code coverage npm script

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,1 +1,8 @@
-{"presets": ["es2015", "stage-0", "react"]}
+{
+  "presets": ["es2015", "stage-0", "react"],
+  "env": {
+    "test": {
+      "plugins": ["istanbul"]
+    }
+  }
+}

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,0 @@
-[run]
-source = testpilot
-
-[report]
-omit = */migrations/*

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,8 @@ tmp/
 .DS_Store
 docs/_build
 MANIFEST
-.coverage
+coverage
+.nyc_output
 node_modules/
 media/
 static/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,12 @@
+{
+  "require": [
+    "babel-register"
+  ],
+  "reporter": [
+    "lcov",
+    "text-summary"
+  ],
+  "cache": true,
+  "sourceMap": false,
+  "instrument": false
+}

--- a/frontend/test-setup.js
+++ b/frontend/test-setup.js
@@ -1,8 +1,5 @@
 // Global setup for all tests
 
-// We're going to babelify everything as it loads.
-require('babel-register')();
-
 // We need jsdom for enzyme mount()'ed components - mainly the sticky header
 // scroll handler stuff on the experiments page.
 

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "babel-core": "^6.14.0",
     "babel-eslint": "^6.1.2",
+    "babel-plugin-istanbul": "^2.0.3",
     "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-0": "^6.5.0",
@@ -75,6 +76,7 @@
     "mocha": "^3.0.2",
     "node-normalize-scss": "1.1.1",
     "node-sass": "^3.9.3",
+    "nyc": "^8.3.2",
     "react-addons-test-utils": "^15.3.1",
     "remarkable": "1.6.2",
     "require-globify": "^1.3.0",
@@ -103,7 +105,8 @@
     "static": "gulp dist-build",
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "gulp scripts-lint styles-lint",
-    "test": "cd frontend && mocha --require test-setup.js --recursive",
-    "test:watch": "npm test -- --watch"
+    "test": "cd frontend && mocha --require babel-register --require test-setup.js --recursive",
+    "test:watch": "npm test -- --watch",
+    "coverage": "NODE_ENV=test nyc mocha --recursive --require frontend/test-setup.js frontend/test"
   }
 }


### PR DESCRIPTION
`npm run coverage`

<img width="570" alt="screen shot 2016-10-25 at 1 12 56 pm" src="https://cloud.githubusercontent.com/assets/87619/19702616/39060b78-9ab5-11e6-9d7b-30d583f7d0b7.png">

and the full coverage report goes to `coverage/lcov-report/index.html`
