### PR TITLE
fixed l20n/react conflict on user count text

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -471,8 +471,10 @@ export class ExperimentDetail extends React.Component {
     }
     const installCount = installation_count.toLocaleString();
     return (
-      <span data-l10n-id="userCountContainer" data-l10n-args={JSON.stringify({ installation_count: installCount, title })}>There are <span data-l10n-id="userCount" className="bold">{installCount}</span>
-      people trying {title} right now!</span>
+      // Note: this doesn't include the text content because of a conflict
+      // in how l20n and react modify the dom.
+      // https://github.com/mozilla/testpilot/pull/1712
+      <span data-l10n-id="userCountContainer" data-l10n-args={JSON.stringify({ installation_count: installCount, title })}><span className="bold"></span></span>
     );
   }
 


### PR DESCRIPTION
This is a semi-hacky way to fix #1696 and #1698 

The problem is that react adds comment nodes that it relies on later for diffing that l20n clobbers when it translates. 

<img width="386" alt="screen shot 2016-10-27 at 4 33 03 pm" src="https://cloud.githubusercontent.com/assets/87619/19817588/01d8073e-9d01-11e6-9cdf-08e4dc929b8c.png">

By not rendering the text in react (just the elements) the replacement by l20n matches react's virtual dom close enough to not cause problems.

Having l20n and react both modify the dom independently isn't ideal. In the future we ought to look into a more integrated approach. This thread might have some leads: https://groups.google.com/forum/#!topic/mozilla.tools.l10n/XtxHgBEokCA
