### PR TITLE
Make URLs non-localizable

### DIFF
--- a/frontend/src/app/components/NewsletterForm.js
+++ b/frontend/src/app/components/NewsletterForm.js
@@ -41,13 +41,12 @@ export default class NewsletterForm extends React.Component {
   renderPrivacyField() {
     const fieldName = 'privacy';
     const url = '/privacy';
-    const l10nArgs = JSON.stringify({ url });
 
     return (
       <label className={this.makeRevealedClassNames()} htmlFor={fieldName}>
         <input name={fieldName} type="checkbox" checked={this.props.privacy} required
                onClick={this.handlePrivacyClick} />
-        <span data-l10n-id="newsletterFormPrivacyNotice" data-l10n-args={l10nArgs}>
+        <span data-l10n-id="newsletterFormPrivacyNotice">
           I'm okay with Mozilla handling by info as explained in
           <a href={url}>this Privacy Notice</a>.
         </span>

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -140,7 +140,7 @@ export class ExperimentDetail extends React.Component {
           <h3 data-l10n-id="incompatibleHeader">
             This experiment may not be compatible with add-ons you have installed.
           </h3>
-          <p data-l10n-id="incompatibleSubheader" data-l10n-args={JSON.stringify({ url: helpUrl })}>
+          <p data-l10n-id="incompatibleSubheader">
             We recommend <a href={helpUrl}>disabling these add-ons</a> before activating this experiment:
           </p>
         </header>

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -167,12 +167,12 @@ eolDisableMessage = The {$title} experiment has ended. Once you uninstall it you
 completedDateLabel = Experiment End Date: {$completedDate}
 
 incompatibleHeader = This experiment may not be compatible with add-ons you have installed.
-incompatibleSubheader = We recommend <a href="{$url}">disabling these add-ons</a> before activating this experiment:
+incompatibleSubheader = We recommend <a>disabling these add-ons</a> before activating this experiment:
 
 newsletterFormEmailPlaceholder =
     [html/placeholder] Your email here
 newsletterFormDisclaimer = We will only send you Test Pilot-related information.
-newsletterFormPrivacyNotice = I'm okay with Mozilla handling by info as explained in <a href="{$url}">this privacy notice</a>.
+newsletterFormPrivacyNotice = I'm okay with Mozilla handling by info as explained in <a>this privacy notice</a>.
 newsletterFormSubmitButton = Sign Up Now
 newsletterFormSubmitButtonSubmitting = Submitting...
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -172,7 +172,7 @@ incompatibleSubheader = We recommend <a>disabling these add-ons</a> before activ
 newsletterFormEmailPlaceholder =
     [html/placeholder] Your email here
 newsletterFormDisclaimer = We will only send you Test Pilot-related information.
-newsletterFormPrivacyNotice = I'm okay with Mozilla handling by info as explained in <a>this privacy notice</a>.
+newsletterFormPrivacyNotice = I'm okay with Mozilla handling my info as explained in <a>this privacy notice</a>.
 newsletterFormSubmitButton = Sign Up Now
 newsletterFormSubmitButtonSubmitting = Submitting...
 


### PR DESCRIPTION
Remove the { $url } external arguments from the localizable content.  The URL
can be defined as the href attribute in the HTML source.  L20n will copy it to
the corresponding <a> element in the translation.