### PR TITLE
Dynamically generate data-l10n-id for content from YAML (closes #1340).

### DIFF
--- a/content-src/experiments/activity-stream.yaml
+++ b/content-src/experiments/activity-stream.yaml
@@ -43,12 +43,10 @@ pre_feedback_image:
 pre_feedback_copy:
 details:
   -
-    headline: ' '
     image: /static/images/experiments/activity-stream/experiments_experimentdetail/1/6/16f2bfb82c63c38573005923f4e08457_image_1462827231_0751.png
     copy: >
       Click on a new tab, and your favorite sites are only one more click away.
   -
-    headline: ' '
     image: /static/images/experiments/activity-stream/experiments_experimentdetail/6/7/67858740793232e7a71f86b4ef272b67_image_1462827231_0657.png
     copy: >
       See where you've been, so you can get on to where you're going.

--- a/content-src/experiments/min-vid.yaml
+++ b/content-src/experiments/min-vid.yaml
@@ -45,17 +45,14 @@ gradient_start: '#FED66F'
 gradient_stop: '#FD667B'
 details:
   -
-    headline: ' '
     image: /static/images/experiments/min-vid/experiments_experimentdetail/detail1.jpg
     copy: >
       Access Min Vid from YouTube and Vimeo video players.
   -
-    headline: ' '
     image: /static/images/experiments/min-vid/experiments_experimentdetail/detail2.jpg
     copy: >
       Watch video in the foreground while you do other things on the Web.
   -
-    headline: ' '
     image: /static/images/experiments/min-vid/experiments_experimentdetail/detail3.jpg
     copy: >
       Right click on links to video to find Min Vid in the in-context controls.

--- a/content-src/experiments/no-more-404s.yaml
+++ b/content-src/experiments/no-more-404s.yaml
@@ -45,12 +45,10 @@ pre_feedback_image:
 pre_feedback_copy:
 details:
   -
-    headline: ' '
     image: /static/images/experiments/no-more-404s/experiments_experimentdetail/2/4/24ddd4335aca6b96cca9106a6f3411d2_image_1470245154_0440.jpg
     copy: >
       Reduce 404 dead ends with the Wayback Machine.
   -
-    headline: ' '
     image: /static/images/experiments/no-more-404s/experiments_experimentdetail/c/d/cdb624363e0e87af81125c39bc69c933_image_1470245154_0280.jpg
     copy: >
       Brought to you by our friends at the Internet Archive.
@@ -74,7 +72,6 @@ notifications:
 contributors:
   -
     display_name: 'The Internet Archive'
-    title: ""
     avatar: /static/images/experiments/no-more-404s/avatars/the-internet-archive.png
   -
     display_name: 'Richard Caceres'

--- a/content-src/experiments/page-shot.yaml
+++ b/content-src/experiments/page-shot.yaml
@@ -52,19 +52,16 @@ gradient_start: '#02BDAD'
 gradient_stop: '#035295'
 details:
   -
-    headline: ' '
     image: /static/images/experiments/page-shot/experiments_experimentdetail/detail1.jpg
     copy: >
       Select the image area and save if you like what you see, cancel without
       saving if you don’t.
   -
-    headline: ' '
     image: /static/images/experiments/page-shot/experiments_experimentdetail/detail2.jpg
     copy: >
       Share links to images via social or email, without having to download and
       attach a file.
   -
-    headline: ' '
     image: /static/images/experiments/page-shot/experiments_experimentdetail/detail3.jpg
     copy: >
       Find saved screenshots easily. Browse thumbnails in grid view or search by keyword.

--- a/content-src/experiments/tab-center.yaml
+++ b/content-src/experiments/tab-center.yaml
@@ -40,17 +40,14 @@ pre_feedback_image:
 pre_feedback_copy:
 details:
   -
-    headline: ' '
     image: /static/images/experiments/tab-center/details/tab-center-1.jpg
     copy: >
       Take your tabs on the side.
   -
-    headline: ' '
     image: /static/images/experiments/tab-center/details/tab-center-2.jpg
     copy: >
       Tuck away those tabs until you need them.
   -
-    headline: ' '
     image: /static/images/experiments/tab-center/details/tab-center-3.jpg
     copy: >
       Redecorate and move the furniture! Tab Center works with your favorite Firefox themes.

--- a/content-src/experiments/tracking-protection.yaml
+++ b/content-src/experiments/tracking-protection.yaml
@@ -53,12 +53,10 @@ pre_feedback_copy: >
 pre_feedback_image: /static/images/experiments/tracking-protection/experiments_experimenttourstep/tour2.jpg
 details:
   -
-    headline: ' '
     image: /static/images/experiments/tracking-protection/experiments_experimentdetail/detail1.jpg
     copy: >
       Access all Tracking Protection features in the address bar.
   -
-    headline: ' '
     image: /static/images/experiments/tracking-protection/experiments_experimentdetail/detail2.jpg
     copy: >
       Report a problem and help us troubleshoot.

--- a/content-src/experiments/universal-search.yaml
+++ b/content-src/experiments/universal-search.yaml
@@ -53,14 +53,11 @@ pre_feedback_image:
 pre_feedback_copy:
 details:
   -
-    headline: ' '
     image: /static/images/experiments/universal-search/experiments_experimentdetail/6/d/6d0ff50eff9223f0d0cc58c5aa5d0c81_image_1462827811_0995.jpg
     copy: >
       Popular sites, people and Wikipedia articles appear as you type.
   -
-    headline: ' '
     image: /static/images/experiments/universal-search/experiments_experimentdetail/8/6/8675c7bf31054abdaf58b47850a1365d_image_1462827811_0451.jpg
-    copy: ' '
 tour_steps:
   -
     image: /static/images/experiments/universal-search/experiments_experimenttourstep/e/b/eb1a0c8bbb18c79f63d0df45d165eb7a_image_1462826805_0035.jpg

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -10,8 +10,8 @@ const MAX_JUST_LAUNCHED_PERIOD = 2 * ONE_WEEK;
 const MAX_JUST_UPDATED_PERIOD = 2 * ONE_WEEK;
 
 export default class ExperimentRowCard extends React.Component {
-  l10nId(pieces, path = null) {
-    return experimentL10nId(this.props.experiment, pieces, path);
+  l10nId(pieces) {
+    return experimentL10nId(this.props.experiment, pieces);
   }
 
   render() {
@@ -48,7 +48,7 @@ export default class ExperimentRowCard extends React.Component {
       <div className="experiment-information">
         <header>
           <h3 data-l10n-id={this.l10nId('title')}>{title}</h3>
-          <h4 data-l10n-id={this.l10nId('subtitle')} className="subtitle">{subtitle}</h4>
+          {subtitle && <h4 data-l10n-id={this.l10nId('subtitle')} className="subtitle">{subtitle}</h4>}
           <h4 className="eol-message">{this.statusMsg()}</h4>
         </header>
         <p data-l10n-id={this.l10nId('description')}>{description}</p>

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -2,12 +2,17 @@ import React from 'react';
 
 import classnames from 'classnames';
 
+import { experimentL10nId } from '../lib/utils';
+
 const ONE_DAY = 24 * 60 * 60 * 1000;
 const ONE_WEEK = 7 * ONE_DAY;
 const MAX_JUST_LAUNCHED_PERIOD = 2 * ONE_WEEK;
 const MAX_JUST_UPDATED_PERIOD = 2 * ONE_WEEK;
 
 export default class ExperimentRowCard extends React.Component {
+  l10nId(pieces, path = null) {
+    return experimentL10nId(this.props.experiment, pieces, path);
+  }
 
   render() {
     const { hasAddon, experiment, enabled, isAfterCompletedDate } = this.props;
@@ -42,11 +47,11 @@ export default class ExperimentRowCard extends React.Component {
       </div>
       <div className="experiment-information">
         <header>
-          <h3>{title}</h3>
-          <h4 className="subtitle">{subtitle}</h4>
+          <h3 data-l10n-id={this.l10nId('title')}>{title}</h3>
+          <h4 data-l10n-id={this.l10nId('subtitle')} className="subtitle">{subtitle}</h4>
           <h4 className="eol-message">{this.statusMsg()}</h4>
         </header>
-        <p>{description}</p>
+        <p data-l10n-id={this.l10nId('description')}>{description}</p>
         { this.renderInstallationCount(installation_count, isCompleted) }
         { this.renderManageButton(enabled, hasAddon, isCompleted) }
       </div>

--- a/frontend/src/app/components/ExperimentTourDialog.js
+++ b/frontend/src/app/components/ExperimentTourDialog.js
@@ -9,8 +9,8 @@ export default class ExperimentTourDialog extends React.Component {
     this.state = { currentStep: 0 };
   }
 
-  l10nId(pieces, path = null) {
-    return experimentL10nId(this.props.experiment, pieces, path);
+  l10nId(pieces) {
+    return experimentL10nId(this.props.experiment, pieces);
   }
 
   render() {
@@ -47,7 +47,7 @@ export default class ExperimentTourDialog extends React.Component {
               </div>
               {step.copy &&
                 <div className="tour-text"
-                     data-l10n-id={this.l10nId(['tourstep', idx], `tour_steps.${idx}.copy`)}
+                     data-l10n-id={this.l10nId(['tour_steps', idx, 'copy'])}
                      dangerouslySetInnerHTML={{ __html: step.copy }}></div>}
             </div>
           ))}

--- a/frontend/src/app/components/ExperimentTourDialog.js
+++ b/frontend/src/app/components/ExperimentTourDialog.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import classnames from 'classnames';
 
+import { experimentL10nId } from '../lib/utils';
+
 export default class ExperimentTourDialog extends React.Component {
   constructor(props) {
     super(props);
     this.state = { currentStep: 0 };
+  }
+
+  l10nId(pieces, path = null) {
+    return experimentL10nId(this.props.experiment, pieces, path);
   }
 
   render() {
@@ -41,6 +47,7 @@ export default class ExperimentTourDialog extends React.Component {
               </div>
               {step.copy &&
                 <div className="tour-text"
+                     data-l10n-id={this.l10nId(['tourstep', idx], `tour_steps.${idx}.copy`)}
                      dangerouslySetInnerHTML={{ __html: step.copy }}></div>}
             </div>
           ))}

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 
 import classnames from 'classnames';
 
-import { buildSurveyURL, formatDate, createMarkup } from '../lib/utils';
+import { buildSurveyURL, createMarkup, experimentL10nId, formatDate } from '../lib/utils';
 
 import LoadingPage from './LoadingPage';
 import NotFoundPage from './NotFoundPage';
@@ -63,6 +63,10 @@ export class ExperimentDetail extends React.Component {
     // HACK: Set this as a plain object property, so we don't trigger crazy
     // state changes on scrolling events.
     this.didScroll = false;
+  }
+
+  l10nId(pieces, path = null) {
+    return experimentL10nId(this.props.experiment, pieces, path);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -256,8 +260,8 @@ export class ExperimentDetail extends React.Component {
             </div>
             <div className="details-header responsive-content-wrapper">
               <header>
-                <h1 data-hook="title">{title}</h1>
-                <h4 data-hook="subtitle" className="subtitle">{subtitle}</h4>
+                <h1 data-hook="title" data-l10n-id={this.l10nId('title')}>{title}</h1>
+                <h4 data-hook="subtitle" className="subtitle" data-l10n-id={this.l10nId('subtitle')}>{subtitle}</h4>
               </header>
               { this.renderExperimentControls() }
               { this.renderMinimumVersionNotice(title, hasAddon, min_release) }
@@ -281,7 +285,7 @@ export class ExperimentDetail extends React.Component {
                     </section>
                     {!hasAddon && <div data-hook="inactive-user">
                       {!!introduction && <section className="introduction" data-hook="introduction-container">
-                        <div data-hook="introduction-html" dangerouslySetInnerHTML={createMarkup(introduction)}></div>
+                        <div data-l10n-id={this.l10nId('introduction')} data-hook="introduction-html" dangerouslySetInnerHTML={createMarkup(introduction)}></div>
                       </section>}
                     </div>}
                     {hasAddon && <section className="stats-section" data-hook="active-user">
@@ -323,7 +327,7 @@ export class ExperimentDetail extends React.Component {
                             <img className="avatar" data-hook="avatar" width="56" height="56" src={contributor.avatar} />
                             <div className="contributor">
                               <p data-hook="name" className="name">{contributor.display_name}</p>
-                              <p data-hook="title" className="title">{contributor.title}</p>
+                              <p data-hook="title" className="title" data-l10n-id={this.l10nId(['contributor', 'title', contributor.display_name], `contributors.${idx}.title`)}>{contributor.title}</p>
                             </div>
                           </li>
                         ))}
@@ -333,7 +337,7 @@ export class ExperimentDetail extends React.Component {
                       {measurements && <section data-hook="measurements-container"
                           className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
                         <h3 data-l10n-id="measurements">Your privacy</h3>
-                        <div data-hook="measurements-html" className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
+                        <div data-hook="measurements-html" data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
                         {privacy_notice_url && <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-l10n-args={JSON.stringify({ title })} data-hook="privacy-notice-url" href={privacy_notice_url}>You can learn more about the data collection for <span data-hook="title">{title}</span> here.</a>}
                       </section>}
                     </div>}
@@ -346,7 +350,7 @@ export class ExperimentDetail extends React.Component {
                   {this.renderEolBlock()}
                   {hasAddon && <div data-hook="active-user">
                     {!!introduction && <section className="introduction" data-hook="introduction-container">
-                      <div data-hook="introduction-html" dangerouslySetInnerHTML={createMarkup(introduction)}></div>
+                      <div data-hook="introduction-html" data-l10n-id={this.l10nId('description')} dangerouslySetInnerHTML={createMarkup(introduction)}></div>
                     </section>}
                   </div>}
                   <div className="details-list">
@@ -354,7 +358,10 @@ export class ExperimentDetail extends React.Component {
                      <div key={idx}>
                        <div data-hook="details" className="details-image">
                          <img data-hook="detail-image" width="680" src={detail.image} />
-                         <p className="caption"><strong data-hook="detail-headline">{detail.headline}</strong> <span data-hook="detail-copy" dangerouslySetInnerHTML={createMarkup(detail.copy)}></span></p>
+                         <p className="caption">
+                           <strong data-hook="detail-headline" data-l10n-id={this.l10nId(['detail', idx, 'headline'], `details.${idx}.headline`)}>{detail.headline}</strong>
+                           <span data-hook="detail-copy" data-l10n-id={this.l10nId(['detail', idx, 'copy'], `details.${idx}.copy`)} dangerouslySetInnerHTML={createMarkup(detail.copy)}></span>
+                         </p>
                        </div>
                      </div>
                     ))}

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -65,8 +65,8 @@ export class ExperimentDetail extends React.Component {
     this.didScroll = false;
   }
 
-  l10nId(pieces, path = null) {
-    return experimentL10nId(this.props.experiment, pieces, path);
+  l10nId(pieces) {
+    return experimentL10nId(this.props.experiment, pieces);
   }
 
   componentWillReceiveProps(nextProps) {
@@ -261,7 +261,7 @@ export class ExperimentDetail extends React.Component {
             <div className="details-header responsive-content-wrapper">
               <header>
                 <h1 data-hook="title" data-l10n-id={this.l10nId('title')}>{title}</h1>
-                <h4 data-hook="subtitle" className="subtitle" data-l10n-id={this.l10nId('subtitle')}>{subtitle}</h4>
+                {subtitle && <h4 data-hook="subtitle" className="subtitle" data-l10n-id={this.l10nId('subtitle')}>{subtitle}</h4>}
               </header>
               { this.renderExperimentControls() }
               { this.renderMinimumVersionNotice(title, hasAddon, min_release) }
@@ -327,7 +327,7 @@ export class ExperimentDetail extends React.Component {
                             <img className="avatar" data-hook="avatar" width="56" height="56" src={contributor.avatar} />
                             <div className="contributor">
                               <p data-hook="name" className="name">{contributor.display_name}</p>
-                              <p data-hook="title" className="title" data-l10n-id={this.l10nId(['contributor', 'title', contributor.display_name], `contributors.${idx}.title`)}>{contributor.title}</p>
+                              {contributor.title && <p data-hook="title" className="title" data-l10n-id={this.l10nId(['contributors', idx, 'title'])}>{contributor.title}</p>}
                             </div>
                           </li>
                         ))}
@@ -359,8 +359,8 @@ export class ExperimentDetail extends React.Component {
                        <div data-hook="details" className="details-image">
                          <img data-hook="detail-image" width="680" src={detail.image} />
                          <p className="caption">
-                           <strong data-hook="detail-headline" data-l10n-id={this.l10nId(['detail', idx, 'headline'], `details.${idx}.headline`)}>{detail.headline}</strong>
-                           <span data-hook="detail-copy" data-l10n-id={this.l10nId(['detail', idx, 'copy'], `details.${idx}.copy`)} dangerouslySetInnerHTML={createMarkup(detail.copy)}></span>
+                           {detail.headline && <strong data-hook="detail-headline" data-l10n-id={this.l10nId(['details', idx, 'headline'])}>{detail.headline}</strong>}
+                           {detail.copy && <span data-hook="detail-copy" data-l10n-id={this.l10nId(['details', idx, 'copy'])} dangerouslySetInnerHTML={createMarkup(detail.copy)}></span>}
                          </p>
                        </div>
                      </div>

--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -1,5 +1,8 @@
 import querystring from 'querystring';
 
+import { experimentL10nId, l10nId, l10nIdFormat, lookup } from '../../../tasks/util';
+
+
 export function formatDate(date) {
   let out = '';
   const d = new Date(date);
@@ -42,10 +45,7 @@ export function isMinFirefoxVersion(isFirefox, ua, minVersion) {
 //
 // > l10nIdFormat('Activity Stream');
 // Activitystream
-export function l10nIdFormat(str) {
-  const segment = String(str).replace(/[^A-Za-z0-9]+/g, '');
-  return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
-}
+export { l10nIdFormat };
 
 
 // Passed an array of pieces, returns a formatted l10n ID comprised of those
@@ -53,11 +53,7 @@ export function l10nIdFormat(str) {
 //
 // > l10nId(['Activity Stream', 'Contributor', 'Title', 'Bryan Bell']);
 // 'activitystreamContributorTitleBryanbell'
-export function l10nId(pieces) {
-  pieces[0] = l10nIdFormat(pieces[0]);
-  const stitched = pieces.reduce((a, b) => `${a}${l10nIdFormat(b)}`);
-  return stitched.charAt(0).toLowerCase() + stitched.slice(1);
-}
+export { l10nId };
 
 
 // Passed three pieces of information, generates and returns an appropriate l10n
@@ -65,27 +61,11 @@ export function l10nId(pieces) {
 //
 // Params:
 // - experiment - the JavaScript object representing the experiment.
-// - pieces - an array of segments comprising the generated l10n ID. If a string
-//            is passed, it's converted to a single-item array.
-// - path - an optional string representing the period-delimited path to the
-//          property of the experiment that the l10n ID references. This is used
-//          to look for a _l10nid version of that field, which is used as a
-//          suffix if present. If omitted, the first item in `pieces` is used.
-export function experimentL10nId(experiment, pieces, path = null) {
-  if (typeof pieces === 'string') {
-    pieces = [pieces];
-  }
-  if (!path) {
-    path = pieces[0];
-  }
-  if (path) {
-    const suffix = lookup(experiment, `${path}_l10nid`);
-    if (suffix) {
-      pieces.push(suffix);
-    }
-  }
-  return l10nId([].concat([experiment.slug], pieces));
-}
+// - pieces - an array of segments used for two purposes:
+//            1) to construct the generated l10n ID
+//            2) to search for an _l10n suffix for the field.
+//            If a string is passed, it's converted to a single-item array.
+export { experimentL10nId };
 
 
 // Passed an object and a period.delimited string indicating a path, returns the
@@ -96,10 +76,4 @@ export function experimentL10nId(experiment, pieces, path = null) {
 //
 // >> lookup({}, 'foo');
 // null
-export function lookup(obj, path) {
-  const pieces = path.split('.');
-  if (pieces.length > 1) {
-    return lookup(obj[pieces[0]], pieces.slice(1).join('.'));
-  }
-  return obj[pieces[0]] || null;
-}
+export { lookup };

--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -34,3 +34,72 @@ export function isMinFirefoxVersion(isFirefox, ua, minVersion) {
   if (!isFirefox) return false;
   return parseInt(ua.split('/').pop(), 10) >= minVersion;
 }
+
+
+// Passed a string, returns a verison of that string sanitized by stripping all
+// non-alphanumeric characters, lowercasing the entire string, then capitalizing
+// the first character.
+//
+// > l10nIdFormat('Activity Stream');
+// Activitystream
+export function l10nIdFormat(str) {
+  const segment = String(str).replace(/[^A-Za-z0-9]+/g, '');
+  return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+}
+
+
+// Passed an array of pieces, returns a formatted l10n ID comprised of those
+// pieces, sanitized and camel-cased.
+//
+// > l10nId(['Activity Stream', 'Contributor', 'Title', 'Bryan Bell']);
+// 'activitystreamContributorTitleBryanbell'
+export function l10nId(pieces) {
+  pieces[0] = l10nIdFormat(pieces[0]);
+  const stitched = pieces.reduce((a, b) => `${a}${l10nIdFormat(b)}`);
+  return stitched.charAt(0).toLowerCase() + stitched.slice(1);
+}
+
+
+// Passed three pieces of information, generates and returns an appropriate l10n
+// ID.
+//
+// Params:
+// - experiment - the JavaScript object representing the experiment.
+// - pieces - an array of segments comprising the generated l10n ID. If a string
+//            is passed, it's converted to a single-item array.
+// - path - an optional string representing the period-delimited path to the
+//          property of the experiment that the l10n ID references. This is used
+//          to look for a _l10nid version of that field, which is used as a
+//          suffix if present. If omitted, the first item in `pieces` is used.
+export function experimentL10nId(experiment, pieces, path = null) {
+  if (typeof pieces === 'string') {
+    pieces = [pieces];
+  }
+  if (!path) {
+    path = pieces[0];
+  }
+  if (path) {
+    const suffix = lookup(experiment, `${path}_l10nid`);
+    if (suffix) {
+      pieces.push(suffix);
+    }
+  }
+  return l10nId([].concat([experiment.slug], pieces));
+}
+
+
+// Passed an object and a period.delimited string indicating a path, returns the
+// value at that path if it exists, or null if it doesn't.
+//
+// >> lookup({ foo: [ { bar: 'baz' } ] }, 'foo.0.bar');
+// 'baz'
+//
+// >> lookup({}, 'foo');
+// null
+export function lookup(obj, path) {
+  const pieces = path.split('.');
+  if (pieces.length > 1) {
+    return lookup(obj[pieces[0]], pieces.slice(1).join('.'));
+  }
+  return obj[pieces[0]] || null;
+}

--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -10,6 +10,7 @@
     <meta name="availableLanguages" content="en-US">
     <meta name="viewport" content="width=device-width">
     <link rel="localization" href="/static/locales/{locale}/app.ftl">
+    <link rel="localization" href="/static/locales/{locale}/experiments.ftl">
 
     <link rel="canonical" href="https://testpilot.firefox.com/{{{ canonical_path }}}">
 

--- a/frontend/tasks/util.js
+++ b/frontend/tasks/util.js
@@ -1,0 +1,59 @@
+const LOCALIZABLE_FIELDS = [
+  'title',
+  'subtitle',
+  'description',
+  'introduction',
+  'measurements',
+  'pre_feedback_copy',
+  'details.copy',
+  'tour_steps.copy',
+  'contributors.title'
+];
+
+function isLocalizableField(pieces) {
+  return LOCALIZABLE_FIELDS.includes(
+    pieces.reduce((a, b) => /^[0-9]+$/.test(b) ? a : `${a}.${b}`)
+  );
+}
+
+function l10nIdFormat(str) {
+  const segment = String(str).replace(/[^A-Za-z0-9]+/g, '');
+  return segment.charAt(0).toUpperCase() + segment.slice(1).toLowerCase();
+}
+
+function l10nId(pieces) {
+  pieces[0] = l10nIdFormat(pieces[0]);
+  const stitched = pieces.reduce((a, b) => `${a}${l10nIdFormat(b)}`);
+  return stitched.charAt(0).toLowerCase() + stitched.slice(1);
+}
+
+function lookup(obj, path) {
+  const pieces = path.split('.');
+  if (pieces.length > 1) {
+    try {
+      return lookup(obj[pieces[0]], pieces.slice(1).join('.'));
+    } catch(exc) {
+      return null;
+    }
+  }
+  return obj[pieces[0]] || null;
+}
+
+function experimentL10nId(experiment, pieces) {
+  if (typeof pieces === 'string') {
+    pieces = [pieces];
+  }
+  const suffix = lookup(experiment, `${pieces.join('.')}_l10nsuffix`);
+  if (suffix) {
+    pieces.push(suffix);
+  }
+  return l10nId([].concat([experiment.slug], pieces));
+}
+
+module.exports = {
+  isLocalizableField: isLocalizableField,
+  l10nIdFormat: l10nIdFormat,
+  l10nId: l10nId,
+  lookup: lookup,
+  experimentL10nId: experimentL10nId
+};

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -12,7 +12,7 @@ describe('app/components/ExperimentRowCard', () => {
     mockExperiment = {
       slug: 'testing',
       title: 'Testing Experiment',
-      title_l10nid: 'foo',
+      title_l10nsuffix: 'foo',
       subtitle: 'This is a subtitle.',
       description: 'This is a description.',
       created: moment().subtract(2, 'months').utc(),

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -12,6 +12,9 @@ describe('app/components/ExperimentRowCard', () => {
     mockExperiment = {
       slug: 'testing',
       title: 'Testing Experiment',
+      title_l10nid: 'foo',
+      subtitle: 'This is a subtitle.',
+      description: 'This is a description.',
       created: moment().subtract(2, 'months').utc(),
       modified: moment().subtract(2, 'months').utc()
     };
@@ -36,6 +39,12 @@ describe('app/components/ExperimentRowCard', () => {
 
   it('should render expected content', () => {
     expect(subject.find('.experiment-information header h3').text()).to.equal(mockExperiment.title);
+  });
+
+  it('should have the expected l10n ID', () => {
+    expect(findByL10nID('testingTitleFoo')).to.have.property('length', 1);
+    expect(findByL10nID('testingSubtitle')).to.have.property('length', 1);
+    expect(findByL10nID('testingDescription')).to.have.property('length', 1);
   });
 
   it('should change style based on hasAddon', () => {

--- a/frontend/test/app/components/ExperimentTourDialog-test.js
+++ b/frontend/test/app/components/ExperimentTourDialog-test.js
@@ -13,8 +13,9 @@ describe('app/components/ExperimentTourDialog', () => {
     props = {
       experiment: {
         title: 'Test Experiment',
+        slug: 'test',
         tour_steps: [
-          { image: '/example1.png', copy: '<p class="example1">Example 1</p>' },
+          { image: '/example1.png', copy: '<p class="example1">Example 1</p>', copy_l10nid: 'foo' },
           { image: '/example2.png', copy: '<p class="example2">Example 2</p>' },
           { image: '/example3.png', copy: '<p class="example3">Example 3</p>' },
         ]
@@ -38,6 +39,10 @@ describe('app/components/ExperimentTourDialog', () => {
       .to.equal(expectedTourStep.image);
     expect(subject.find('.tour-text').html())
       .to.include(expectedTourStep.copy);
+  });
+
+  it('should have the correct l10n IDs', () => {
+    expect(subject.find('.tour-text').prop('data-l10n-id')).to.equal('testTourstep0Foo');
   });
 
   it('should advance one step and ping GA when the next button is clicked', () => {

--- a/frontend/test/app/components/ExperimentTourDialog-test.js
+++ b/frontend/test/app/components/ExperimentTourDialog-test.js
@@ -15,7 +15,7 @@ describe('app/components/ExperimentTourDialog', () => {
         title: 'Test Experiment',
         slug: 'test',
         tour_steps: [
-          { image: '/example1.png', copy: '<p class="example1">Example 1</p>', copy_l10nid: 'foo' },
+          { image: '/example1.png', copy: '<p class="example1">Example 1</p>', copy_l10nsuffix: 'foo' },
           { image: '/example2.png', copy: '<p class="example2">Example 2</p>' },
           { image: '/example3.png', copy: '<p class="example3">Example 3</p>' },
         ]
@@ -42,7 +42,7 @@ describe('app/components/ExperimentTourDialog', () => {
   });
 
   it('should have the correct l10n IDs', () => {
-    expect(subject.find('.tour-text').prop('data-l10n-id')).to.equal('testTourstep0Foo');
+    expect(subject.find('.tour-text').prop('data-l10n-id')).to.equal('testToursteps0CopyFoo');
   });
 
   it('should advance one step and ping GA when the next button is clicked', () => {

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -42,10 +42,13 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
     mockExperiment = {
       slug: 'testing',
       title: 'Testing',
+      title_l10nid: 'foo',
+      subtitle: 'Testing',
       version: '1.0',
       thumbnail: '/thumbnail.png',
       introduction: '<p class="test-introduction">Introduction!</p>',
       measurements: '<p class="test-measurements">Measurements</p>',
+      description: 'Description',
       pre_feedback_copy: null,
       contribute_url: 'https://example.com/contribute',
       bug_report_url: 'https://example.com/bugs',
@@ -53,8 +56,20 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
       privacy_notice_url: 'https://example.com/privacy',
       changelog_url: 'https://example.com/changelog',
       survey_url: 'https://example.com/survey',
-      contributors: [ ],
-      details: [ ],
+      contributors: [
+        {
+          display_name: 'Jorge Soler',
+          title: 'Right Fielder',
+          avatar: '/soler.jpg'
+        }
+      ],
+      details: [
+        {
+          headline: ' ',
+          image: '/img.jpg',
+          copy: 'Testing'
+        }
+      ],
       min_release: 48.0,
       error: false
     };
@@ -107,6 +122,21 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
     });
     return experiment;
   };
+
+  it('should have the correct l10n IDs', () => {
+    setExperiment(mockExperiment);
+    expect(findByL10nID('testingTitleFoo')).to.have.property('length', 1);
+    expect(findByL10nID('testingSubtitle')).to.have.property('length', 1);
+    expect(findByL10nID('testingIntroduction')).to.have.property('length', 1);
+    expect(findByL10nID('testingContributorTitleJorgesoler')).to.have.property('length', 1);
+    expect(findByL10nID('testingDetail0Headline')).to.have.property('length', 1);
+    expect(findByL10nID('testingDetail0Copy')).to.have.property('length', 1);
+
+    // Fields only available when the add-on is installed.
+    subject.setProps({ hasAddon: true });
+    expect(findByL10nID('testingMeasurements')).to.have.property('length', 1);
+    expect(findByL10nID('testingDescription')).to.have.property('length', 1);
+  });
 
   it('should render a loading page if no experiments are available', () => {
     expect(subject.find('LoadingPage')).to.have.property('length', 1);

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -42,7 +42,7 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
     mockExperiment = {
       slug: 'testing',
       title: 'Testing',
-      title_l10nid: 'foo',
+      title_l10nsuffix: 'foo',
       subtitle: 'Testing',
       version: '1.0',
       thumbnail: '/thumbnail.png',
@@ -128,9 +128,9 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
     expect(findByL10nID('testingTitleFoo')).to.have.property('length', 1);
     expect(findByL10nID('testingSubtitle')).to.have.property('length', 1);
     expect(findByL10nID('testingIntroduction')).to.have.property('length', 1);
-    expect(findByL10nID('testingContributorTitleJorgesoler')).to.have.property('length', 1);
-    expect(findByL10nID('testingDetail0Headline')).to.have.property('length', 1);
-    expect(findByL10nID('testingDetail0Copy')).to.have.property('length', 1);
+    expect(findByL10nID('testingContributors0Title')).to.have.property('length', 1);
+    expect(findByL10nID('testingDetails0Headline')).to.have.property('length', 1);
+    expect(findByL10nID('testingDetails0Copy')).to.have.property('length', 1);
 
     // Fields only available when the add-on is installed.
     subject.setProps({ hasAddon: true });

--- a/frontend/test/app/lib/utils-test.js
+++ b/frontend/test/app/lib/utils-test.js
@@ -1,0 +1,87 @@
+import { expect } from 'chai';
+import { l10nIdFormat, l10nId, experimentL10nId, lookup } from '../../../src/app/lib/utils';
+
+describe('app/lib/utils', () => {
+
+  describe('l10nIdFormat', () => {
+    it('should strip non-alpha characters', () => {
+      expect(l10nIdFormat('a_%-b')).to.equal('Ab');
+    });
+
+    it('should only capitalize the first letter', () => {
+      expect(l10nIdFormat('ABCDE')).to.equal('Abcde');
+    });
+
+    it('should coerce integers to strings', () => {
+      expect(l10nIdFormat(1)).to.equal('1');
+    });
+  });
+
+  describe('l10nId', () => {
+    it('should join the pieces', () => {
+      expect(l10nId(['a', 'b', 'c'])).to.equal('aBC');
+    });
+
+    it('should sanitize each piece', () => {
+      expect(l10nId(['A-', 'b-', 'c-'])).to.equal('aBC');
+    });
+  });
+
+  const mockLookup = {
+    string: 'a',
+    object: {
+      b: 'c'
+    },
+    array: [
+      {
+        x: 'y',
+        x_l10nid: 'z'
+      }
+    ],
+    string2: 'h',
+    string2_l10nid: 'i'
+  };
+
+  describe('lookup', () => {
+    it('should fetch properties of the object', () => {
+      expect(lookup(mockLookup, 'string')).to.equal(mockLookup.string);
+    });
+
+    it('should fetch nested properties', () => {
+      expect(lookup(mockLookup, 'object.b')).to.equal(mockLookup.object.b);
+    });
+
+    it('should fetch array items via index', () => {
+      expect(lookup(mockLookup, 'array.0.x')).to.equal(mockLookup.array[0].x);
+    });
+  });
+
+  describe('experimentL10nId', () => {
+    const mockExperiment = Object.assign({slug: 'foo'}, mockLookup);
+
+    it('should generate the correct l10n ID', () => {
+      expect(experimentL10nId(mockExperiment, ['string'], 'string')).to.equal('fooString');
+    });
+
+    it('should respect _l10nid suffices', () => {
+      expect(experimentL10nId(mockExperiment, ['string2'], 'string2')).to.equal('fooString2I');
+    });
+
+    it('handles missing paths by using the first piece', () => {
+      expect(experimentL10nId(mockExperiment, ['string'])).to.equal('fooString');
+    });
+
+    it('handles a string piece by turning it into an array', () => {
+      expect(experimentL10nId(mockExperiment, 'string')).to.equal('fooString');
+    });
+
+    it('looks up object properties', () => {
+      expect(experimentL10nId(mockExperiment, ['object', 'b'], 'object.b')).to.equal('fooObjectB');
+    });
+
+    it('looks up array items', () => {
+      expect(experimentL10nId(mockExperiment, ['array', '0', 'x'], 'object.b')).to.equal('fooArray0X');
+    });
+  });
+
+});

--- a/frontend/test/app/lib/utils-test.js
+++ b/frontend/test/app/lib/utils-test.js
@@ -35,11 +35,11 @@ describe('app/lib/utils', () => {
     array: [
       {
         x: 'y',
-        x_l10nid: 'z'
+        x_l10nsuffix: 'z'
       }
     ],
     string2: 'h',
-    string2_l10nid: 'i'
+    string2_l10nsuffix: 'i'
   };
 
   describe('lookup', () => {
@@ -60,15 +60,11 @@ describe('app/lib/utils', () => {
     const mockExperiment = Object.assign({slug: 'foo'}, mockLookup);
 
     it('should generate the correct l10n ID', () => {
-      expect(experimentL10nId(mockExperiment, ['string'], 'string')).to.equal('fooString');
-    });
-
-    it('should respect _l10nid suffices', () => {
-      expect(experimentL10nId(mockExperiment, ['string2'], 'string2')).to.equal('fooString2I');
-    });
-
-    it('handles missing paths by using the first piece', () => {
       expect(experimentL10nId(mockExperiment, ['string'])).to.equal('fooString');
+    });
+
+    it('should respect _l10nsuffix suffices', () => {
+      expect(experimentL10nId(mockExperiment, ['string2'])).to.equal('fooString2I');
     });
 
     it('handles a string piece by turning it into an array', () => {
@@ -76,11 +72,11 @@ describe('app/lib/utils', () => {
     });
 
     it('looks up object properties', () => {
-      expect(experimentL10nId(mockExperiment, ['object', 'b'], 'object.b')).to.equal('fooObjectB');
+      expect(experimentL10nId(mockExperiment, ['object', 'b'])).to.equal('fooObjectB');
     });
 
     it('looks up array items', () => {
-      expect(experimentL10nId(mockExperiment, ['array', '0', 'x'], 'object.b')).to.equal('fooArray0X');
+      expect(experimentL10nId(mockExperiment, ['array', '0', 'x'])).to.equal('fooArray0XZ');
     });
   });
 


### PR DESCRIPTION
As discussed, this has been updated to allow for per-field l10n ID suffixes. So if the title of Activity Stream is updated to be plural again, the YAML can be updated to this:

``` yaml
title: 'Activity Streams'
title_l10nid: 'plural'
```

And its `data-l10n-id` will be changed from `activitystreamTitle` to `activitystreamTitlePlural`, invalidating all the translations. This also works for nested properties, e.g.:

``` yaml
contributors:
  -
    title: 'Staff Engineer'
    title_l10nid: 'staff'
```

Note: when this is merged, we will need to go through Pontoon and translate all the YAML content in English. This will always have to be done for new experiments.
