### PR TITLE
Enable new locales in the frontend

### DIFF
--- a/bin/circleci/build-frontend.sh
+++ b/bin/circleci/build-frontend.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 if [[ " $TESTPILOT_ENABLE_PONTOON_BRANCHES " =~ " $CIRCLE_BRANCH " ]]; then
-    NODE_ENV=production ENABLE_PONTOON=1 npm run static
+    NODE_ENV=production ENABLE_PONTOON=1 ENABLE_DEV_LOCALES=1 npm run static
 else
-    NODE_ENV=production ENABLE_PONTOON=0 npm run static
+    NODE_ENV=production ENABLE_PONTOON=0 ENABLE_DEV_LOCALES=0 npm run static
 fi

--- a/compiled-templates/compiled-templates.js
+++ b/compiled-templates/compiled-templates.js
@@ -1,3 +1,5 @@
+const config = require('../frontend/config.js');
+
 module.exports.templateBegin = `
 <!doctype html>
 <html>
@@ -7,7 +9,7 @@ module.exports.templateBegin = `
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css">
     <link rel="stylesheet" href="/static/styles/main.css">
     <meta name="defaultLanguage" content="en-US">
-    <meta name="availableLanguages" content="en-US">
+    <meta name="availableLanguages" content="${config.AVAILABLE_LOCALES}">
     <meta name="viewport" content="width=device-width">
     <link rel="localization" href="/static/locales/{locale}/app.ftl">
 

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -3,6 +3,11 @@ module.exports = {
   IS_DEBUG: (process.env.NODE_ENV === 'development'),
   USE_HTTPS: (process.env.USE_HTTPS == 1),
   ENABLE_PONTOON: (process.env.ENABLE_PONTOON === '1'),
+  AVAILABLE_LOCALES: (process.env.ENABLE_DEV_LOCALES === '1') ?
+    // All locales on Pontoon for local & dev
+    'en-US,zh-CN,de,ja,fy-NL,fa,zh-TW,ast,uk,fr,sv-SE,bn-BD,pt-BR,tr,kab,es-ES,sl,cs,ru,bs,es-CL' :
+    // Enabled locales for stage & production - update as they reach 100%
+    'en-US,zh-CN,de',
 
   // TODO: Move addon build to a better path
   ADDON_SRC_PATH: './addon/',

--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="/static/styles/main.css">
 
     <meta name="defaultLanguage" content="en-US">
-    <meta name="availableLanguages" content="en-US">
+    <meta name="availableLanguages" content="{{{ available_locales }}}">
     <meta name="viewport" content="width=device-width">
     <link rel="localization" href="/static/locales/{locale}/app.ftl">
     <link rel="localization" href="/static/locales/{locale}/experiments.ftl">

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -63,7 +63,8 @@ function buildLandingPage() {
       canonical_path: '',
       image_facebook: THUMBNAIL_FACEBOOK,
       image_twitter: THUMBNAIL_TWITTER,
-      enable_pontoon: config.ENABLE_PONTOON
+      enable_pontoon: config.ENABLE_PONTOON,
+      available_locales: config.AVAILABLE_LOCALES
     });
     this.push(new gutil.File({
       path: 'index.html',
@@ -83,7 +84,8 @@ function buildExperimentPage() {
       canonical_path: 'experiments/' + experiment.slug + '/',
       image_facebook: experiment.image_facebook || THUMBNAIL_FACEBOOK,
       image_twitter: experiment.image_twitter || THUMBNAIL_TWITTER,
-      enable_pontoon: config.ENABLE_PONTOON
+      enable_pontoon: config.ENABLE_PONTOON,
+      available_locales: config.AVAILABLE_LOCALES
     });
     this.push(new gutil.File({
       path: experiment.slug + '/index.html',

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "url": "git+https://github.com/mozilla/testpilot.git"
   },
   "scripts": {
-    "start": "gulp",
+    "start": "NODE_ENV=development ENABLE_DEV_LOCALES=1 gulp",
     "server": "gulp server",
     "static": "gulp dist-build",
     "docs": "doctoc README.md && doctoc addon/README.md",


### PR DESCRIPTION
- Default enabled locales in a manual list to be updated as translation
  work reaches 100% in each locale

- New `ENABLE_DEV_LOCALES=1` env var for gulp which enables all known
  locales in Pontoon

- Add locale set to availableLanguages meta header for L20n

- Update package.json to enable dev locales on local env

- Update bin/circleci/build-frontend.sh to enable dev locales on dev env

- Prod & stage use the default of known completed locales

Fixes #1784