### PR TITLE
Fix email dialog on home page, add to experiment page

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -8,6 +8,7 @@ import { buildSurveyURL, createMarkup, experimentL10nId, formatDate } from '../l
 import LoadingPage from './LoadingPage';
 import NotFoundPage from './NotFoundPage';
 
+import EmailDialog from '../components/EmailDialog';
 import ExperimentDisableDialog from '../components/ExperimentDisableDialog';
 import ExperimentEolDialog from '../components/ExperimentEolDialog';
 import ExperimentTourDialog from '../components/ExperimentTourDialog';
@@ -40,7 +41,14 @@ export class ExperimentDetail extends React.Component {
   constructor(props) {
     super(props);
 
-    const { isExperimentEnabled, experiment } = this.props;
+    const { isExperimentEnabled, experiment,
+            getCookie, removeCookie } = this.props;
+
+    let showEmailDialog = false;
+    if (getCookie('first-run')) {
+      removeCookie('first-run');
+      showEmailDialog = true;
+    }
 
     // TODO: Clean this up per #1367
     this.state = {
@@ -50,6 +58,7 @@ export class ExperimentDetail extends React.Component {
       isEnabling: false,
       isDisabling: false,
       progressButtonWidth: null,
+      showEmailDialog,
       showDisableDialog: false,
       shouldShowTourDialog: false,
       showTourDialog: false,
@@ -177,7 +186,7 @@ export class ExperimentDetail extends React.Component {
     }
 
     const { enabled, useStickyHeader, highlightMeasurementPanel,
-            showDisableDialog, showTourDialog,
+            showEmailDialog, showDisableDialog, showTourDialog,
             showPreFeedbackDialog, showEolDialog,
             stickyHeaderSiblingHeight } = this.state;
 
@@ -202,6 +211,10 @@ export class ExperimentDetail extends React.Component {
 
     return (
       <section id="details" data-hook="experiment-page">
+
+        {showEmailDialog &&
+          <EmailDialog {...this.props}
+            onDismiss={() => this.setState({ showEmailDialog: false })} />}
 
         {showDisableDialog &&
           <ExperimentDisableDialog {...this.props}

--- a/frontend/src/app/containers/HomePageWithAddon.js
+++ b/frontend/src/app/containers/HomePageWithAddon.js
@@ -11,25 +11,27 @@ export default class HomePageWithAddon extends React.Component {
 
   constructor(props) {
     super(props);
+    const { getCookie, removeCookie, getWindowLocation } = this.props;
+
+    let showEmailDialog = false;
+    if (getCookie('first-run') ||
+      getWindowLocation().search.indexOf('utm_campaign=restart-required') > -1) {
+      removeCookie('first-run');
+      showEmailDialog = true;
+    }
+
     this.state = {
-      hideEmailDialog: false,
+      showEmailDialog,
       showPastExperiments: false
     };
   }
 
   render() {
-    const { experiments, getCookie, removeCookie, getWindowLocation, isAfterCompletedDate } = this.props;
+    const { experiments, isAfterCompletedDate } = this.props;
 
     if (experiments.length === 0) { return <LoadingPage />; }
 
-    let showEmailDialog = false;
-    if (!this.state.hideEmailDialog &&
-        (getCookie('first-run') ||
-         getWindowLocation().search.indexOf('utm_campaign=restart-required') > -1)) {
-      removeCookie('first-run');
-      showEmailDialog = true;
-    }
-    const { showPastExperiments } = this.state;
+    const { showEmailDialog, showPastExperiments } = this.state;
     const currentExperiments = experiments.filter(x => !isAfterCompletedDate(x));
     const pastExperiments = experiments.filter(isAfterCompletedDate);
 
@@ -37,7 +39,7 @@ export default class HomePageWithAddon extends React.Component {
       <View {...this.props}>
         {showEmailDialog &&
           <EmailDialog {...this.props}
-            onDismiss={() => this.setState({ hideEmailDialog: true })} />}
+            onDismiss={() => this.setState({ showEmailDialog: false })} />}
 
         <div className="responsive-content-wrapper reverse-split-banner ">
           <div className="copter-wrapper fly-down">

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -45,6 +45,8 @@ export function installAddon(requireRestart, sendToGA, eventCategory) {
     eventLabel: 'Install the Add-on'
   };
 
+  cookies.set('first-run', 'true');
+
   if (useMozAddonManager) {
     mozAddonManagerInstall(downloadUrl).then(() => {
       gaEvent.dimension7 = RESTART_NEEDED ? 'restart required' : 'no restart';
@@ -54,7 +56,6 @@ export function installAddon(requireRestart, sendToGA, eventCategory) {
       }
     });
   } else {
-    cookies.set('first-run', 'true');
     gaEvent.outboundURL = downloadUrl;
     sendToGA('event', gaEvent);
   }

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -19,6 +19,8 @@ describe('app/containers/ExperimentPage', () => {
   const mockExperiments = [ mockExperiment ];
   const mockParams = { slug: mockExperiment.slug };
   const mockProps = {
+    getCookie: sinon.spy(),
+    removeCookie: sinon.spy(),
     experiments: [ mockExperiment ],
     getExperimentBySlug: slug => {
       return slug === mockExperiment.slug ? mockExperiment : null;
@@ -106,6 +108,8 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
       getElementY: sinon.spy(),
       getElementOffsetHeight: sinon.spy(),
       setExperimentLastSeen: sinon.spy(),
+      getCookie: sinon.spy(),
+      removeCookie: sinon.spy(),
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:51.0) Gecko/20100101 Firefox/51.0',
       newsletterForm: newsletterState
     };
@@ -260,6 +264,20 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
       it('should not display a call-to-action to install Test Pilot', () => {
         expect(subject.find('.experiment-promo')).to.have.property('length', 0);
         expect(subject.find('MainInstallButton')).to.have.property('length', 0);
+      });
+
+      it('should show an email dialog if the first-run cookie is set', () => {
+        const getCookie = sinon.spy(name => 1);
+        const removeCookie = sinon.spy();
+        props = { ...props, hasAddon: true, getCookie, removeCookie }
+        subject = shallow(<ExperimentDetail {...props} />);
+        setExperiment(mockExperiment);
+
+        expect(subject.find('EmailDialog')).to.have.property('length', 1);
+        expect(removeCookie.called).to.be.true;
+
+        subject.setState({ showEmailDialog: false });
+        expect(subject.find('EmailDialog')).to.have.property('length', 0);
       });
 
       it('should not show a "Disable" button', () =>

--- a/frontend/test/app/containers/HomePageWithAddon-test.js
+++ b/frontend/test/app/containers/HomePageWithAddon-test.js
@@ -26,7 +26,7 @@ describe('app/containers/HomePageWithAddon', () => {
   });
 
   it('should render expected content', () => {
-    expect(subject.state('hideEmailDialog')).to.be.false;
+    expect(subject.state('showEmailDialog')).to.be.false;
     expect(subject.find('ExperimentCardList')).to.have.property('length', 1);
     expect(subject.find('EmailDialog')).to.have.property('length', 0);
   });
@@ -39,19 +39,22 @@ describe('app/containers/HomePageWithAddon', () => {
   it('should show an email dialog if the URL contains utm_campaign=restart-required',  () => {
     const getWindowLocation = sinon.spy(() =>
       ({ search: 'utm_campaign=restart-required' }));
-    subject.setProps({ getWindowLocation });
+    props = { ...props, getWindowLocation }
+    subject = shallow(<HomePageWithAddon {...props} />);
     expect(subject.find('EmailDialog')).to.have.property('length', 1);
 
-    subject.setState({ hideEmailDialog: true });
+    subject.setState({ showEmailDialog: false });
     expect(subject.find('EmailDialog')).to.have.property('length', 0);
   });
 
   it('should show an email dialog if the first-run cookie is set', () => {
     const getCookie = sinon.spy(name => 1);
-    subject.setProps({ getCookie });
+    props = { ...props, getCookie }
+    subject = shallow(<HomePageWithAddon {...props} />);
     expect(subject.find('EmailDialog')).to.have.property('length', 1);
+    expect(props.removeCookie.called).to.be.true;
 
-    subject.setState({ hideEmailDialog: true });
+    subject.setState({ showEmailDialog: false });
     expect(subject.find('EmailDialog')).to.have.property('length', 0);
   });
 


### PR DESCRIPTION
- Set first-run cookie on both old-style add-on installs and on
  new-style mozAddonManager installs.

- Add email dialog on first-run cookie to ExperimentPage

- Switch back to showEmailDialog logic with cookie in constructor,
  because the cookie was getting deleted on the first render and dialog
  state was reset with subsequent renders using hideEmailDialog logic

- Test fixes

Fixes #1551, Fixes #1447