### PR TITLE
Fix missing data-l10n-id in "Your Privacy" section at small viewport

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -407,7 +407,7 @@ export class ExperimentDetail extends React.Component {
                     {measurements && <section data-hook="measurements-container"
                           className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
                       <h3 data-l10n-id="measurements">Your privacy</h3>
-                      <div data-hook="measurements-html" className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
+                      <div data-hook="measurements-html" data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
                       <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-hook="privacy-notice-url">You can learn more about the data collection for <span data-hook="title">{title}</span> here.</a>
                     </section>}
                   </div>}

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -140,7 +140,7 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
 
     // Fields only available when the add-on is installed.
     subject.setProps({ hasAddon: true });
-    expect(findByL10nID('testingMeasurements')).to.have.property('length', 1);
+    expect(findByL10nID('testingMeasurements')).to.have.property('length', 2);
     expect(findByL10nID('testingDescription')).to.have.property('length', 1);
   });
 


### PR DESCRIPTION
Fixes issue #1860