### PR TITLE
[fixes #1678] Use 'location' instead of 'page' for pageviews

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -70,7 +70,7 @@ class App extends Component {
     if (window.ga && ga.loaded) {
       const data = dataIn || {};
       data.hitType = type;
-      data.page = (pathname === '/') ? pathname : '/' + pathname;
+      data.location = window.location;
       ga('send', data);
     }
   }


### PR DESCRIPTION
`window.location` has the correct URL host/path/query params in my testing.

Fixes #1678.
