### PR TITLE
updated circleci build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Test Pilot Logo](testpilot/frontend/src/images/copter.png)
+![Test Pilot Logo](frontend/src/images/copter.png)
 
 # Test Pilot
 
@@ -6,8 +6,8 @@ Test Pilot is an opt-in platform that allows us to perform controlled tests of n
 
 Test Pilot is not intended to replace trains for most features, nor is it a test bed for concepts we do not believe have a strong chance of shipping in general release. Rather, it is reserved for features that require user feedback, testing, and tuning before they ship with the browser.
 
-[![Build](https://img.shields.io/circleci/project/mozilla/testpilot.svg?maxAge=2592000)](https://circleci.com/gh/mozilla/testpilot/)
-
+[![Build](https://img.shields.io/circleci/project/mozilla/testpilot.svg)](https://circleci.com/gh/mozilla/testpilot/)
+[![codecov](https://codecov.io/gh/mozilla/testpilot/branch/master/graph/badge.svg)](https://codecov.io/gh/mozilla/testpilot)
 
 ## Table of Contents
 

--- a/bin/circleci/build-addon.sh
+++ b/bin/circleci/build-addon.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 set -ex
 cd addon/
-npm config set spin false
-npm install
-npm run lint
-npm test -- --binary=$HOME/firefox/firefox-bin
 # only sign when on master branch or a tag
-if [[ $CIRCLE_BRANCH == 'master' || $CIRCLE_TAG != '' ]]; then
+if [[ $CIRCLE_PROJECT_USERNAME == 'mozilla' && ($CIRCLE_BRANCH == 'master' || $CIRCLE_TAG != '') ]]; then
     npm run sign;
 else
     npm run package;
 fi
-npm run lint-addon

--- a/bin/circleci/build-frontend.sh
+++ b/bin/circleci/build-frontend.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 set -ex
-npm install
 if [[ " $TESTPILOT_ENABLE_PONTOON_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
     NODE_ENV=production ENABLE_PONTOON=1 npm run static
 else
     NODE_ENV=production ENABLE_PONTOON=0 npm run static
 fi
-npm test

--- a/bin/circleci/install-node-dependencies.sh
+++ b/bin/circleci/install-node-dependencies.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+npm install
+cd addon && npm install

--- a/bin/circleci/test-addon.sh
+++ b/bin/circleci/test-addon.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ex
+cd addon/
+npm run lint
+npm test -- --binary=$HOME/firefox/firefox-bin
+npm run lint-addon

--- a/bin/circleci/test-frontend.sh
+++ b/bin/circleci/test-frontend.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+
+npm run lint
+MOCHA_FILE="$CIRCLE_TEST_REPORTS/junit/test-results.xml" npm run test:ci

--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ machine:
   hosts:
     testpilot.dev: 127.0.0.1
   node:
-    version: 6.2.0
+    version: 6.9.1
   environment:
     TESTPILOT_ENABLE_PONTOON_BRANCHES: master
 
@@ -15,32 +15,32 @@ dependencies:
 
   cache_directories:
     - "addon/node_modules"
-    - "node_modules"
-
-  pre:
-    # https://discuss.circleci.com/t/nvm-commands-are-not-evaluated/943
-    - nvm use 6.2.0 && nvm alias default 6.2.0
+    # node_modules is included by default
 
   override:
-    - node --version
-    - npm --version
     - google-chrome --version
+    - ./bin/circleci/install-node-dependencies.sh
     - ./bin/circleci/setup-test-dependencies.sh
-    - ./bin/circleci/build-version-json.sh
     - ./bin/circleci/build-addon.sh
-    - ./bin/circleci/build-frontend.sh
 
 test:
   override:
+    - ./bin/circleci/test-addon.sh
+    - ./bin/circleci/test-frontend.sh
     - echo "Skipping integration tests."
     # - ./bin/circleci/run-integration-tests.sh
+  post:
+    - bash <(curl -s https://codecov.io/bash)
 
 deployment:
 
   static_development:
+    owner: mozilla
     branch:
       - master
     commands:
+      - ./bin/circleci/build-version-json.sh
+      - ./bin/circleci/build-frontend.sh
       - TESTPILOT_BUCKET=testpilot.dev.mozaws.net ./bin/deploy.sh
       - aws configure set preview.cloudfront true
       - aws cloudfront create-invalidation --distribution-id E2ERG47PHCWD0Z --paths '/*'

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "jsdom": "^9.6.0",
     "merge-stream": "^1.0.0",
     "mocha": "^3.0.2",
+    "mocha-junit-reporter": "^1.12.1",
     "node-normalize-scss": "1.1.1",
     "node-sass": "^3.9.3",
     "nyc": "^8.3.2",
@@ -107,6 +108,7 @@
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "gulp scripts-lint styles-lint",
     "test": "cd frontend && mocha --require babel-register --require test-setup.js --recursive",
+    "test:ci": "NODE_ENV=test nyc mocha --recursive --reporter mocha-junit-reporter --require frontend/test-setup.js frontend/test",
     "test:watch": "npm test -- --watch",
     "coverage": "NODE_ENV=test nyc mocha --recursive --require frontend/test-setup.js frontend/test"
   }


### PR DESCRIPTION
The main feature of this change is to run the frontend tests with code coverage and send the results to https://codecov.io

Other changes:
- altered circleci scripts to run on personal forks more easily
- split the dependency install steps from the test steps
  - circleci runs all test steps even if the previous fails which can be useful if there's errors in both addon and frontend code
- moved some build steps that aren't required for testing to the deployment phase
- utilize the circleci "Test Summary" area for frontend tests
- updated node to the LTS version
- fixed logo path on readme

Example circleci run: https://circleci.com/gh/dannycoates/testpilot/15
Example codecov: https://codecov.io/gh/dannycoates/testpilot
