### PR TITLE
Use l20n sections in FTL files (closes #1814).

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -1,59 +1,72 @@
 siteName = Firefox Test Pilot
 
+# Page titles, put in the <title> HTML tag.
+[[pageTitle]]
 pageTitleDefault = Firefox Test Pilot
 pageTitleLandingPage = Firefox Test Pilot
 pageTitleExperimentListPage = Firefox Test Pilot - Experiments
 pageTitleExperiment = Firefox Test Pilot - {$title}
 
-footerLinkContribute = Contribute
+# Links in the footer.
+[[footerLink]]
 footerLinkCookies = Cookies
 footerLinkPrivacy = Privacy
 footerLinkTerms = Terms
 footerLinkLegal = Legal
 footerLinkAbout = About Test Pilot
 
+# Items in the menu.
+[[menu]]
 home = Home
-
 menuTitle = Settings
 menuWiki = Test Pilot Wiki
 menuDiscuss = Discuss Test Pilot
 menuFileIssue = File an Issue
-menuLogout = Sign out
 menuRetire = Uninstall Test Pilot
 
-landingFxaAlternateButton = Sign in
+# The splash on the homepage.
+[[landing]]
 landingIntroLead = Go beyond . . .
 landingIntroOne = Test new features.
 landingIntroTwo = Give your feedback.
 landingIntroThree = Help build Firefox.
-landingFxaGetStartedButton = Get started with a Firefox Account
 landingLegalNotice = By proceeding, you agree to the <a>Terms of Use</a> and <a>Privacy Notice</a> of Test Pilot.
+landingExperimentsTitle = Try out the latest experimental features
 
-landingInstallHeader = Get the add-on to get going!
+# Related to the installation of the Test Pilot add-on.
+[[landingInstall]]
 landingInstallButton = Install the Test Pilot Add-on
 landingInstallingButton = Installing...
-landingInstallMessage = Test Pilot installed!
 landingInstalledButton = Choose your features
 
+# Homepage messaging for users not on Firefox or with an old version of Firefox.
+[[landingFirefox]]
 landingRequiresDesktop = Test Pilot requires Firefox for Desktop on Windows, Mac or Linux
 landingDownloadFirefoxDesc = (Test Pilot is available for Firefox on Windows, OS X and Linux)
 landingUpgradeDesc = Test Pilot requires Firefox 45 or higher.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Upgrade Firefox
 landingDownloadFirefoxSubTitle = Free Download
-landingExperimentsTitle = Try out the latest experimental features
+
+# A section of the homepage explaining how Test Pilot works.
+[[landingCard]]
 landingCardListTitle = Get started in 3, 2, 1
 landingCardOne = Get the Test Pilot add-on
 landingCardTwo = Enable experimental features
 landingCardThree = Tell us what you think
 
+# Shown after the user installs the Test Pilot add-on.
+[[onboarding]]
 onboardingMessage = We put an icon in your toolbar so you can always find Test Pilot.
 
+# Error message pages.
+[[error]]
 errorHeading = Whoops!
 errorMessage = Looks like we broke something. <br> Maybe try again later.
-
 notFoundHeader = Four Oh Four!
 
+# A modal prompt to sign up for the Test Pilot newsletter.
+[[emailOptIn]]
 emailOptInDialogTitle = Welcome to Test Pilot!
 emailOptInMessage = Find out about new experiments and see test results for experiments you've tried.
 emailValidationError = Please use a valid email address!
@@ -66,6 +79,8 @@ emailOptInConfirmationTitle = Email Sent
 emailOptInSuccessMessage2 = Thank you!
 emailOptInConfirmationClose = On to the experiments...
 
+# A listing of all Test Pilot experiments.
+[[experimentsList]]
 experimentListPageHeader = Ready for Takeoff!
 experimentListPageSubHeader  = Pick the features you want to try. <br> Check back soon for more experiments.
 experimentListEnabledTab = Enabled
@@ -73,38 +88,25 @@ experimentListJustLaunchedTab = Just Launched
 experimentListJustUpdatedTab = Just Updated
 experimentListEndingTomorrow = Ending Tomorrow
 experimentListEndingSoon = Ending Soon
-isEnabledStatusMessage = {$title} is enabled.
-installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.
-participantCount = <span>{$installation_count}</span> participants
+
+# An individual experiment in the listing of all Test Pilot experiments.
+[[experimentCard]]
 experimentCardManage = Manage
 experimentCardGetStarted = Get Started
 experimentCardLearnMore = Learn More
 
-experimentPreFeedbackTitle = {$title} feedback
-experimentPreFeedbackLinkCopy = Give feedback about the {$title} experiment
-
-experimentPromoHeader = Ready for Takeoff?
-experimentPromoSubheader = We're building next-generation features for Firefox. Install Test Pilot to try them!
-
-otherExperiments = Try out these experiments as well
-
-giveFeedback = Give Feedback
-
-disableHeader = Disable Experiment?
-disableExperiment = Disable {$title}
-disableExperimentTransition = Disabling...
-enableExperiment = Enable {$title}
-enableExperimentTransition = Enabling...
-
+# A modal prompt shown when a user disables an experiment.
+[[feedback]]
 feedbackSubmitButton = Take a quick survey
 feedbackCancelButton = Close
-
 feedbackUninstallTitle = Thank You!
 feedbackUninstallCopy =
     | Your participation in Firefox Test Pilot means
     | a lot! Please check out our other experiments,
     | and stay tuned for more to come!
 
+# A modal prompt telling a user that they are about to go to an external forum for discussion.
+[[discussNotify]]
 discussNotifyTitle = Just one second...
 discussNotifyMessageAccountless =
     | <p>In the spirit of experimentation, we are using an external forum service.
@@ -114,27 +116,31 @@ discussNotifyMessageAccountless =
     | always leave feedback through Test Pilot.
     | <br>
     | (We really do read this stuff)</p>
-
 discussNotifySubmitButton = Take me to the forum
 discussNotifyCancelButton = Cancel
 
-retireDialogTitle = Uninstall Test Pilot?
-retireMessage = As you wish. This will disable any active tests, uninstall the add-on and remove your account info from our servers.
-retireEmailMessage = To opt out of email updates, simply click the <em>unsubscribe</em> link on any Test Pilot email.
-retireSubmitButton = Proceed
-retireCancelButton = Cancel
+# A modal prompt shown before the feedback survey for some experiments.
+[[experimentPreFeedback]]
+experimentPreFeedbackTitle = {$title} feedback
+experimentPreFeedbackLinkCopy = Give feedback about the {$title} experiment
 
-pageTitleRetirePage = Firefox Test Pilot - Uninstall Test Pilot
-retirePageProgressMessage = Shutting down...
-retirePageHeadline = Thanks for flying!
-retirePageMessage = Hope you had fun experimenting with us. <br> Come back any time.
-retirePageSurveyButton = Take a quick survey
+# A splash shown on top of the experiment page when Test Pilot is not installed.
+[[experimentPromo]]
+experimentPromoHeader = Ready for Takeoff?
+experimentPromoSubheader = We're building next-generation features for Firefox. Install Test Pilot to try them!
 
-restartIntroLead = Preflight checklist
-restartIntroOne = Restart your browser
-restartIntroTwo = Locate the Test Pilot add-on
-restartIntroThree = Select your experiments
-
+# The experiment detail page. 
+[[experimentPage]]
+isEnabledStatusMessage = {$title} is enabled.
+installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.
+participantCount = <span>{$installation_count}</span> participants
+otherExperiments = Try out these experiments as well
+giveFeedback = Give Feedback
+disableHeader = Disable Experiment?
+disableExperiment = Disable {$title}
+disableExperimentTransition = Disabling...
+enableExperiment = Enable {$title}
+enableExperimentTransition = Enabling...
 measurements = Your privacy
 experimentPrivacyNotice = You can learn more about the data collection for {$title} here.
 contributorsHeading = Brought to you by
@@ -145,31 +151,57 @@ lastUpdate = Last Update
 contribute = Contribute
 bugReports = Bug Reports
 discourse = Discourse
-nowActive = Active
-userCount =
-    [html/title] Active Users of this Experiment
 tourOnboardingTitle = {$title} enabled!
-tourStartButton = Take the Tour
-tourCancelButton = Skip
 tourDoneButton = Done
 userCountContainer = There are <span>{$installation_count}</span> people trying {$title} right now!
 userCountContainerAlt = Just launched!
 highlightPrivacy = Your privacy
+
+# Shown when an experiment requires a version of Firefox newer than the user's.
+[[upgradeNotice]]
 upgradeNoticeTitle = {$title} requires Firefox {$min_release} or later.
 upgradeNoticeLink = How to update Firefox.
 
+# Shown while uninstalling Test Pilot.
+[[uninstall]]
+retireDialogTitle = Uninstall Test Pilot?
+retireMessage = As you wish. This will disable any active tests, uninstall the add-on and remove your account info from our servers.
+retireEmailMessage = To opt out of email updates, simply click the <em>unsubscribe</em> link on any Test Pilot email.
+retireSubmitButton = Proceed
+retireCancelButton = Cancel
+pageTitleRetirePage = Firefox Test Pilot - Uninstall Test Pilot
+retirePageProgressMessage = Shutting down...
+retirePageHeadline = Thanks for flying!
+retirePageMessage = Hope you had fun experimenting with us. <br> Come back any time.
+retirePageSurveyButton = Take a quick survey
+
+# Shown to users after installing Test Pilot if a restart is required.
+[[restartIntro]]
+restartIntroLead = Preflight checklist
+restartIntroOne = Restart your browser
+restartIntroTwo = Locate the Test Pilot add-on
+restartIntroThree = Select your experiments
+
+# Shown on a page presented to users three days after installing their first experiment.
+[[share]]
 sharePrimary = Love Test Pilot? Help us find some new recruits.
 shareSecondary = or just copy and paste this link...
 shareEmail = E-mail
 shareCopy = Copy
 
+# Shown on pages of retired experiments.
+[[eol]]
 eolMessage = <strong>This experiment is ending on {$completedDate}</strong>.<br/><br/>After then you will still be able to use {$title} but we will no longer be providing updates or support.
 eolDisableMessage = The {$title} experiment has ended. Once you uninstall it you won't be able to re-install it through Test Pilot again.
 completedDateLabel = Experiment End Date: <b>{$completedDate}</b>
 
+# A warning shown to users looking at experiments incompatible with add-ons they already have installed.
+[[incompatible]]
 incompatibleHeader = This experiment may not be compatible with add-ons you have installed.
 incompatibleSubheader = We recommend <a>disabling these add-ons</a> before activating this experiment:
 
+# A form prompting the user to sign up for the Test Pilot Newsletter.
+[[newsletterForm]]
 newsletterFormEmailPlaceholder =
     [html/placeholder] Your email here
 newsletterFormDisclaimer = We will only send you Test Pilot-related information.
@@ -177,29 +209,32 @@ newsletterFormPrivacyNotice = I'm okay with Mozilla handling my info as explaine
 newsletterFormSubmitButton = Sign Up Now
 newsletterFormSubmitButtonSubmitting = Submitting...
 
+# A section of the footer containing a newsletter signup form.
+[[newsletterFooter]]
 newsletterFooterError = There was an error submitting your email address. Try again?
 newsletterFooterHeader = Stay Informed
 newsletterFooterBody = Find out about new experiments and see test results for experiments you've tried.
 newsletterFooterSuccessHeader = Thanks!
 newsletterFooterSuccessBody = If you haven't previously confirmed a subscription to a Mozilla-related newsletter you may have to do so. Please check your inbox or your spam filter for an email from us.
 
+# A warning shown to users viewing an experiment that is only available in English.
+[[localeWarning]]
 localeWarningTitle = This experiment is only available in English.
 localeWarningSubtitle = You can still enable it if you like.
 
-# Alternate splash page header for users who have installed Test Pilot, but no experiments.
+# An alternate splash page shown to users who have had Test Pilot installed for some time, but have no experiments installed.
+[[experimentsListNoneInstalled]]
 experimentsListNoneInstalledHeader = Let's get this baby off the ground!
-# Alternate splash page subheader for users who have installed Test Pilot, but no experiments.
 experimentsListNoneInstalledSubheader = Ready to try a new Test Pilot experiment? Select one to enable, take it for a spin, and let us know what you think.
-# Call to action on the alternate splash page for users who have installed Test Pilot, but no experiments.
 experimentsListNoneInstalledCTA = Not interested? <a>Let us know why</a>.
 
-# TODO: these strings are not currently localized.
-# They are served by the python static dir
-# and will need python-l20n implementation for coverage
-
+# Shown to users who do not have JavaScript enabled.
+[[noscript]]
 noScriptHeading = Uh oh...
 noScriptMessage = Test Pilot requires JavaScript.<br>Sorry about that.
 noScriptLink = Find out why
 
+# Text of a button to toggle visibility of a list of past experiments.
+[[pastExperiments]]
 viewPastExperiments = View Past Experiments
 hidePastExperiments = Hide Past Experiments


### PR DESCRIPTION
Additionally, this PR deletes strings no longer used:

- `footerLinkContribute`
- `menuLogout`
- `landingFxaAlternateButton`
- `landingFxaGetStartedButton`
- `landingInstallHeader`
- `landingInstallMessage`
- `nowActive`
- `userCount`
- `tourStartButton`
- `tourCancelButton`

Exception: the page title strings, which [I filed a separate bug](https://github.com/mozilla/testpilot/issues/1824) about, since we probably _should_ be using them.

CC @flodolo for an extra peek.