### PR TITLE
Fixes #1682. Add docs for windows users

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,3 +37,4 @@ rules:
   no-unused-expressions: [0]
   no-use-before-define: [2, nofunc]
   yoda: [0]
+  linebreak-style: [0]

--- a/addon/package.json
+++ b/addon/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint --no-eslintrc -c ./.eslintrc .",
     "sign": "./bin/update-version && ./bin/sign",
     "package": "jpm xpi && mv testpilot-addon.xpi addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf update.rdf",
+    "package-win": "jpm xpi && move testpilot-addon.xpi addon.xpi && move @testpilot-addon-%npm_package_version%.update.rdf update.rdf",
     "lint-addon": "addons-linter addon.xpi -o text"
   },
   "license": "MPL-2.0",

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -67,7 +67,32 @@ it communicates with the site and grants the ability to enable & disable
 experiments. Setting up your browser with the steps above should make it easier
 for you to get it working.
 
-## Windows hosts
+## For Windows hosts
 
-**Help wanted**: Getting things working on Windows may be similar to OS X,
-but the team has little experience with that environment.
+After installing Node.js for Windows, run these commands to get started: 
+
+```cmd
+:: Set up add-on environment and build an unsigned package
+cd addon
+npm install
+npm run package-win
+
+:: Set up frontend web site environment
+cd ..
+npm install
+```
+
+Now, open a second command prompt window, this time with admin privileges and run this:
+
+```cmd
+:: Add hostname alias to /etc/hosts and start up dev webserver
+echo 127.0.0.1 testpilot.dev >> %WINDIR%\System32\Drivers\Etc\Hosts
+```
+
+Go back to the previous command prompt window and run
+
+```cmd
+npm start
+```
+
+Follow the remaining instructions from **Linux & OS X** section and you're all set.

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -1,6 +1,6 @@
 const gulp = require('gulp');
 const config = require('../config.js');
-
+const path = require('path');
 const Remarkable = require('remarkable');
 const fs = require('fs');
 const gutil = require('gulp-util');
@@ -95,7 +95,7 @@ function buildExperimentPage() {
 
 function convertToCompiledPage() {
   return through.obj(function compiledConvert(file, encoding, callback) {
-    const filename = file.path.split('/').pop();
+    const filename = path.basename(file.path);
     this.push(new gutil.File({
       path: compiledPagePaths[filename],
       contents: new Buffer(`${compiledTemplates.templateBegin}


### PR DESCRIPTION
Added development quick start guide for Windows hosts and made some changes to a few files to make testpilot run on all operating systems.
Here are the changes: 

`.eslintrc` : Added `linebreak-style: [0]` option as without that eslint throws error on Windows because Windows uses CRLF as newline and *nix systems use LF. 

`addon/package.json` : Added  `package-win` option for Windows users.

`docs/development/quickstart.md` : Updated quickstart.md

`frontend/tasks/pages.js` : Use `Path.basename` for getting file name from an absolute path instead of `file.path.split('/').pop()` as Windows uses backslashes so the latter only works on *nix systems.
