### PR TITLE
Localize page titles

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -174,6 +174,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     subscribeToBasket,
     clipboard,
     userAgent: navigator.userAgent,
+    setPageTitleL10N: (id, args) => {
+      const title = document.querySelector('head title');
+      title.setAttribute('data-l10n-id', id);
+      title.setAttribute('data-l10n-args', JSON.stringify(args));
+    },
     openWindow: (href, name) => window.open(href, name),
     getWindowLocation: () => window.location,
     addScrollListener: listener =>

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -187,13 +187,17 @@ export class ExperimentDetail extends React.Component {
   }
 
   render() {
-    const { experiment, experiments, installed, isAfterCompletedDate, isDev, hasAddon, setExperimentLastSeen, clientUUID } = this.props;
+    const { experiment, experiments, installed, isAfterCompletedDate, isDev,
+            hasAddon, setExperimentLastSeen, clientUUID,
+            setPageTitleL10N } = this.props;
 
     // Show the loading animation if experiments haven't been loaded yet.
     if (experiments.length === 0) { return <LoadingPage />; }
 
     // Show a 404 page if an experiment for this slug wasn't found.
     if (!experiment) { return <NotFoundPage />; }
+
+    setPageTitleL10N('pageTitleExperiment', experiment);
 
     // Show a 404 page if an experiment is not ready for launch yet
     const utcNow = moment.utc();

--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -14,7 +14,8 @@
 
     <link rel="canonical" href="https://testpilot.firefox.com/{{{ canonical_path }}}">
 
-    <title>{{ meta_title }}</title>
+    <title data-l10n-id="pageTitleDefault">{{ meta_title }}</title>
+
     <meta property="og:title" content="{{ meta_title }}" />
     <meta name="twitter:title" content="{{ meta_title }}" />
     <meta name="description" content="{{ meta_description }}" />

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -37,7 +37,7 @@ describe('app/containers/ExperimentPage', () => {
 });
 
 
-describe('app/components/ExperimentPage:ExperimentDetail', () => {
+describe('app/containers/ExperimentPage:ExperimentDetail', () => {
 
   let mockExperiment, mockClickEvent, props, subject;
   beforeEach(() => {
@@ -112,7 +112,8 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
       getCookie: sinon.spy(),
       removeCookie: sinon.spy(),
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:51.0) Gecko/20100101 Firefox/51.0',
-      newsletterForm: newsletterState
+      newsletterForm: newsletterState,
+      setPageTitleL10N: sinon.spy()
     };
 
     subject = shallow(<ExperimentDetail {...props} />);
@@ -173,6 +174,13 @@ describe('app/components/ExperimentPage:ExperimentDetail', () => {
       subject.setProps({
         isExperimentEnabled: experiment => false
       });
+    });
+
+    it('should localize the page title', () => {
+      expect(props.setPageTitleL10N.called).to.be.true;
+      expect(props.setPageTitleL10N.lastCall.args).to.deep.equal([
+        'pageTitleExperiment', mockExperiment
+      ]);
     });
 
     it('should render a 404 page if not on dev and launch date has not yet passed', () => {


### PR DESCRIPTION
- Use data-l10n-id=pageTitleDefault for all static page titles

- setPageTitleL10N helper to change page title string

- Change to pageTitleExperiment with placeholder for experiment title on
  experiment pages

Fixes #1824