### PR TITLE
Localize dates displayed on Test Pilot website

### DIFF
--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -11,7 +11,7 @@ export function formatDate(date) {
   } else {
     // safari is the new IE :(
     try {
-      out = d.toLocaleDateString();
+      out = d.toLocaleDateString(navigator.language);
     } catch (e) {
       out = `${d.getMonth() + 1} / ${d.getDate()} / ${d.getFullYear()}`;
     }


### PR DESCRIPTION
Fixes #1823.

@pdehaan did most of the work in the description for #1823, just used [`navigator.language`](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorLanguage/language) to get the preferred cross-browser locale.