### PR TITLE
Prompt user to check out experiments after a day if they have none installed (closes #1770).

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -18,6 +18,7 @@ const { App } = require('./lib/app');
 const ExperimentHacks = require('./lib/experiment-hacks');
 const ExperimentNotifications = require('./lib/experiment-notifications');
 const Metrics = require('./lib/metrics');
+const NoExperiments = require('./lib/no-experiments');
 const SharePrompt = require('./lib/share-prompt');
 const survey = require('./lib/survey');
 const ToolbarButton = require('./lib/toolbar-button');
@@ -344,6 +345,7 @@ exports.main = function(options) {
   ToolbarButton.init(settings);
   ExperimentNotifications.init(settings);
   SharePrompt.init(settings);
+  NoExperiments.init(settings);
 
   if (reason === 'install') {
     openOnboardingTab();
@@ -367,6 +369,7 @@ exports.onUnload = function(reason) {
   ToolbarButton.destroy();
   ExperimentNotifications.destroy();
   SharePrompt.destroy(reason);
+  NoExperiments.destroy(reason);
 
   if (reason === 'uninstall' || reason === 'disable') {
     Metrics.onDisable();

--- a/addon/lib/no-experiments.js
+++ b/addon/lib/no-experiments.js
@@ -1,0 +1,105 @@
+ /*
+  * This Source Code is subject to the terms of the Mozilla Public License
+  * version 2.0 (the 'License'). You can obtain a copy of the License at
+  * http://mozilla.org/MPL/2.0/.
+  */
+
+const _ = require('sdk/l10n').get;
+const notify = require('./notify');
+const Metrics = require('./metrics');
+const store = require('sdk/simple-storage').storage;
+const tabs = require('sdk/tabs');
+
+let SETTINGS;
+
+
+module.exports = {
+  DELAY: 1000,
+  QS: 'utm_source=testpilot-addon&utm_medium=firefox-browser&utm_campaign=testpilot-notification&utm_content=no-experiments-installed',
+
+  makeUrl() {
+    return `${SETTINGS.BASE_URL}/?${this.QS}`;
+  },
+
+  hasNoExperimentsInstalled: function() {
+    try {
+      return Object.keys(store.installedAddons).length === 0;
+    } catch (err) {
+      return true;
+    }
+  },
+
+  shouldShowNotification: function() {
+    return (
+      this.hasNoExperimentsInstalled() &&
+      store.noExperiments.hasBeenShown === false &&
+      store.noExperiments.showAt &&
+      store.noExperiments.showAt <= Date.now()
+    );
+  },
+
+  applyCSS: function(notif) {
+    if (notif && notif.box) {
+      const button = notif.box.getElementsByClassName('notification-button')[0];
+      if (button) {
+        button.setAttribute('style', 'background: #0095dd; color: #fff; cursor: pointer; height: 30px; font-size: 12px; border-radius: 2px; border: 0px; text-shadow: 0 0px; box-shadow: 0 0px;');
+      }
+    }
+  },
+
+  showNotification: function() {
+    const notif = notify.createNotificationBox({
+      label: _('no_experiment_message'),
+      image: 'resource://@testpilot-addon/data/icon-96.png',
+      persistence: -1,
+      buttons: [{
+        label: _('no_experiment_button'),
+        popup: null,
+        callback: () => {
+          tabs.open({ url: this.makeUrl() });
+          Metrics.sendGAEvent({
+            t: 'event',
+            ec: 'add-on Interactions',
+            ea: 'click notification',
+            el: 'no experiments installed'
+          });
+        }
+      }]
+    });
+    this.applyCSS(notif);
+
+    Metrics.sendGAEvent({
+      t: 'event',
+      ec: 'add-on Interactions',
+      ea: 'display notification',
+      el: 'no experiments installed'
+    });
+  },
+
+  setup: function() {
+    if (typeof store.noExperiments === 'undefined') {
+      store.noExperiments = {
+        showAt: null,
+        hasBeenShown: false
+      };
+    }
+    if (this.hasNoExperimentsInstalled() && !store.noExperiments.showAt) {
+      store.noExperiments.showAt = Date.now() + this.DELAY;
+    }
+  },
+
+  destroy: function(reason) {
+    if (reason === 'uninstall') {
+      delete store.noExperiments;
+    }
+  },
+
+  init: function(settings) {
+    SETTINGS = settings;
+    this.setup();
+    if (this.shouldShowNotification()) {
+      this.showNotification();
+      store.noExperiments.hasBeenShown = true;
+    }
+  }
+};

--- a/addon/lib/notify.js
+++ b/addon/lib/notify.js
@@ -1,0 +1,49 @@
+const { Services } = require('resource://gre/modules/Services.jsm');
+
+
+function getAnonEl(win, box, attrName) {
+  return win.document.getAnonymousElementByAttribute(box, 'anonid', attrName);
+}
+
+function createNotificationBox(options) {
+  const win = Services.wm.getMostRecentWindow('navigator:browser');
+  const notifyBox = win.gBrowser.getNotificationBox();
+  const box = notifyBox.appendNotification(
+    options.label,
+    options.value || '',
+    options.image,
+    notifyBox.PRIORITY_INFO_LOW,
+    options.buttons || [],
+    options.callback
+  );
+  const messageText = getAnonEl(win, box, 'messageText');
+  const messageImage = getAnonEl(win, box, 'messageImage');
+
+  if (options.child) {
+    const child = options.child(win);
+    // Make sure the child is not pushed to the right by the spacer.
+    const rightSpacer = win.document.createElement('spacer');
+    rightSpacer.flex = 20;
+    child.appendChild(rightSpacer);
+    box.appendChild(child);
+  }
+  messageText.flex = 0; // Collapse the space before the stars/button.
+  const leftSpacer = messageText.nextSibling;
+  leftSpacer.flex = 0;
+  box.classList.add('heartbeat');
+  messageImage.classList.add('heartbeat');
+  if (options.pulse) {
+    messageImage.classList.add('pulse-onshow');
+  }
+  messageText.classList.add('heartbeat');
+  messageImage.setAttribute('style', 'filter: invert(80%)');
+  box.persistence = options.persistence || 0;
+  return {
+    notifyBox,
+    box
+  };
+}
+
+module.exports = {
+  createNotificationBox: createNotificationBox
+};

--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -11,7 +11,7 @@
  */
 
 const Metrics = require('./metrics');
-const { Services } = require('resource://gre/modules/Services.jsm');
+const notify = require('./notify');
 const { setTimeout, clearTimeout } = require('sdk/timers');
 const tabs = require('sdk/tabs');
 const querystring = require('sdk/querystring');
@@ -83,10 +83,6 @@ function getRandomExperiment() {
   const installedKeys = Object.keys(store.installedAddons);
   const randomIndex = Math.floor(Math.random() * installedKeys.length);
   return store.installedAddons[installedKeys[randomIndex]];
-}
-
-function getAnonEl(win, box, attrName) {
-  return win.document.getAnonymousElementByAttribute(box, 'anonid', attrName);
 }
 
 // check if the addon is due for a survey at the current interval
@@ -171,52 +167,13 @@ function createRatingUI(win, cb) {
   return frag;
 }
 
-function createNotificationBox(options) {
-  const win = Services.wm.getMostRecentWindow('navigator:browser');
-  const notifyBox = win.gBrowser.getNotificationBox();
-  const box = notifyBox.appendNotification(
-    options.label,
-    options.value || '',
-    options.image,
-    notifyBox.PRIORITY_INFO_LOW,
-    options.buttons || [],
-    options.callback
-  );
-  const messageText = getAnonEl(win, box, 'messageText');
-  const messageImage = getAnonEl(win, box, 'messageImage');
-
-  if (options.child) {
-    const child = options.child(win);
-    // Make sure the child is not pushed to the right by the spacer.
-    const rightSpacer = win.document.createElement('spacer');
-    rightSpacer.flex = 20;
-    child.appendChild(rightSpacer);
-    box.appendChild(child);
-  }
-  messageText.flex = 0; // Collapse the space before the stars/button.
-  const leftSpacer = messageText.nextSibling;
-  leftSpacer.flex = 0;
-  box.classList.add('heartbeat');
-  messageImage.classList.add('heartbeat');
-  if (options.pulse) {
-    messageImage.classList.add('pulse-onshow');
-  }
-  messageText.classList.add('heartbeat');
-  messageImage.setAttribute('style', 'filter: invert(80%)');
-  box.persistence = options.persistence || 0;
-  return {
-    notifyBox,
-    box
-  };
-}
-
 function showRating(options) {
   return new Promise((resolve) => {
     const experiment = options.experiment;
     const uiTimeout = setTimeout(uiClosed, options.duration || 60000);
     let experimentRating = null;
 
-    const { notifyBox, box } = createNotificationBox({
+    const { notifyBox, box } = notify.createNotificationBox({
       label: options.label || _('survey_show_rating_label', experiment.title),
       image: experiment.thumbnail,
       child: win => createRatingUI(win, uiClosed),
@@ -243,7 +200,7 @@ function showSurveyButton(options) {
     let clicked = false;
     const { experiment, duration } = options;
     const uiTimeout = setTimeout(uiClosed, duration || 60000);
-    const { notifyBox, box } = createNotificationBox({
+    const { notifyBox, box } = notify.createNotificationBox({
       label: _('survey_rating_thank_you', experiment.title),
       image: experiment.thumbnail,
       buttons: [{

--- a/addon/test/test-no-experiments.js
+++ b/addon/test/test-no-experiments.js
@@ -1,0 +1,168 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the "License"). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+const { before } = require('sdk/test/utils');
+const MockUtils = require('./lib/mock-utils');
+
+
+const mocks = {
+  store: {},
+  callbacks: MockUtils.callbacks({
+    Tabs: ['open'],
+    Notify: ['createNotificationBox'],
+    Metrics: ['sendGAEvent']
+  })
+};
+const mockLoader = MockUtils.loader(module, './lib/no-experiments.js', {
+  'sdk/simple-storage': {storage: mocks.store},
+  'sdk/tabs': mocks.callbacks.Tabs,
+  './lib/notify.js': mocks.callbacks.Notify,
+  './lib/metrics.js': mocks.callbacks.Metrics
+});
+const NoExperiments = mockLoader.require('../lib/no-experiments');
+
+
+exports['test makeUrl'] = assert => {
+  const MOCK_SETTINGS = { BASE_URL: 'foo' };
+  NoExperiments.init(MOCK_SETTINGS);
+  assert.ok(NoExperiments.makeUrl().includes(MOCK_SETTINGS.BASE_URL));
+  assert.ok(NoExperiments.makeUrl().includes(NoExperiments.QS));
+  assert.ok(!NoExperiments.makeUrl().includes('undefined'));
+};
+
+
+exports['test hasNoExperimentsInstalled'] = assert => {
+  assert.equal(NoExperiments.hasNoExperimentsInstalled(), true,
+    'Not handling undefined list of installed experiments.');
+
+  mocks.store.installedAddons = {};
+  assert.equal(NoExperiments.hasNoExperimentsInstalled(), true,
+    'Not recognizing empty list of experiments.');
+
+  mocks.store.installedAddons = { 'a': 'b' };
+  assert.equal(NoExperiments.hasNoExperimentsInstalled(), false,
+    'Not recognizing installed experiments.');
+};
+
+
+exports['test shouldShowNotification:experiments'] = assert => {
+  mocks.store.noExperiments = { hasBeenShown: false, showAt: 1 };
+  assert.equal(NoExperiments.shouldShowNotification(), true,
+    'Notification not shown when there are no experiments installed.');
+
+  mocks.store.installedAddons = { 'a': 'b' };
+  assert.equal(NoExperiments.shouldShowNotification(), false,
+    'Notification shown when there are experiments installed.');
+};
+
+
+exports['test shouldShowNotification:hasBeenShown'] = assert => {
+  mocks.store.noExperiments = { hasBeenShown: false, showAt: 1 };
+  assert.equal(NoExperiments.shouldShowNotification(), true,
+    'Notification not shown when it hasn\'t already been shown.');
+
+  mocks.store.noExperiments.hasBeenShown = true;
+  assert.equal(NoExperiments.shouldShowNotification(), false,
+    'Notification shown when it has already been shown.');
+};
+
+
+exports['test shouldShowNotification:showAt'] = assert => {
+  mocks.store.noExperiments = { hasBeenShown: false, showAt: 1 };
+  assert.equal(NoExperiments.shouldShowNotification(), true,
+    'Notification not shown when showAt is in the past.');
+
+  mocks.store.noExperiments.showAt = Date.now() + 9999;
+  assert.equal(NoExperiments.shouldShowNotification(), false,
+    'Notification shown when showAt is in the future.');
+};
+
+
+exports['test setup:store'] = assert => {
+  const MOCK = {foo: 'bar'};
+
+  assert.equal(typeof mocks.store.noExperiments, 'undefined',
+    'did not start with an empty store.');
+
+  NoExperiments.setup();
+  assert.equal(typeof mocks.store.noExperiments, 'object',
+    'did not set store when undefined.');
+
+  mocks.store.noExperiments = MOCK;
+  NoExperiments.setup();
+  assert.equal(mocks.store.noExperiments, MOCK,
+    'changed an already-set store.');
+};
+
+
+exports['test setup:showAt'] = assert => {
+  const MOCK = 'FOO';
+
+  mocks.store.installedAddons = { 'a': 'b' };
+  NoExperiments.setup();
+  assert.equal(mocks.store.noExperiments.showAt, null,
+    'set a showAt time when there were experiments installed.');
+
+  delete mocks.store.installedAddons;
+  mocks.store.noExperiments.showAt = MOCK;
+  NoExperiments.setup();
+  assert.equal(mocks.store.noExperiments.showAt, MOCK,
+    'set a showAt time when one was already set.');
+
+  mocks.store.noExperiments.showAt = null;
+  NoExperiments.setup();
+  assert.ok(mocks.store.noExperiments.showAt >= Date.now() - 1000,
+    'did not correctly set a showAt time.');
+};
+
+
+exports['test destroy'] = assert => {
+  const MOCK = {foo: 'bar'};
+  mocks.store.noExperiments = MOCK;
+
+  NoExperiments.destroy('shutdown');
+  assert.equal(mocks.store.noExperiments, MOCK,
+    'noExperiment state was deleted on shutdown.');
+
+  NoExperiments.destroy('upgrade');
+  assert.equal(mocks.store.noExperiments, MOCK,
+    'noExperiment state was deleted on upgrade.');
+
+  NoExperiments.destroy('downgrade');
+  assert.equal(mocks.store.noExperiments, MOCK,
+    'noExperiment state was deleted on downgrade.');
+
+  NoExperiments.destroy('disable');
+  assert.equal(mocks.store.noExperiments, MOCK,
+    'noExperiment state was deleted on disable.');
+
+  NoExperiments.destroy('uninstall');
+  assert.equal(typeof mocks.store.noExperiments, 'undefined',
+    'noExperiment state was not deleted on uninstall.');
+};
+
+
+exports['test init'] = assert => {
+  NoExperiments.init();
+  assert.equal(mocks.callbacks.Notify.createNotificationBox.calls().length, 0,
+    'Notification created when it shouldn\'t have been.');
+
+  mocks.store.noExperiments = { hasBeenShown: false, showAt: 1 };
+  NoExperiments.init();
+  assert.equal(mocks.callbacks.Notify.createNotificationBox.calls().length, 1,
+    'Notification not created when it should have been.');
+  assert.equal(mocks.callbacks.Metrics.sendGAEvent.calls().length, 1,
+    'Did not fire a GA event when the notification was created.');
+};
+
+
+before(module.exports, function(name, assert, done) {
+  MockUtils.resetCallbacks(mocks.callbacks);
+  Object.keys(mocks.store).forEach(key => delete mocks.store[key]);
+  done();
+});
+
+
+require('sdk/test').run(exports);

--- a/docs/metrics/ga.md
+++ b/docs/metrics/ga.md
@@ -49,33 +49,34 @@ app.sendToGA('event', {
 
 Here are the current events on the website as of this writing
 
-| Description                                              | eventCategory                      | eventAction              | eventLabel                    |
-|----------------------------------------------------------|------------------------------------|--------------------------|-------------------------------|
-| Toggle settings menu                                     | Menu Interactions                  | drop-down menu           | Toggle Menu                   |            
-| Click Leave from settings                                | Menu Interactions                  | drop-down menu           | Retire                        |            
-| Click Discuss from settings                              | Menu Interactions                  | drop-down menu           | Discuss                       |            
-| Click Wiki from settings                                 | Menu Interactions                  | drop-down menu           | wiki                          |            
-| Click File Issue from settings                           | Menu Interactions                  | drop-down menu           | File Issue                    |            
-| Click on experiment from landing page                    | ExperimentsPage Interactions       | Open details page        | `{experiment title}`          |            
-| Click on Install from experiment details page            | ExperimentDetailsPage Interactions | button click             | Install the Add-on            |
-| Click on the "Try out these experiments as well" section | ExperimentsDetailPage Interactions | Open details page        | try out `{experiment title}`  |            
-| Click Enable Experiment                                  | ExperimentDetailsPage Interactions | Enable Experiment        | `{experiment title}`          |            
-| Click Disable Experiment                                 | ExperimentDetailsPage Interactions | Disable Experiment       | `{experiment title}`          |            
-| Click Give Feedback for experiment                       | ExperimentDetailsPage Interactions | Give Feedback            | `{experiment title}`          |
-| Click upgrade notice                                     | ExperimentDetailsPage Interactions | Upgrade Notice           | `{experiment title}`          |             
-| Click Take Survey after disable                          | ExperimentDetailsPage Interactions | button click             | exit survey disabled          |            
-| Click Cancel on tour dialogue                            | ExperimentDetailsPage Interactions | button click             | cancel tour                   |            
-| Complete the tour                                        | ExperimentDetailsPage Interactions | button click             | complete tour                 |            
-| Click Take Tour on tour dialogue                         | ExperimentDetailsPage Interactions | button click             | take tour                     |           
-| Click next during Tour                                   | ExperimentDetailsPage Interactions | button click             | forward to step `n`           |            
-| Click back during Tour                                   | ExperimentDetailsPage Interactions | button click             | back to step `n`              |            
-| Click on Install from landing page                       | HomePage Interactions              | button click             | Install the Add-on            |
-| Click on experiment from landing page                    | HomePage Interactions              | Open details page        | `{experiment title}`          |            
-| Click take survey after Leave                            | RetirePage Interactions            | button click             | take survey                   |            
-| Click on Twitter link in footer                          | FooterView Interactions            | social link clicked      | Twitter                       |            
-| Click on GitHub link in footer                           | FooterView Interactions            | social link clicked      | GitHub                        |            
-| Click on a button in the Share section                   | ShareView Interactions             | button click             | {facebook,twitter,email,copy} |           
-| Prompted to restart the browser                          | PostInstall Interactions           | view modal               | restart required              |            
+| Description                                                                    | eventCategory                      | eventAction              | eventLabel                    |
+|--------------------------------------------------------------------------------|------------------------------------|--------------------------|-------------------------------|
+| Toggle settings menu                                                           | Menu Interactions                  | drop-down menu           | Toggle Menu                   |            
+| Click Leave from settings                                                      | Menu Interactions                  | drop-down menu           | Retire                        |            
+| Click Discuss from settings                                                    | Menu Interactions                  | drop-down menu           | Discuss                       |            
+| Click Wiki from settings                                                       | Menu Interactions                  | drop-down menu           | wiki                          |            
+| Click File Issue from settings                                                 | Menu Interactions                  | drop-down menu           | File Issue                    |            
+| Click on experiment from landing page                                          | ExperimentsPage Interactions       | Open details page        | `{experiment title}`          |            
+| Click on Install from experiment details page                                  | ExperimentDetailsPage Interactions | button click             | Install the Add-on            |
+| Click on the "Try out these experiments as well" section                       | ExperimentsDetailPage Interactions | Open details page        | try out `{experiment title}`  |            
+| Click Enable Experiment                                                        | ExperimentDetailsPage Interactions | Enable Experiment        | `{experiment title}`          |            
+| Click Disable Experiment                                                       | ExperimentDetailsPage Interactions | Disable Experiment       | `{experiment title}`          |            
+| Click Give Feedback for experiment                                             | ExperimentDetailsPage Interactions | Give Feedback            | `{experiment title}`          |
+| Click upgrade notice                                                           | ExperimentDetailsPage Interactions | Upgrade Notice           | `{experiment title}`          |             
+| Click Take Survey after disable                                                | ExperimentDetailsPage Interactions | button click             | exit survey disabled          |            
+| Click Cancel on tour dialogue                                                  | ExperimentDetailsPage Interactions | button click             | cancel tour                   |            
+| Complete the tour                                                              | ExperimentDetailsPage Interactions | button click             | complete tour                 |            
+| Click Take Tour on tour dialogue                                               | ExperimentDetailsPage Interactions | button click             | take tour                     |           
+| Click next during Tour                                                         | ExperimentDetailsPage Interactions | button click             | forward to step `n`           |            
+| Click back during Tour                                                         | ExperimentDetailsPage Interactions | button click             | back to step `n`              |            
+| Click on Install from landing page                                             | HomePage Interactions              | button click             | Install the Add-on            |
+| Click on the no thank you survey after coming from no experiments notification | HomePage Interactions              | button click             | no experiments no thank you   |
+| Click on experiment from landing page                                          | HomePage Interactions              | Open details page        | `{experiment title}`          |            
+| Click take survey after Leave                                                  | RetirePage Interactions            | button click             | take survey                   |            
+| Click on Twitter link in footer                                                | FooterView Interactions            | social link clicked      | Twitter                       |            
+| Click on GitHub link in footer                                                 | FooterView Interactions            | social link clicked      | GitHub                        |            
+| Click on a button in the Share section                                         | ShareView Interactions             | button click             | {facebook,twitter,email,copy} |           
+| Prompted to restart the browser                                                | PostInstall Interactions           | view modal               | restart required              |            
 
 * Indicates whether or not a restart is required.
 
@@ -132,12 +133,13 @@ Here is a description of the different utm tags ([URL builder tool from Google](
 
 We should maintain a consistent convention when using campaign parameters.
 
-| Description                                                            | utm_source                    | utm_medium      | utm_campaign         | utm_content            |
-|------------------------------------------------------------------------|-------------------------------|-----------------|----------------------|------------------------|
-| Clicking on an experiment (or "view all") from the doorhanger          | testpilot-addon               | firefox-browser | testpilot-doorhanger | {'badged','not badged'}|
-| Clicking on an experiment from the in-product messaging                | testpilot-addon               | firefox-browser | push notification    | {messageID}            |
-| Tab opens after user has tried an experiment for n days (#1292)        | testpilot-addon               | firefox-browser | share-page           |                        |
-| Links that get shared from /share                                      | {facebook,twitter,email,copy} | social          | share-page           |                        |
-| User hits home page after being sent by the add-on after installation. | testpilot-addon               | firefox-browser | restart-required     |                        |
+| Description                                                            | utm_source                    | utm_medium      | utm_campaign           | utm_content              |
+|------------------------------------------------------------------------|-------------------------------|-----------------|------------------------|--------------------------|
+| Clicking on an experiment (or "view all") from the doorhanger          | testpilot-addon               | firefox-browser | testpilot-doorhanger   | {'badged','not badged'}  |
+| Clicking on an experiment from the in-product messaging                | testpilot-addon               | firefox-browser | push notification      | {messageID}              |  
+| Tab opens after user has tried an experiment for n days (#1292)        | testpilot-addon               | firefox-browser | share-page             |                          |
+| Links that get shared from /share                                      | {facebook,twitter,email,copy} | social          | share-page             |                          |
+| User hits home page after being sent by the add-on after installation. | testpilot-addon               | firefox-browser | restart-required       |                          |
+| Clicks on the no experiments installed notification                    | testpilot-addon               | firefox-browser | testpilot-notification | no-experiments-installed |
 
 * Indicates whether the toolbar button had the 'New' badge on it.

--- a/frontend/src/app/containers/HomePageWithAddon.js
+++ b/frontend/src/app/containers/HomePageWithAddon.js
@@ -26,6 +26,48 @@ export default class HomePageWithAddon extends React.Component {
     };
   }
 
+  onNotInterestedSurveyClick() {
+    this.props.sendToGA('event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'no experiments no thank you'
+    });
+  }
+
+  renderSplash() {
+    if (window.location.search.includes('utm_content=no-experiments-installed')) {
+      return (
+        <div className="intro-text">
+          <h2 data-l10n-id="experimentsListNoneInstalledHeader" className="banner">
+            Let's get this baby off the ground!
+          </h2>
+          <p data-l10n-id="experimentsListNoneInstalledSubheader">
+            Ready to try a new Test Pilot experiment? Select one to enable, take
+            it for a spin, and let us know what you think.
+          </p>
+          <p data-l10n-id="experimentsListNoneInstalledCTA" className="cta">
+            Not interested?
+           <a onClick={() => this.onNotInterestedSurveyClick()}
+              href="https://qsurvey.mozilla.com/s3/TxP-User" target="_blank">
+            Let us know why
+           </a>.
+          </p>
+        </div>
+      );
+    }
+    return (
+      <div className="intro-text">
+        <h2 data-l10n-id="experimentListPageHeader" className="banner">
+          Ready for Takeoff!
+        </h2>
+        <p data-l10n-id="experimentListPageSubHeader">
+          Pick the features you want to try.<br />
+          Check back soon for more experiments.
+        </p>
+      </div>
+    );
+  }
+
   render() {
     const { experiments, isAfterCompletedDate } = this.props;
 
@@ -45,10 +87,7 @@ export default class HomePageWithAddon extends React.Component {
           <div className="copter-wrapper fly-down">
             <div className="copter"></div>
           </div>
-          <div className="intro-text">
-            <h2 data-l10n-id="experimentListPageHeader" className="banner">Ready for Takeoff!</h2>
-            <p data-l10n-id="experimentListPageSubHeader">Pick the features you want to try. <br /> Check back soon for more experiments.</p>
-          </div>
+          {this.renderSplash()}
         </div>
 
         <div className="pinstripe responsive-content-wrapper"></div>

--- a/frontend/src/styles/modules/_banners.scss
+++ b/frontend/src/styles/modules/_banners.scss
@@ -62,6 +62,16 @@
 
       margin: 0;
       position: relative;
+
+      &.cta {
+        font-size: $font-unit * 1.33;
+        line-height: $line-unit * 1.33;
+        margin-top: $grid-unit;
+
+        a {
+          color: $eol-orange;
+        }
+      }
     }
 
     .legal-information {

--- a/locales/en-US/addon.properties
+++ b/locales/en-US/addon.properties
@@ -18,3 +18,6 @@ survey_launch_survey_label = The %s experiment has ended. What did you think?
 
 # LOCALIZER NOTE: Placeholder is site host (e.g. testpilot.firefox.com)
 notification_via = via %s
+
+no_experiment_message = Test out Firefox's latest experimental features with Test Pilot!
+no_experiment_button = What experiments?

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -186,6 +186,13 @@ newsletterFooterSuccessBody = If you haven't previously confirmed a subscription
 localeWarningTitle = This experiment is only available in English.
 localeWarningSubtitle = You can still enable it if you like.
 
+# Alternate splash page header for users who have installed Test Pilot, but no experiments.
+experimentsListNoneInstalledHeader = Let's get this baby off the ground!
+# Alternate splash page subheader for users who have installed Test Pilot, but no experiments.
+experimentsListNoneInstalledSubheader = Ready to try a new Test Pilot experiment? Select one to enable, take it for a spin, and let us know what you think.
+# Call to action on the alternate splash page for users who have installed Test Pilot, but no experiments.
+experimentsListNoneInstalledCTA = Not interested? <a>Let us know why</a>.
+
 # TODO: these strings are not currently localized.
 # They are served by the python static dir
 # and will need python-l20n implementation for coverage


### PR DESCRIPTION
This is mostly ready to go and should be ready to review. A few things to do:

- [x] Use GA params (#1773; merge is blocked on this).
- [x] Change the copy of the landing page based on URL's GA params.
- [x] Get a link to a SurveyGizmo survey.

To test this, you can [use the Add-on Debugger to modify `simple-storage`](https://developer.mozilla.org/en-US/Add-ons/SDK/High-Level_APIs/simple-storage#Accessing_storage_from_the_console), setting `noExperiments.showAt` to `1`.

## Screenshots

<img width="1139" alt="screen shot 2016-11-11 at 8 59 51 am" src="https://cloud.githubusercontent.com/assets/23885/20221276/f0122172-a7ed-11e6-9ba3-aa5d8756d028.png">

This doesn't exactly match the mocks, but instead uses the same style as our existing survey prompts. @sevaan, let me know if there are tweaks you'd like made.

<img width="1276" alt="screen shot 2016-11-11 at 9 39 19 am" src="https://cloud.githubusercontent.com/assets/23885/20222482/bf8da030-a7f2-11e6-883b-d9ab40ad435d.png">
