### PR TITLE
[ref #904] Add app.optimizely.com to script-src and update style-src

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -43,7 +43,7 @@ XSS="\"x-xss-protection\": \"1; mode=block\""
 # enable localization.  Also expires more often.
 if [ "$DEST" = "dev" ]; then
     MAX_AGE="15"
-    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org https://cdn.optimizely.com; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org https://app.optimizely.com; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://cdn.optimizely.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
+    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org https://cdn.optimizely.com; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org https://app.optimizely.com; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://cdn.optimizely.com https://app.optimizely.com; style-src 'self' 'unsafe-inline' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
 fi
 
 # build version.json if it isn't provided


### PR DESCRIPTION
- add app.optimizely.com to `script-src`
- ~~add `unsafe-inline` and `unsafe-eval` to `script-src`~~ 
- add `unsafe-inline` to `style-src`

Ref #904.

Closer! I'm reading console errors from [the Optimizely dashboard now](https://cloud.githubusercontent.com/assets/8632184/20158107/58c3875e-a68d-11e6-88d1-5583b601c8c7.png). Additions are based on [these recommendations](https://help.optimizely.com/Troubleshoot_Problems/Update_your_site's_Content_Security_Policies_(CSP)#2._Script).
