### PR TITLE
Support a fake dev-only experiment for feature QA

### DIFF
--- a/bin/circleci/build-frontend.sh
+++ b/bin/circleci/build-frontend.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
-if [[ " $TESTPILOT_ENABLE_PONTOON_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
-    NODE_ENV=production ENABLE_PONTOON=1 ENABLE_DEV_LOCALES=1 npm run static
+if [[ $CIRCLE_BRANCH == 'master' ]]; then
+    NODE_ENV=production ENABLE_PONTOON=1 ENABLE_DEV_CONTENT=1 ENABLE_DEV_LOCALES=1 npm run static
 else
-    NODE_ENV=production ENABLE_PONTOON=0 ENABLE_DEV_LOCALES=0 npm run static
+    NODE_ENV=production ENABLE_PONTOON=0 ENABLE_DEV_CONTENT=0 ENABLE_DEV_LOCALES=0 npm run static
 fi

--- a/circle.yml
+++ b/circle.yml
@@ -10,8 +10,6 @@ machine:
     version: 6.9.1
   python:
     version: 2.7.11
-  environment:
-    TESTPILOT_ENABLE_PONTOON_BRANCHES: master
 
 dependencies:
 

--- a/content-src/experiments/dev-example.yaml
+++ b/content-src/experiments/dev-example.yaml
@@ -1,0 +1,89 @@
+dev: true
+id: 999
+title: 'Dev Example'
+slug: dev-example
+thumbnail: /static/images/check.png
+description: >
+  This is an example experiment that you should never see in production.
+introduction: >
+  <p>Do you like Test Pilot experiments? Well, this one should exercise all the
+  features of the site. You should never see it on production!</p>
+  <ul>
+    <li><strong>Markup in introduction:</strong> Look at this HTML list!</li>
+    <li><strong>Hidden from production:</strong> If you see this on production
+      or staging, something has gone horribly wrong!</li>
+    <li><strong>Lorem ipsum dolor sit amet:</strong> Etiam lacinia, turpis sit
+      amet sagittis viverra, est erat tincidunt mi, a cursus leo orci et
+      orci.</li>
+  </ul>
+image_twitter: /static/images/experiments/min-vid/social/mv-twitter.jpg
+image_facebook: /static/images/experiments/min-vid/social/mv-facebook.jpg
+version: '0.3.1'
+changelog_url: 'https://github.com/meandavejustice/min-vid/blob/master/CHANGELOG.md'
+contribute_url: 'https://github.com/meandavejustice/min-vid'
+bug_report_url: 'https://github.com/meandavejustice/min-vid/issues'
+discourse_url: 'https://discourse.mozilla-community.org/c/test-pilot/min-vid'
+privacy_notice_url: 'https://github.com/meandavejustice/min-vid/blob/master/docs/metrics.md'
+measurements: >
+  <p>In addition to the <a href="/privacy">data</a> collected by all Test Pilot
+    experiments, here are the key things you should know about what is happening
+    when you use Example:</p>
+  <ul>
+    <li>Stumptown neutra mixtape, wayfarers hexagon ramps organic typewriter
+      mumblecore microdosing coloring book forage humblebrag.</li>
+    <li>Fam slow-carb snackwave cronut wayfarers. Mixtape put a bird on it
+      iPhone PBR&B subway tile, kale chips occupy af hexagon vaporware.</li>
+    <li>Franzen vinyl polaroid cold-pressed hashtag flexitarian.</li>
+  </ul>
+xpi_url: 'https://testpilot.firefox.com/files/min-vid/latest'
+addon_id: '@example-experiment'
+gradient_start: '#8725A7'
+gradient_stop: '#035295'
+details:
+  -
+    image: /static/images/experiments/min-vid/experiments_experimentdetail/detail1.jpg
+    copy: >
+      Access Min Vid from YouTube and Vimeo video players.
+  -
+    image: /static/images/experiments/min-vid/experiments_experimentdetail/detail2.jpg
+    copy: >
+      Watch video in the foreground while you do other things on the Web.
+  -
+    image: /static/images/experiments/min-vid/experiments_experimentdetail/detail3.jpg
+    copy: >
+      Right click on links to video to find Min Vid in the in-context controls.
+tour_steps:
+  -
+    image: /static/images/experiments/min-vid/experiments_experimenttourstep/tour1.jpg
+    copy: >
+      <p>Select the icon to start using Min Vid.</p>
+  -
+    image: /static/images/experiments/min-vid/experiments_experimenttourstep/tour2.jpg
+    copy: >
+      <p>Play video in the foreground while you continue to browse.</p>
+  -
+    image: /static/images/experiments/min-vid/experiments_experimenttourstep/tour3.jpg
+    copy: >
+      <p>Access controls in the frame to adjust volume, play, pause and move the video.</p>
+  -
+    image: /static/images/experiments/min-vid/experiments_experimenttourstep/tour4.jpg
+    copy: >
+      <p>You can always give us feedback or disable Min Vid from Test Pilot.</p>
+notifications: []
+contributors:
+  -
+    display_name: 'Dave Justice'
+    title: 'Engineer'
+    avatar: /static/images/experiments/min-vid/avatars/dave-justice.jpg
+  -
+    display_name: 'Jared Hirsch'
+    title: 'Staff Engineer'
+    avatar: /static/images/experiments/min-vid/avatars/jared-hirsch.jpg
+  -
+    display_name: 'Jen Kagan'
+    title: 'Engineering Intern'
+    avatar: /static/images/experiments/min-vid/avatars/jen-kagan.jpg
+installation_count: 1
+created: '2016-09-22T00:07:28.847430Z'
+modified: '2016-10-06T22:19:14.129Z'
+order: 999

--- a/docs/experiments/experiment-content/template.yaml
+++ b/docs/experiments/experiment-content/template.yaml
@@ -1,10 +1,11 @@
 id: # Unique numeric ID, we've been going sequentially here, so check other experiments
+dev: false # When true. this experiment will only appear on local or dev environments - i.e. for testing
 title: 'Experiment Name'
 subtitle: '' #Optionally add a subtitle to the experiment
 slug: experiment-name #should match title
 thumbnail: /static/images/experiments/ #followed by path to experiment-name/icon/experiment-name.png
 description: > # Appears in the experiment card, NO HTML WRAPPER
-  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum cum ad deserunt 
+  Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum cum ad deserunt
   iusto possimus. Fugiat odit corrupti cumque.
 introduction: > # Introduction on the details page, should be formatted as html indented
   <p> Lorem ipsum dolor sit amet. </p>
@@ -43,7 +44,7 @@ details: # this is a repeater field for detail images, copy and paste to loop
     headline: '' # Bold caption text, can be blank
     image: /static/images/experiments/ #followed by path to experiment-name/details/experiment-detail-1.jpg
     copy: > # Caption copy NO HTML WRAPPER
-      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum cum ad deserunt 
+      Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ipsum cum ad deserunt
       iusto possimus. Fugiat odit corrupti cumque.
 tour_steps: #this is a repeater field for tour images, copy and paste to loop
   -

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -3,6 +3,7 @@ module.exports = {
   IS_DEBUG: (process.env.NODE_ENV === 'development'),
   USE_HTTPS: (process.env.USE_HTTPS == 1),
   ENABLE_PONTOON: (process.env.ENABLE_PONTOON === '1'),
+  ENABLE_DEV_CONTENT: (process.env.ENABLE_DEV_CONTENT === '1'),
   AVAILABLE_LOCALES: (process.env.ENABLE_DEV_LOCALES === '1') ?
     // All locales on Pontoon for local & dev
     'en-US,ast,bn-BD,cs,de,es-ES,fa,fr,fy-NL,hu,it,ja,kab,pt-BR,ru,sk,sl,sv-SE,tr,uk,zh-CN,zh-TW' :

--- a/frontend/src/app/selectors/experiment.js
+++ b/frontend/src/app/selectors/experiment.js
@@ -19,8 +19,10 @@ export const allExperimentSelector = createSelector(
 export const onlyLaunchedExperimentSelector = createSelector(
   allExperimentSelector,
   experiments => experiments.filter(experiment => (
-    moment(moment.utc()).isAfter(experiment.launch_date) ||
-    typeof experiment.launch_date === 'undefined'
+    (!experiment.dev)
+    &&
+    (moment(moment.utc()).isAfter(experiment.launch_date) ||
+     typeof experiment.launch_date === 'undefined')
   ))
 );
 
@@ -34,7 +36,6 @@ export const launchedExperimentSelector = store => (
 
 // Return the user's primary language subtag.
 export const localeSelector = store => store.browser.locale;
-
 
 // Passed a locale and set of experiments, filters out the experiments that are
 // blockedlisted in that locale, or grantlisted and not available in that locale.

--- a/frontend/tasks/content.js
+++ b/frontend/tasks/content.js
@@ -66,6 +66,11 @@ function buildExperimentsData() {
     const yamlData = file.contents.toString();
     const experiment = YAML.parse(yamlData);
 
+    if (experiment.dev && !config.ENABLE_DEV_CONTENT) {
+      // Exclude dev content if it's not enabled in config
+      return cb();
+    }
+
     // Auto-generate some derivative API values expected by the frontend.
     Object.assign(experiment, {
       url: `/api/experiments/${experiment.id}.json`,
@@ -83,7 +88,9 @@ function buildExperimentsData() {
     }));
 
     index.results.push(experiment);
-    findLocalizableStrings(experiment);
+    if (!experiment.dev) {  // Don't collect strings for dev-only experiments
+      findLocalizableStrings(experiment);
+    }
 
     cb();
   }

--- a/frontend/tasks/util.js
+++ b/frontend/tasks/util.js
@@ -39,6 +39,9 @@ function lookup(obj, path) {
 }
 
 function experimentL10nId(experiment, pieces) {
+  if (experiment.dev) { // For dev-only experiments, data-l10n-id=null is omitted from the DOM
+    return null;
+  }
   if (typeof pieces === 'string') {
     pieces = [pieces];
   }

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -48,6 +48,12 @@ describe('app/components/ExperimentRowCard', () => {
     expect(findByL10nID('testingDescription')).to.have.property('length', 1);
   });
 
+  it('should not have l10n IDs if the experiment is dev-only', () => {
+    subject.setProps({ experiment: { dev: true, ...props.experiment } });
+    expect(findByL10nID('testingSubtitleFoo')).to.have.property('length', 0);
+    expect(findByL10nID('testingDescription')).to.have.property('length', 0);
+  });
+
   it('should change style based on hasAddon', () => {
     expect(subject.find('.experiment-summary').hasClass('has-addon')).to.be.false;
     subject.setProps({ hasAddon: true });

--- a/frontend/test/app/components/ExperimentTourDialog-test.js
+++ b/frontend/test/app/components/ExperimentTourDialog-test.js
@@ -45,6 +45,11 @@ describe('app/components/ExperimentTourDialog', () => {
     expect(subject.find('.tour-text').prop('data-l10n-id')).to.equal('testToursteps0CopyFoo');
   });
 
+  it('should not have l10n IDs if the experiment is dev-only', () => {
+    subject.setProps({ experiment: { dev: true, ...props.experiment } });
+    expect(subject.find('.tour-text').prop('data-l10n-id')).to.equal(null);
+  });
+
   it('should advance one step and ping GA when the next button is clicked', () => {
     subject.find('.tour-next').simulate('click', mockClickEvent);
 

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -143,6 +143,15 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
     expect(findByL10nID('testingDescription')).to.have.property('length', 1);
   });
 
+  it('should omit l10n IDs for dev-only content', () => {
+    setExperiment({ dev: true, ...mockExperiment });
+    expect(findByL10nID('testingSubtitleFoo')).to.have.property('length', 0);
+    expect(findByL10nID('testingIntroduction')).to.have.property('length', 0);
+    expect(findByL10nID('testingContributors0Title')).to.have.property('length', 0);
+    expect(findByL10nID('testingDetails0Headline')).to.have.property('length', 0);
+    expect(findByL10nID('testingDetails0Copy')).to.have.property('length', 0);
+  });
+
   it('should render a loading page if no experiments are available', () => {
     expect(subject.find('LoadingPage')).to.have.property('length', 1);
   });

--- a/frontend/test/app/lib/utils-test.js
+++ b/frontend/test/app/lib/utils-test.js
@@ -78,6 +78,10 @@ describe('app/lib/utils', () => {
     it('looks up array items', () => {
       expect(experimentL10nId(mockExperiment, ['array', '0', 'x'])).to.equal('fooArray0XZ');
     });
+
+    it('should return null for a dev-only experiment', () => {
+      expect(experimentL10nId({ dev: true, ...mockExperiment }, ['string'])).to.equal(null);
+    });
   });
 
 });

--- a/frontend/test/app/selectors/experiment-test.js
+++ b/frontend/test/app/selectors/experiment-test.js
@@ -22,7 +22,8 @@ describe('app/selectors/experiment', () => {
     const _exp = [
       { name: 'foo', order: 1 },
       { name: 'baz', order: 3, launch_date: moment.utc() + 99999 },
-      { name: 'bat', order: 2, launch_date: moment.utc() - 99999 }
+      { name: 'bat', order: 2, launch_date: moment.utc() - 99999 },
+      { name: 'xyzzy', order: 4, dev: true }
     ];
 
     describe('allExperimentSelector', () => {
@@ -38,7 +39,7 @@ describe('app/selectors/experiment', () => {
         const store = _store(_exp);
         assert.deepEqual(
           allExperimentSelector(store),
-          [_exp[0], _exp[2], _exp[1]]
+          [_exp[0], _exp[2], _exp[1], _exp[3]]
         );
       });
     });
@@ -68,6 +69,18 @@ describe('app/selectors/experiment', () => {
           onlyLaunchedExperimentSelector(store),
           launchedExperimentSelector(store)
         );
+      });
+
+      it('should contain no experiments marked for dev if not dev', () => {
+        const store = _store(_exp, false);
+        const result = launchedExperimentSelector(store);
+        assert.equal(0, result.filter(exp => exp.dev).length);
+      });
+
+      it('should contain experiments marked for dev if dev', () => {
+        const store = _store(_exp, true);
+        const result = launchedExperimentSelector(store);
+        assert.equal(1, result.filter(exp => exp.dev).length);
       });
     });
 

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "url": "git+https://github.com/mozilla/testpilot.git"
   },
   "scripts": {
-    "start": "NODE_ENV=development ENABLE_DEV_LOCALES=1 gulp",
+    "start": "NODE_ENV=development ENABLE_DEV_LOCALES=1 ENABLE_DEV_CONTENT=1 gulp",
     "server": "gulp server",
     "static": "gulp dist-build",
     "docs": "doctoc README.md && doctoc addon/README.md",


### PR DESCRIPTION
This turned out a little bit more involved than I'd anticipated, after thinking through localization issues and such. Hopefully this catches things, should let us create fake experiments that a) only get built for local & dev environments and b) never show up in our .ftl files as noise for localizers.

I was also lazy on creating the first fake experiment: I copied min-vid and only changed a few fields. We can tweak the rest as needed to try out features.

- `dev: true` YAML property to mark an experiment as dev-only

- ENABLE_DEV_CONTENT=1 env var to include dev content in build

- Update `npm start` to use dev environment vars

- New dev-example.yaml for a fake experiment

- Localization disabled for dev-only experiments
  - excluded from .ftl string extraction
  - data-l10n-id generation returns null

- onlyLaunchedExperimentSelector selector also excludes dev-only
  experiments on stage & prod - reduntant measure alongside build
  process ENABLE_DEV_CONTENT default

- Test updates

Fixes #1762