### PR TITLE
Restore integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,28 @@
-frontend/build/
-dist/
-build/
-tmp/
+# File types to ignore globally
+*.DS_Store
 *.log
-.env
+*.pyc
 *.sw?
-.DS_Store
-docs/_build
-MANIFEST
-coverage
-.nyc_output
-node_modules/
-media/
-static/
-legal-copy/*html
 
+# Files to ignore in the base directory
+coverage
 debug-config.json
+.env
+MANIFEST
+.nyc_output
 version.json
-addon/*.xpi
+
+# Directories to ignore
+build/
+dist/
+docs/_build
+frontend/build/
+media/
+node_modules/
+static/
+tmp/
+
+# Files to ignore within specific directories
 addon/*.rdf
+addon/*.xpi
+legal-copy/*html

--- a/bin/circleci/run-integration-tests.sh
+++ b/bin/circleci/run-integration-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-npm run server &
+npm start &
 STATIC_SERVER_PID=$!
 
 # Wait until the server is available...
@@ -12,7 +12,7 @@ done
 python integration/runtests.py \
     --binary=$HOME/firefox/firefox-bin \
     --verbose \
-    integration
+    integration/test_installation.py
 TEST_STATUS=$?
 
 kill $STATIC_SERVER_PID

--- a/bin/circleci/setup-test-dependencies.sh
+++ b/bin/circleci/setup-test-dependencies.sh
@@ -9,5 +9,5 @@ wget -qO $HOME/fx-release.tar.bz2 $FIREFOX_URL
 tar -C $HOME -jxf $HOME/fx-release.tar.bz2
 $HOME/firefox/firefox-bin --version
 
-# cd integration
-# pip install -r requirements.txt
+cd integration
+pip install -r requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,7 @@ test:
   override:
     - ./bin/circleci/test-addon.sh
     - ./bin/circleci/test-frontend.sh
-    - echo "Skipping integration tests."
-    # - ./bin/circleci/run-integration-tests.sh
+    - ./bin/circleci/run-integration-tests.sh
   post:
     - bash <(curl -s https://codecov.io/bash)
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -87,7 +87,7 @@ Once you've got that whole stack available, you can run the tests like so:
 pip install -r integration/requirements.txt
 python integration/runtests.py \
     --binary=/Applications/Nightly.app/Contents/MacOS/firefox-bin \
-    --verbose integration
+    --verbose integration/test_installation.py
 ```
 
 The first line installs the requires Python modules. The second line starts an

--- a/frontend/test/app/components/Loading-test.js
+++ b/frontend/test/app/components/Loading-test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 
 import Loading from '../../../src/app/components/Loading';
 
-describe('app/compomnents/Loading', () => {
+describe('app/components/Loading', () => {
   it('should render <div class="loader">', () =>
     expect(shallow(<Loading />).find('.loader')).to.have.length(1));
   it('should render 4 loader-bars', () =>

--- a/frontend/test/app/components/Warning-test.js
+++ b/frontend/test/app/components/Warning-test.js
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import Warning from '../../../src/app/components/Warning';
 
 
-describe('app/compomnents/Warning', () => {
+describe('app/components/Warning', () => {
 
   it('should omit the <header> when a title isn\'t passed', () => {
     const subject = shallow(<Warning/>);

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,3 +1,3 @@
-marionette_client==3.1.0
-firefox-puppeteer==50.0.0
+marionette_client==3.2.0
+firefox-puppeteer==52.0.0
 mozlog==3.3

--- a/integration/test_installation.py
+++ b/integration/test_installation.py
@@ -40,10 +40,10 @@ class TestAddonInstallation(FirefoxTestCase):
         with m.using_context(m.CONTEXT_CONTENT):
             m.navigate(SITE_URL)
             m.find_element(By.CSS_SELECTOR,
-                           'button[data-hook=install]').click()
+                           'button.install').click()
             w = Wait(m, ignored_exceptions=NoSuchElementException)
             w.until(lambda m: m.find_element(By.CSS_SELECTOR,
-                                             'button[data-hook=install].state-change'))
+                                             'button.install.state-change'))
 
         # Click through the blocked notification
         b.wait_for_notification(AddOnInstallBlockedNotification, timeout=60)
@@ -71,9 +71,10 @@ class TestAddonInstallation(FirefoxTestCase):
                         next_tab_loc.endswith('/onboarding/'))
         b.tabbar.close_tab(b.tabbar.tabs[1])
 
-        # The frontend should redirect to /experiments after it contacts the add-on
-        Wait(m).until(lambda m: b.tabbar.tabs[0].location.endswith('/experiments') or
-                                b.tabbar.tabs[0].location.endswith('/experiments/'))
+        # The frontend should show a list of experiments after it contacts the add-on
+        with m.using_context(m.CONTEXT_CONTENT):
+            w = Wait(m, ignored_exceptions=NoSuchElementException)
+            w.until(lambda m: m.find_element(By.CSS_SELECTOR, 'div.experiments'))
 
         # Clean up by uninstalling the add-on
         Addons(m).uninstall('@testpilot-addon')


### PR DESCRIPTION
Get our lone integration test working again on circle-CI.

TL;DR: mostly just needed to bump deps.

Some breaking changes occurred between Firefox and the Marionette python client. It looks like https://bugzil.la/1302707 (landed around the time #1437 was filed) removed `marionette.timeouts`, which broke the self-test that runs inside marionette 3.1.0. I was seeing this error locally today, not sure if others did or not. Upgrading marionette to 3.2.0 (le sigh, a minor version number bump for a breaking API change...) and updating firefox-puppeteer to latest seems to have fixed everything.

Also tweaked the integration test to stop looking for the now-defunct `/experiments` redirect, and cleaned up the docs and .gitignore a bit. :beers: