### PR TITLE
Fixes two SCSS linting warnings.

### DIFF
--- a/frontend/src/styles/modules/_banners.scss
+++ b/frontend/src/styles/modules/_banners.scss
@@ -156,6 +156,7 @@
 }
 
 .restart-message {
+  margin: $grid-unit * -2 auto 0 auto;
 
   ol {
     list-style-type: decimal;
@@ -197,6 +198,4 @@
 
     font-weight: bold;
   }
-
-  margin: $grid-unit * -2 auto 0 auto;
 }

--- a/frontend/src/styles/modules/_main-header.scss
+++ b/frontend/src/styles/modules/_main-header.scss
@@ -2,7 +2,7 @@
   @include flex-container(row, space-between, center);
 
   h1 {
-    margin: $grid-unit * .75 0 $grid-unit * .75 -$grid-unit * .25;
+    margin: $grid-unit * .75 0 $grid-unit * .75 - $grid-unit * .25;
     text-indent: -9999px;
 
     .wordmark {


### PR DESCRIPTION
```
frontend/src/styles/modules/_banners.scss
  201:3  warning  Declarations should come before nestings  declarations-before-nesting

✖ 1 problem (0 errors, 1 warning)


frontend/src/styles/modules/_main-header.scss
  5:49  warning  Space expected around operator  space-around-operator

✖ 1 problem (0 errors, 1 warning)
```