### PR TITLE
#1462 Modified the experiment cards to be actual links.

### DIFF
--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -24,7 +24,7 @@ export default class ExperimentRowCard extends React.Component {
         'just-updated': this.justUpdated(),
         'has-addon': hasAddon
       })}>
-        <Link className='overlap-block' to={`/experiments/${slug}`} onClick={() => this.sendToAnalytics()} />
+        <Link className='overlap-block' to={`/experiments/${slug}`} onClick={(evt) => this.openDetailPage(evt)} />
         <div className="experiment-actions">
           {enabled && <div data-l10n-id="experimentListEnabledTab" className="tab enabled-tab"></div>}
           {this.justLaunched() && <div data-l10n-id="experimentListJustLaunchedTab" className="tab just-launched-tab"></div>}
@@ -133,15 +133,18 @@ export default class ExperimentRowCard extends React.Component {
     return '';
   }
 
-  sendToAnalytics() {
-    const { eventCategory, experiment, sendToGA } = this.props;
+  openDetailPage(evt) {
+    const { navigateTo, eventCategory, experiment, sendToGA } = this.props;
     const { title } = experiment;
+
+    evt.preventDefault();
 
     sendToGA('event', {
       eventCategory,
       eventAction: 'Open detail page',
       eventLabel: title
     });
+    navigateTo(`/experiments/${experiment.slug}`);
   }
 
 }

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { Link } from 'react-router';
 import classnames from 'classnames';
 
 const ONE_DAY = 24 * 60 * 60 * 1000;
@@ -12,34 +12,33 @@ export default class ExperimentRowCard extends React.Component {
   render() {
     const { hasAddon, experiment, enabled, isAfterCompletedDate } = this.props;
 
-    const { description, thumbnail, subtitle } = experiment;
+    const { description, thumbnail, subtitle, slug } = experiment;
     const installation_count = (experiment.installation_count) ? experiment.installation_count : 0;
     const title = experiment.short_title || experiment.title;
     const isCompleted = isAfterCompletedDate(experiment);
 
     return (
-      <div data-hook="show-detail"
-        className={classnames('experiment-summary', {
-          enabled,
-          'just-launched': this.justLaunched(),
-          'just-updated': this.justUpdated(),
-          'has-addon': hasAddon
-        })}
-        onClick={(evt) => this.openDetailPage(evt)}>
+      <div data-hook="show-detail" className={classnames('experiment-summary', {
+        enabled,
+        'just-launched': this.justLaunched(),
+        'just-updated': this.justUpdated(),
+        'has-addon': hasAddon
+      })}>
+        <Link className='overlap-block' to={`/experiments/${slug}`} onClick={() => this.sendToAnalytics()} />
         <div className="experiment-actions">
           {enabled && <div data-l10n-id="experimentListEnabledTab" className="tab enabled-tab"></div>}
           {this.justLaunched() && <div data-l10n-id="experimentListJustLaunchedTab" className="tab just-launched-tab"></div>}
           {this.justUpdated() && <div data-l10n-id="experimentListJustUpdatedTab" className="tab just-updated-tab"></div>}
         </div>
-      <div className="experiment-icon-wrapper" data-hook="bg"
-        style={{
-          backgroundColor: experiment.gradient_start,
-          backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop}`
-        }}>
-        <div className="experiment-icon" style={{
-          backgroundImage: `url(${thumbnail})`
-        }}></div>
-      </div>
+        <div className="experiment-icon-wrapper" data-hook="bg"
+          style={{
+            backgroundColor: experiment.gradient_start,
+            backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop}`
+          }}>
+          <div className="experiment-icon" style={{
+            backgroundImage: `url(${thumbnail})`
+          }}></div>
+        </div>
       <div className="experiment-information">
         <header>
           <h3>{title}</h3>
@@ -50,7 +49,7 @@ export default class ExperimentRowCard extends React.Component {
         { this.renderInstallationCount(installation_count, isCompleted) }
         { this.renderManageButton(enabled, hasAddon, isCompleted) }
       </div>
-     </div>
+    </div>
     );
   }
 
@@ -134,17 +133,15 @@ export default class ExperimentRowCard extends React.Component {
     return '';
   }
 
-  openDetailPage(evt) {
-    const { navigateTo, eventCategory, experiment, sendToGA } = this.props;
+  sendToAnalytics() {
+    const { eventCategory, experiment, sendToGA } = this.props;
     const { title } = experiment;
 
-    evt.preventDefault();
     sendToGA('event', {
       eventCategory,
       eventAction: 'Open detail page',
       eventLabel: title
     });
-    navigateTo(`/experiments/${experiment.slug}`);
   }
 
 }

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -18,13 +18,14 @@ export default class ExperimentRowCard extends React.Component {
     const isCompleted = isAfterCompletedDate(experiment);
 
     return (
-      <div data-hook="show-detail" className={classnames('experiment-summary', {
-        enabled,
-        'just-launched': this.justLaunched(),
-        'just-updated': this.justUpdated(),
-        'has-addon': hasAddon
-      })}>
-        <Link className='overlap-block' to={`/experiments/${slug}`} onClick={(evt) => this.openDetailPage(evt)} />
+      <Link data-hook="show-detail" to={`/experiments/${slug}`} onClick={(evt) => this.openDetailPage(evt)}
+        className={classnames('experiment-summary', {
+          enabled,
+          'just-launched': this.justLaunched(),
+          'just-updated': this.justUpdated(),
+          'has-addon': hasAddon
+        })}
+      >
         <div className="experiment-actions">
           {enabled && <div data-l10n-id="experimentListEnabledTab" className="tab enabled-tab"></div>}
           {this.justLaunched() && <div data-l10n-id="experimentListJustLaunchedTab" className="tab just-launched-tab"></div>}
@@ -49,7 +50,7 @@ export default class ExperimentRowCard extends React.Component {
         { this.renderInstallationCount(installation_count, isCompleted) }
         { this.renderManageButton(enabled, hasAddon, isCompleted) }
       </div>
-    </div>
+    </Link>
     );
   }
 
@@ -69,15 +70,15 @@ export default class ExperimentRowCard extends React.Component {
   renderManageButton(enabled, hasAddon, isCompleted) {
     if (enabled && hasAddon) {
       return (
-        <div className="button card-control secondary" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardManage">Manage</div>
+        <div className="button card-control secondary" data-l10n-id="experimentCardManage">Manage</div>
       );
     } else if (isCompleted) {
       return (
-        <div className="button card-control secondary" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardLearnMore">Learn More</div>
+        <div className="button card-control secondary" data-l10n-id="experimentCardLearnMore">Learn More</div>
       );
     }
     return (
-      <div className="button card-control default" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardGetStarted">Get Started</div>
+      <div className="button card-control default" data-l10n-id="experimentCardGetStarted">Get Started</div>
     );
   }
 

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -69,11 +69,11 @@ export default class ExperimentRowCard extends React.Component {
   renderManageButton(enabled, hasAddon, isCompleted) {
     if (enabled && hasAddon) {
       return (
-        <div className="button card-control secondary" data-l10n-id="experimentCardManage">Manage</div>
+        <div className="button card-control secondary" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardManage">Manage</div>
       );
     } else if (isCompleted) {
       return (
-        <div className="button card-control secondary" data-l10n-id="experimentCardLearnMore">Learn More</div>
+        <div className="button card-control secondary" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardLearnMore">Learn More</div>
       );
     }
     return (

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -77,7 +77,7 @@ export default class ExperimentRowCard extends React.Component {
       );
     }
     return (
-      <div className="button card-control default" data-l10n-id="experimentCardGetStarted">Get Started</div>
+      <div className="button card-control default" onClick={(evt) => this.openDetailPage(evt)} data-l10n-id="experimentCardGetStarted">Get Started</div>
     );
   }
 

--- a/frontend/src/styles/modules/_experiment-list.scss
+++ b/frontend/src/styles/modules/_experiment-list.scss
@@ -103,6 +103,19 @@
       box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue, 0 0 0 9px $transparent-white-1;
     }
   }
+
+  a.overlap-block {
+    background-color: $white;
+    filter: alpha(opacity=1);
+    height: 100%;
+    left: 0;
+    opacity: 0;
+    position: absolute;
+    text-decoration: none;
+    top: 0;
+    width: 100%;
+    z-index: 10;
+  }
 }
 
 .eol-message {

--- a/frontend/src/styles/modules/_experiment-list.scss
+++ b/frontend/src/styles/modules/_experiment-list.scss
@@ -25,7 +25,6 @@
   background-color: $white;
   border-radius: $small-border-radius + 1;
   box-shadow: 0 0 0 1px $transparent-black-1, 0 1px 0 1px $transparent-black-1;
-  color: $black;
   cursor: pointer;
   margin: 0 0 ($grid-unit * 1.75) ($grid-unit * 2);
   position: relative;
@@ -37,6 +36,7 @@
 
   .experiment-information {
     @include flex-container(column, flex-start, flex-start);
+    color: $black;
     flex: 1;
     padding: $grid-unit;
   }
@@ -102,23 +102,6 @@
     &:hover {
       box-shadow: 0 0 0 3px $white, 0 0 0 6px $bright-blue, 0 0 0 9px $transparent-white-1;
     }
-  }
-
-  a.overlap-block {
-    background-color: $white;
-    filter: alpha(opacity=1);
-    height: 100%;
-    left: 0;
-    opacity: 0;
-    position: absolute;
-    text-decoration: none;
-    top: 0;
-    width: 100%;
-    z-index: 2;
-  }
-
-  .card-control {
-    z-index: 3;
   }
 }
 

--- a/frontend/src/styles/modules/_experiment-list.scss
+++ b/frontend/src/styles/modules/_experiment-list.scss
@@ -114,7 +114,11 @@
     text-decoration: none;
     top: 0;
     width: 100%;
-    z-index: 10;
+    z-index: 2;
+  }
+
+  .card-control {
+    z-index: 3;
   }
 }
 

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -166,6 +166,15 @@ describe('app/components/ExperimentRowCard', () => {
     expect(findByL10nID('participantCount')).to.have.property('length', 0);
   });
 
+  it('should have a "Manage" button if the experiment is enabled and has an addon', () => {
+    expect(findByL10nID('experimentCardManage')).to.have.property('length', 0);
+    subject.setProps({
+      enabled: true,
+      hasAddon: true
+    });
+    expect(findByL10nID('experimentCardManage')).to.have.property('length', 1);
+  })
+
   it('should ping GA and open the detail page when clicked', () => {
     subject.find('.overlap-block').simulate('click', mockClickEvent);
 
@@ -175,6 +184,36 @@ describe('app/components/ExperimentRowCard', () => {
       eventAction: 'Open detail page',
       eventLabel: mockExperiment.title
     }]);
+    expect(props.navigateTo.lastCall.args[0])
+      .to.equal(`/experiments/${mockExperiment.slug}`);
+  });
+
+  it('Get Started button should open the detail page when clicked', () => {
+    findByL10nID('experimentCardGetStarted').simulate('click', mockClickEvent);
+
+    expect(mockClickEvent.preventDefault.called).to.be.true;
+    expect(props.navigateTo.lastCall.args[0])
+      .to.equal(`/experiments/${mockExperiment.slug}`);
+  });
+
+  it('Manage button should open the detail page when clicked', () => {
+    // Set props so manage button is in DOM.
+    subject.setProps({
+      enabled: true,
+      hasAddon: true
+    });
+
+    findByL10nID('experimentCardManage').simulate('click', mockClickEvent);
+
+    expect(mockClickEvent.preventDefault.called).to.be.true;
+    expect(props.navigateTo.lastCall.args[0])
+      .to.equal(`/experiments/${mockExperiment.slug}`);
+  });
+
+  it('Learn More button should open the detail page when clicked', () => {
+    findByL10nID('experimentCardGetStarted').simulate('click', mockClickEvent);
+
+    expect(mockClickEvent.preventDefault.called).to.be.true;
     expect(props.navigateTo.lastCall.args[0])
       .to.equal(`/experiments/${mockExperiment.slug}`);
   });

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -167,7 +167,7 @@ describe('app/components/ExperimentRowCard', () => {
   });
 
   it('should ping GA and open the detail page when clicked', () => {
-    subject.find('.experiment-summary').simulate('click', mockClickEvent);
+    subject.find('.overlap-block').simulate('click', mockClickEvent);
 
     expect(mockClickEvent.preventDefault.called).to.be.true;
     expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -187,4 +187,14 @@ describe('app/components/ExperimentRowCard', () => {
     expect(props.navigateTo.lastCall.args[0])
       .to.equal(`/experiments/${mockExperiment.slug}`);
   });
+
+  it('should have a Link component with the right properties', () => {
+    const link = subject.find('Link');
+    expect(link).to.not.be.a('null');
+    expect(link.props()).to.contain.all({
+      'data-hook': 'show-detail',
+      to: `/experiments/${mockExperiment.slug}`,
+      className: 'experiment-summary'
+    });
+  });
 });

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -176,7 +176,7 @@ describe('app/components/ExperimentRowCard', () => {
   })
 
   it('should ping GA and open the detail page when clicked', () => {
-    subject.find('.overlap-block').simulate('click', mockClickEvent);
+    subject.find('.experiment-summary').simulate('click', mockClickEvent);
 
     expect(mockClickEvent.preventDefault.called).to.be.true;
     expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
@@ -184,36 +184,6 @@ describe('app/components/ExperimentRowCard', () => {
       eventAction: 'Open detail page',
       eventLabel: mockExperiment.title
     }]);
-    expect(props.navigateTo.lastCall.args[0])
-      .to.equal(`/experiments/${mockExperiment.slug}`);
-  });
-
-  it('Get Started button should open the detail page when clicked', () => {
-    findByL10nID('experimentCardGetStarted').simulate('click', mockClickEvent);
-
-    expect(mockClickEvent.preventDefault.called).to.be.true;
-    expect(props.navigateTo.lastCall.args[0])
-      .to.equal(`/experiments/${mockExperiment.slug}`);
-  });
-
-  it('Manage button should open the detail page when clicked', () => {
-    // Set props so manage button is in DOM.
-    subject.setProps({
-      enabled: true,
-      hasAddon: true
-    });
-
-    findByL10nID('experimentCardManage').simulate('click', mockClickEvent);
-
-    expect(mockClickEvent.preventDefault.called).to.be.true;
-    expect(props.navigateTo.lastCall.args[0])
-      .to.equal(`/experiments/${mockExperiment.slug}`);
-  });
-
-  it('Learn More button should open the detail page when clicked', () => {
-    findByL10nID('experimentCardGetStarted').simulate('click', mockClickEvent);
-
-    expect(mockClickEvent.preventDefault.called).to.be.true;
     expect(props.navigateTo.lastCall.args[0])
       .to.equal(`/experiments/${mockExperiment.slug}`);
   });


### PR DESCRIPTION
Fixes #1462.

This enables default browser functionality like opening the card links in another tab. This was a rather fun little problem to fix and I might need help testing this cross-browser. So far I've tested in Firefox, Chrome and IE11.

There are actually three possible solutions for this problem:
1. Wrap the div inside an anchor tag. - This is invalid HTML unless it contains other interactive elements, see [stack overflow question](http://stackoverflow.com/questions/1827965/is-putting-a-div-inside-an-anchor-ever-correct).
2. Make the anchor tag the div. - This is buggy cross-browser, so a complete no go imo.
3. Add an overlaying anchor tag. - Better solution, but I don't know how this affects clickable elements inside the card(which you do not have right now, but seem to be planning to add, refers back to solution 1.)

I've chosen for solution 3 as it includes the least amount of hacks in my opinion. If you know any other solution that's not as hacky as aforementioned solutions please do let me know and I will realize that instead.
