### PR TITLE
Wait longer before checking for addon install notification

### DIFF
--- a/integration/test_installation.py
+++ b/integration/test_installation.py
@@ -48,11 +48,11 @@ class TestAddonInstallation(FirefoxTestCase):
         # HACK: Checking _visibility_ of chrome elements, like notifications,
         # is known to be buggy. Padding the wait_for_notification call with
         # sleeps is the current workaround. See https://bugzil.la/1094246#c17
-        time.sleep(5)
+        time.sleep(15)
         # Click through the blocked notification
         b.wait_for_notification(AddOnInstallBlockedNotification, timeout=60)
         # HACK: Things seem to fail intermittently here if we don't wait a tick
-        time.sleep(0.5)
+        time.sleep(5)
         b.notification.allow_button.click()
 
         # Click through the installation notification


### PR DESCRIPTION
There are some complicated Gecko-centric solutions we can try, but starting with the simplest thing: wait longer before trying to find the notification UI.

Hopefully fixes #1780.