### PR TITLE
Fix broken build by explicitly listing python in CI config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     testpilot.dev: 127.0.0.1
   node:
     version: 6.9.1
+  python:
+    version: 2.7.11
   environment:
     TESTPILOT_ENABLE_PONTOON_BRANCHES: master
 


### PR DESCRIPTION
Circle-CI automatically creates a virtualenv if a python version is
included in the circle.yml file:
https://circleci.com/docs/language-python/#version

Try adding a listing for the default version.