### PR TITLE
First pass at l10n on add-on

### DIFF
--- a/addon/.jpmignore
+++ b/addon/.jpmignore
@@ -1,6 +1,7 @@
 .*
 *
 !/data/**
+!/locale/**
 !/lib/**
 !/index.js
 !/install.rdf

--- a/addon/index.js
+++ b/addon/index.js
@@ -342,7 +342,7 @@ exports.main = function(options) {
 
   WebExtensionChannels.init();
   ToolbarButton.init(settings);
-  ExperimentNotifications.init();
+  ExperimentNotifications.init(settings);
   SharePrompt.init(settings);
 
   if (reason === 'install') {

--- a/addon/lib/experiment-notifications.js
+++ b/addon/lib/experiment-notifications.js
@@ -2,14 +2,23 @@ const Notifications = require('sdk/notifications');
 const querystring = require('sdk/querystring');
 const store = require('sdk/simple-storage').storage;
 const tabs = require('sdk/tabs');
+const URL = require('sdk/url').URL;
+
+const _ = require('sdk/l10n').get;
 
 // Maximum period within which to consider an experiment recently created or
 // updated for notification purposes.
 const MAX_NOTIFICATION_DELAY_PERIOD = 14 * 24 * 60 * 60 * 1000; // 2 weeks
 
+let envHost = '';
+
 module.exports = {
 
-  init() {
+  init(settings) {
+    // Grab the host from BASE_URL for the "via testpilot.firefox.com" bit of
+    // notification text.
+    envHost = URL(settings.BASE_URL).host; // eslint-disable-line new-cap
+
     // Initialize last-checked timestamp to now
     if (!('notificationsLastChecked' in store)) {
       store.notificationsLastChecked = Date.now();
@@ -109,7 +118,7 @@ function sendNotificationForExperiment(experiment, notification) {
   Notifications.notify({
     title: notification.title,
     // HACK: Simulate a web push notification by injecting 'via' here
-    text: 'via testpilot.firefox.com\n' + notification.text,
+    text: `${_('notification_via', envHost)}\n${notification.text}`,
     iconURL: './notification-icon.png',
     onClick: () => {
       const url = experiment.html_url + '?' + querystring.stringify({

--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -16,6 +16,7 @@ const { setTimeout, clearTimeout } = require('sdk/timers');
 const tabs = require('sdk/tabs');
 const querystring = require('sdk/querystring');
 const store = require('sdk/simple-storage').storage;
+const _ = require('sdk/l10n').get;
 
 const NUM_STARS = 5; // Number of survey stars
 const TEN_MINUTES = 60 * 1000 * 10;
@@ -62,7 +63,7 @@ function checkForCompletedExperiments() {
           launchSurvey({
             experiment,
             interval: 'eol',
-            label: `The ${experiment.title} experiment has ended. What did you think?`,
+            label: _('survey_launch_survey_label', experiment.title),
             persistence: 10
           }),
           1000
@@ -216,7 +217,7 @@ function showRating(options) {
     let experimentRating = null;
 
     const { notifyBox, box } = createNotificationBox({
-      label: options.label || `Please rate ${experiment.title}`,
+      label: options.label || _('survey_show_rating_label', experiment.title),
       image: experiment.thumbnail,
       child: win => createRatingUI(win, uiClosed),
       persistence: options.persistence,
@@ -243,10 +244,10 @@ function showSurveyButton(options) {
     const { experiment, duration } = options;
     const uiTimeout = setTimeout(uiClosed, duration || 60000);
     const { notifyBox, box } = createNotificationBox({
-      label: `Thank you for rating ${experiment.title}.`,
+      label: _('survey_rating_thank_you', experiment.title),
       image: experiment.thumbnail,
       buttons: [{
-        label: 'Take a Quick Survey',
+        label: _('survey_rating_survey_button'),
         callback: () => { clicked = true; }
       }],
       callback: () => {

--- a/addon/lib/templates.js
+++ b/addon/lib/templates.js
@@ -3,6 +3,7 @@
  * version 2.0 (the 'License'). You can obtain a copy of the License at
  * http://mozilla.org/MPL/2.0/.
  */
+const _ = require('sdk/l10n').get;
 
 module.exports.experimentList = `
 <div class="experiment-list">
@@ -13,16 +14,16 @@ module.exports.experimentList = `
         <div class="icon" style="background-image:url('{{thumbnail}}');"></div>
       </div>
       <div class="experiment-title">{{title}}
-        <span class="active-span" style="{{#hideActive}}display:none;{{/hideActive}}">Enabled</span>
-        <span class="is-new-span">New Experiment</span>
+        <span class="active-span" style="{{#hideActive}}display:none;{{/hideActive}}">${_('experiment_list_enabled')}</span>
+        <span class="is-new-span">${_('experiment_list_new_experiment')}</span>
         <span class="eol-span {{#showEol}}visible{{/showEol}}">{{eolMessage}}</span>
       </div>
     </a>
   {{/experiments}}
 </div>
-<a class="view-all" href="{{base_url}}/experiments?{{view_all_params}}">View all experiments</a>`;
+<a class="view-all" href="{{base_url}}/experiments?{{view_all_params}}">${_('experiment_list_view_all')}</a>`;
 
 module.exports.installed = `
 <div class="installed-message">
-  <p><strong>FYI:</strong> We put a button in your toolbar <br> so you can always find Test Pilot.</p>
+  <p>${_('installed_message')}</p>
 </div>`;

--- a/addon/lib/toolbar-button.js
+++ b/addon/lib/toolbar-button.js
@@ -5,6 +5,7 @@ const store = require('sdk/simple-storage').storage;
 const tabs = require('sdk/tabs');
 const self = require('sdk/self');
 const { URL } = require('sdk/url');
+const _ = require('sdk/l10n').get;
 
 const Mustache = require('mustache');
 const templates = require('./templates');
@@ -46,7 +47,7 @@ function getExperimentList(availableExperiments, installedAddons) {
       const completed = (new Date(experiment.completed)).getTime();
       const delta = completed - Date.now();
       if (delta < 0) {
-        experiment.eolMessage = 'Experiment Complete';
+        experiment.eolMessage = _('experiment_eol_complete_message');
         if (experiment.active &&
           !(experiment.addon_id in store.surveyChecks.eol)) {
           experiment.link = experiment.survey_url;
@@ -56,9 +57,9 @@ function getExperimentList(availableExperiments, installedAddons) {
             installed: Object.keys(store.installedAddons)});
         }
       } else if (delta < ONE_DAY) {
-        experiment.eolMessage = 'Ending Tomorrow';
+        experiment.eolMessage = _('experiment_eol_tomorrow_message');
       } else if (delta < ONE_WEEK) {
-        experiment.eolMessage = 'Ending Soon';
+        experiment.eolMessage = _('experiment_eol_soon_message');
       }
       if (experiment.eolMessage) {
         experiment.showEol = true;

--- a/addon/locale/en-US.properties
+++ b/addon/locale/en-US.properties
@@ -1,0 +1,20 @@
+experiment_list_enabled = Enabled
+experiment_list_new_experiment = New Experiment
+experiment_list_view_all = View all experiments
+
+experiment_eol_tomorrow_message = Ending Tomorrow
+experiment_eol_soon_message = Ending Soon
+experiment_eol_complete_message = Experiment Complete
+
+installed_message = <strong>FYI:</strong> We put a button in your toolbar <br> so you can always find Test Pilot.
+
+# LOCALIZER NOTE: Placeholder is experiment title
+survey_show_rating_label = Please rate %s
+# LOCALIZER NOTE: Placeholder is experiment title
+survey_rating_thank_you = Thank you for rating %s.
+survey_rating_survey_button = Take a Quick Survey
+# LOCALIZER NOTE: Placeholder is experiment title
+survey_launch_survey_label = The %s experiment has ended. What did you think?
+
+# LOCALIZER NOTE: Placeholder is site host (e.g. testpilot.firefox.com)
+notification_via = via %s

--- a/addon/test/test-experiment-notifications.js
+++ b/addon/test/test-experiment-notifications.js
@@ -20,6 +20,10 @@ const mocks = {
   })
 };
 
+const mockSettings = {
+  BASE_URL: 'https://example.com'
+};
+
 const mockLoader = MockUtils.loader(module, './lib/experiment-notifications.js', {
   'sdk/simple-storage': {storage: mocks.store},
   'sdk/notifications': mocks.callbacks.Notifications,
@@ -28,13 +32,13 @@ const mockLoader = MockUtils.loader(module, './lib/experiment-notifications.js',
 
 const ExperimentNotifications = mockLoader.require('../lib/experiment-notifications');
 
-exports['test ExperimentNotifications.init()'] = assert => {
+exports['test ExperimentNotifications.init(mockSettings)'] = assert => {
   assert.ok(!('notificationsLastChecked' in mocks.store),
             'notificationsLastChecked should not initially be in store');
   assert.ok(!('notificationsProcessed' in mocks.store),
             'notificationsProcessed should not initially be in store');
 
-  ExperimentNotifications.init();
+  ExperimentNotifications.init(mockSettings);
 
   assert.ok('notificationsLastChecked' in mocks.store,
             'notificationsLastChecked should be in store after init');
@@ -110,6 +114,8 @@ exports['test single notification'] = assert => {
     }
   };
 
+  ExperimentNotifications.init(mockSettings);
+
   ExperimentNotifications.maybeSendNotifications();
 
   const notifyCalls = mocks.callbacks.Notifications.notify.calls();
@@ -118,7 +124,7 @@ exports['test single notification'] = assert => {
 
   const resultNotification = notifyCalls[0][0];
   assert.equal(expectedTitle, resultNotification.title);
-  assert.equal('via testpilot.firefox.com\n' + expectedText, resultNotification.text);
+  assert.equal('via example.com\n' + expectedText, resultNotification.text);
   resultNotification.onClick();
 
   const tabOpenCalls = mocks.callbacks.Tabs.open.calls();


### PR DESCRIPTION
Issue #557

I read through all the JS modules in the add-on, and I think I found all the strings. Might have missed some, though.

My goal was just to see if I could get these changes working with the standard `sdk/l10n` approach in [the Localization tutorial](https://developer.mozilla.org/en-US/Add-ons/SDK/Tutorials/l10n). But, this seems to be a requirement:

> although note that the .properties files need to be in /locale/%LOCALE%/whatever.properties 
> instead of what min vid is doing.

So, this might need a follow up / more work to get things working in Pontoon?