### PR TITLE
Run ZAP baseline when deploying to dev environment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -6,6 +6,8 @@
 machine:
   hosts:
     testpilot.dev: 127.0.0.1
+  services:
+    - docker
   node:
     version: 6.9.1
   environment:
@@ -44,6 +46,8 @@ deployment:
       - TESTPILOT_BUCKET=testpilot.dev.mozaws.net ./bin/deploy.sh dev
       - aws configure set preview.cloudfront true
       - aws cloudfront create-invalidation --distribution-id E2ERG47PHCWD0Z --paths '/*'
+      - docker pull owasp/zap2docker-weekly
+      - timeout 300 docker run -t owasp/zap2docker-weekly zap-baseline.py -t https://testpilot.dev.mozaws.net/
 
 # Only notify of builds on master branch.
 experimental:


### PR DESCRIPTION
This change (hopefully;) allows us to run the ZAP baseline scan whenever testpilot is deployed to the dev environment. This perform a 1 min spider of testpilot and then checks for whatever we can check for on the security checklist https://wiki.mozilla.org/Security/CloudSec#Security_Checklist 
For more info about the ZAP baseline scan see https://github.com/zaproxy/zaproxy/wiki/ZAP-Baseline-Scan
The current checks are actually defaulted and need to be tuned via a config file - any suggestions as to where this could live in this repo?