### PR TITLE
Add Self-Destructing Cookies to incompatible add-on list

### DIFF
--- a/content-src/experiments/page-shot.yaml
+++ b/content-src/experiments/page-shot.yaml
@@ -109,3 +109,4 @@ modified: '2016-09-22T16:51:12.188781Z'
 order: 0
 incompatible:
     '@no-resource-uri-leak': 'No Resource URI Leak'
+    'jid0-9XfBwUWnvPx4wWsfBWMCm4Jj69E@jetpack': 'Self-Destructing Cookies'


### PR DESCRIPTION
While we have some workarounds for Self-Destructing Cookies, by wiping cookies it breaks My Shots and generally makes things difficult.  SInce incompatible add-ons only give a warning, it seems appropriate to add the add-on there.
