### PR TITLE
[fixes #904] Add Optimizely

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -34,18 +34,16 @@ fi
 MAX_AGE="600"
 
 HPKP="\"public-key-pins\": \"max-age=300;pin-sha256=\\\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\\\";pin-sha256=\\\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\\\"\""
-CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'self' code.cdn.mozilla.net; report-uri /__cspreport__;\""
+CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org https://*.optimizely.com; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://*.optimizely.com; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'self' code.cdn.mozilla.net; report-uri /__cspreport__;\""
 HSTS="\"strict-transport-security\": \"max-age=31536000; includeSubDomains; preload\""
 TYPE="\"x-content-type-options\": \"nosniff\""
-FRAME="\"x-frame-options\": \"DENY\""
 XSS="\"x-xss-protection\": \"1; mode=block\""
 
 # Our dev server has a couple different rules to allow easier debugging and
 # enable localization.  Also expires more often.
 if [ "$DEST" = "dev" ]; then
     MAX_AGE="15"
-    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-src 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
-    FRAME="\"x-frame-options\": \"ALLOW-FROM https://pontoon.mozilla.org/\""
+    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org https://*.optimizely.com; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org https://*.optimizely.com; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
 fi
 
 # build version.json if it isn't provided
@@ -69,7 +67,7 @@ aws s3 sync \
   --content-type "text/html" \
   --exclude "*" \
   --include "*.html" \
-  --metadata "{${HPKP}, ${CSP}, ${HSTS}, ${TYPE}, ${FRAME}, ${XSS}}" \
+  --metadata "{${HPKP}, ${CSP}, ${HSTS}, ${TYPE}, ${XSS}}" \
   --metadata-directive "REPLACE" \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
@@ -135,7 +133,7 @@ for fn in $(find dist -name 'index.html' -not -path 'dist/index.html'); do
     --content-type "text/html" \
     --exclude "*" \
     --include "*.html" \
-    --metadata "{${HPKP}, ${CSP}, ${HSTS}, ${TYPE}, ${FRAME}, ${XSS}}" \
+    --metadata "{${HPKP}, ${CSP}, ${HSTS}, ${TYPE}, ${XSS}}" \
     --metadata-directive "REPLACE" \
     --acl "public-read" \
     $fn s3://${TESTPILOT_BUCKET}/${s3path}

--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -3,7 +3,8 @@ const defaultConfig = {
   minFirefoxVersion: 45,
   experimentsURL: '/api/experiments.json',
   usageCountsURL: 'https://analysis-output.telemetry.mozilla.org/testpilot/data/installation-counts/latest.json',
-  ravenPublicDSN: 'https://5ceef9a20a6e4cdd93cc9a935be78c73@sentry.prod.mozaws.net/169'
+  ravenPublicDSN: 'https://5ceef9a20a6e4cdd93cc9a935be78c73@sentry.prod.mozaws.net/169',
+  optimizelyEnabled: true
 };
 
 const hostname = (typeof window === 'undefined') ? '' : window.location.hostname;
@@ -11,11 +12,13 @@ const hostname = (typeof window === 'undefined') ? '' : window.location.hostname
 const hostConfig = {
   'testpilot.firefox.com': {
     isDev: false,
-    ravenPublicDSN: 'https://51e23d7263e348a7a3b90a5357c61cb2@sentry.prod.mozaws.net/168'
+    ravenPublicDSN: 'https://51e23d7263e348a7a3b90a5357c61cb2@sentry.prod.mozaws.net/168',
+    optimizelyEnabled: false
   },
   'testpilot.stage.mozaws.net': {
     isDev: false,
-    ravenPublicDSN: 'https://5aa2b40919a64763b32e1bca6e40b322@sentry.prod.mozaws.net/171'
+    ravenPublicDSN: 'https://5aa2b40919a64763b32e1bca6e40b322@sentry.prod.mozaws.net/171',
+    optimizelyEnabled: false
   }
 };
 

--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -36,6 +36,10 @@ class App extends Component {
 
     const experimentsPath = 'experiments/';
 
+    // These are used to expose page state for Optimizely, testing, etc.
+    window.testPilotPathname = pathname;
+    window.testPilotHasAddon = hasAddon;
+
     if (pathname === '/') {
       const installedCount = Object.keys(installed).length;
       const anyInstalled = installedCount > 0;
@@ -95,12 +99,19 @@ function sendToGA(type, dataIn) {
       document.location = data.outboundURL;
     }
   };
+  sendToOptimizely(data.eventCategory + '/' + data.eventAction + '/' + data.eventLabel);
   if (window.ga && ga.loaded) {
     data.hitType = type;
     data.hitCallback = hitCallback;
     ga('send', data);
   } else {
     hitCallback();
+  }
+}
+
+function sendToOptimizely(evt) {
+  if (window.optimizely) {
+    window.optimizely.push(['trackEvent', evt]);
   }
 }
 

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -14,6 +14,7 @@ import { syncHistoryWithStore } from 'react-router-redux';
 import { Provider } from 'react-redux';
 
 import './lib/ga-snippet';
+import './lib/optimizely-snippet';
 
 import { setupAddonConnection } from './lib/addon';
 import createStore from './store';
@@ -21,7 +22,6 @@ import config from './config';
 
 import experimentsActions from './actions/experiments';
 import Routes from './components/Routes';
-
 
 es6Promise.polyfill();
 

--- a/frontend/src/app/lib/optimizely-snippet.js
+++ b/frontend/src/app/lib/optimizely-snippet.js
@@ -1,0 +1,18 @@
+/*eslint-disable*/
+// HACK: Optimizely lives here, because CSP won't let it live inline
+
+import config from '../config';
+
+if (config.optimizelyEnabled) {
+	(function() { 
+	    var projectId = '5941720679';
+	    var scriptTag = document.createElement('script');
+	    scriptTag.type = 'text/javascript';
+	    scriptTag.async = true;
+	    scriptTag.src = 'https://cdn.optimizely.com/js/' + 
+	    projectId + '.js';
+	    var s = document.getElementsByTagName('script')[0];
+	    s.parentNode.insertBefore(scriptTag, s);
+	})();
+}
+/*eslint-enable*/


### PR DESCRIPTION
This PR does ~~two~~ three things - one optional, two required - for Optimizely integration (in addition to adding the code snippet)

(1) Set JavaScript variables to explicitly set the current page state ([optional:ref](https://help.optimizely.com/Build_Campaigns_and_Experiments/AngularJS,_Backbone.js,_React,_and_Single_Page_Applications_in_Optimizely_Classic#1._Identify_states_in_your_Single_Page_App)).

As noted in the docs, we can scrape the page's DOM elements to determine page state in lieu of setting these variables. For instance, in the Optimizely dashboard, if our targeting has `document.getElementById('feedback-button')` we would know that the page state is most likely an experiment page.

The environment variables give us a pretty certain way to determine page state now and going forward. But again, this is optional, so I would welcome input here on removing. There may be another way we can determine this that I missed.

(2) Send a custom event to Optimizely when things happen on the page ([required:ref](https://help.optimizely.com/Build_Campaigns_and_Experiments/AngularJS,_Backbone.js,_React,_and_Single_Page_Applications_in_Optimizely_Classic#3._Use_Custom_Event_Goals)).

Piggy-backing on the `sendToGA` function used for event tracking seemed like the best way to go.

(3) Update CSP to give Optimizely framing rights ([required:ref](https://help.optimizely.com/Troubleshoot_Problems/Update_your_site's_Content_Security_Policies_(CSP))).

(this one got a bit sticky)

Updated the prod/stage CSP rule to include the `frame-src` directive and add Optimizely.

Updated the dev CSP rule to include Optimizely in the `frame-src` directive.

I removed the `X-FRAME-OPTION` header because 1. [it looks to be deprecated](https://www.owasp.org/index.php/Content_Security_Policy_Cheat_Sheet#Preventing_Clickjacking), and 2. multiple URLs aren't fully supported.

It seems as though the `frame-ancestors` directive is the preferred way to add this, but there's a note that you can't use it in a `<meta>` tag, which - from what I gathered [in `deploy.sh`](https://github.com/mozilla/testpilot/blob/master/bin/deploy.sh#L72) - is what we are doing. If it's not, I can update this to use `frame-ancestors` instead.

@clouserw noted you can't test this stuff locally so I couldn't verify that this change made the Optimizely dashboard work, but we can in dev. Very much open to opinions here as I haven't done much CSP stuff before.

Fixes #904.


