### PR TITLE
[fixes #1461] Add ID to Survey Gizmo URLs

### DIFF
--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -121,6 +121,7 @@ function launchSurvey(options) {
             if (clicked) {
               const urlParams = {
                 id: experiment.addon_id,
+                cid: store.clientUUID,
                 installed: Object.keys(store.installedAddons),
                 rating,
                 interval

--- a/frontend/src/app/components/ExperimentDisableDialog.js
+++ b/frontend/src/app/components/ExperimentDisableDialog.js
@@ -4,10 +4,10 @@ import { buildSurveyURL } from '../lib/utils';
 
 export default class ExperimentDisableDialog extends React.Component {
   render() {
-    const { experiment, installed } = this.props;
+    const { experiment, installed, clientUUID } = this.props;
     const { title, survey_url } = experiment;
 
-    const surveyURL = buildSurveyURL('disable', title, installed, survey_url);
+    const surveyURL = buildSurveyURL('disable', title, installed, clientUUID, survey_url);
 
     return (
       <div className="modal-container">

--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -127,6 +127,7 @@ const mapStateToProps = state => ({
   getExperimentBySlug: slug =>
     getExperimentBySlug(state.experiments, slug),
   hasAddon: state.addon.hasAddon,
+  clientUUID: state.addon.clientUUID,
   installed: getInstalled(state.addon),
   installedAddons: state.addon.installedAddons,
   installedLoaded: isInstalledLoaded(state.addon),

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -140,7 +140,7 @@ export class ExperimentDetail extends React.Component {
   }
 
   render() {
-    const { experiment, experiments, installed, isDev, hasAddon, setExperimentLastSeen } = this.props;
+    const { experiment, experiments, installed, isDev, hasAddon, setExperimentLastSeen, clientUUID } = this.props;
 
     // Show the loading animation if experiments haven't been loaded yet.
     if (experiments.length === 0) { return <LoadingPage />; }
@@ -170,7 +170,7 @@ export class ExperimentDetail extends React.Component {
     // ExperimentRowCard updated/launched banner logic)
     setExperimentLastSeen(experiment);
 
-    const surveyURL = buildSurveyURL('givefeedback', title, installed, survey_url);
+    const surveyURL = buildSurveyURL('givefeedback', title, installed, clientUUID, survey_url);
     const modified = formatDate(experiment.modified);
 
     let statusType = null;
@@ -473,10 +473,10 @@ export class ExperimentDetail extends React.Component {
 
   renderExperimentControls() {
     const { enabled, isEnabling, isDisabling, progressButtonWidth } = this.state;
-    const { experiment, installed, isAfterCompletedDate, hasAddon } = this.props;
+    const { experiment, installed, isAfterCompletedDate, hasAddon, clientUUID } = this.props;
     const { title, min_release, survey_url } = experiment;
     const validVersion = this.isValidVersion(min_release);
-    const surveyURL = buildSurveyURL('givefeedback', title, installed, survey_url);
+    const surveyURL = buildSurveyURL('givefeedback', title, installed, clientUUID, survey_url);
 
     if (!hasAddon || !validVersion) {
       return null;
@@ -647,6 +647,7 @@ export class ExperimentDetail extends React.Component {
 
 ExperimentDetail.propTypes = {
   userAgent: React.PropTypes.string,
+  clientUUID: React.PropTypes.string,
   isDev: React.PropTypes.bool,
   hasAddon: React.PropTypes.bool,
   experiments: React.PropTypes.array,

--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -16,10 +16,11 @@ export function formatDate(date) {
   return out;
 }
 
-export function buildSurveyURL(ref, title, installed, survey_url) {
+export function buildSurveyURL(ref, title, installed, clientUUID, survey_url) {
   const queryParams = querystring.stringify({
     ref,
     experiment: title,
+    cid: clientUUID,
     installed: installed ? Object.keys(installed) : []
   });
   return `${survey_url}?${queryParams}`;

--- a/frontend/test/app/components/ExperimentDisableDialog-test.js
+++ b/frontend/test/app/components/ExperimentDisableDialog-test.js
@@ -8,6 +8,7 @@ import ExperimentDisableDialog from '../../../src/app/components/ExperimentDisab
 describe('app/components/ExperimentDisableDialog', () => {
   const experiment = { title: 'foobar', survey_url: 'https://example.com' };
   const installed = { ex1: true, ex2: true };
+  const clientUUID = '38c51b84-9586-499f-ac52-94626e2b29cf';
 
   let onSubmit, onCancel, sendToGA, preventDefault, mockClickEvent, subject;
   beforeEach(function() {
@@ -20,7 +21,7 @@ describe('app/components/ExperimentDisableDialog', () => {
       <ExperimentDisableDialog
         experiment={experiment} installed={installed}
         onSubmit={onSubmit} onCancel={onCancel}
-        sendToGA={sendToGA} />
+        clientUUID={clientUUID} sendToGA={sendToGA} />
     );
   });
 
@@ -38,7 +39,7 @@ describe('app/components/ExperimentDisableDialog', () => {
 
   it('should launch a survey when submit button clicked', () => {
     const submitLink = subject.find('.modal-actions a.submit');
-    const expectedHref = 'https://example.com?ref=disable&experiment=foobar&installed=ex1&installed=ex2';
+    const expectedHref = 'https://example.com?ref=disable&experiment=foobar&cid=38c51b84-9586-499f-ac52-94626e2b29cf&installed=ex1&installed=ex2';
 
     expect(submitLink.props().href).to.equal(expectedHref);
 

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -398,9 +398,9 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
         });
 
         it('should have the expected survey URL on the "Give Feedback" button', () => {
-          subject.setProps({ installed: { foo: true, bar: true } });
+          subject.setProps({ installed: { foo: true, bar: true }, clientUUID: '38c51b84-9586-499f-ac52-94626e2b29cf' });
           const button = subject.find('#feedback-button');
-          const expectedHref = 'https://example.com/survey?ref=givefeedback&experiment=Testing&installed=foo&installed=bar';
+          const expectedHref = 'https://example.com/survey?ref=givefeedback&experiment=Testing&cid=38c51b84-9586-499f-ac52-94626e2b29cf&installed=foo&installed=bar';
           expect(button.prop('href')).to.equal(expectedHref);
         });
 


### PR DESCRIPTION
Would like verification from someone else that the add-on heartbeat survey is populating correctly.

Fixes #1461.
