### PR TITLE
remove all leftover data-hooks

### DIFF
--- a/frontend/src/app/components/DiscussDialog.js
+++ b/frontend/src/app/components/DiscussDialog.js
@@ -21,7 +21,7 @@ export default class DiscussDialog extends React.Component {
               </div>
             </div>
             <div className="modal-actions">
-              <button onClick={e => this.submit(e)} data-hook="submit-feedback" data-l10n-id="discussNotifySubmitButton" className="submit button large default">Take me to the forum</button>
+              <button onClick={e => this.submit(e)} data-l10n-id="discussNotifySubmitButton" className="submit button large default">Take me to the forum</button>
               <a onClick={e => this.cancel(e)} data-l10n-id="discussNotifyCancelButton" className="cancel modal-escape" href="">Cancel</a>
             </div>
           </form>

--- a/frontend/src/app/components/EmailDialog.js
+++ b/frontend/src/app/components/EmailDialog.js
@@ -17,32 +17,32 @@ export default class EmailDialog extends React.Component {
 
     return (
       <div className="modal-container">
-        {isFirstPage && <div data-hook="first-page" className="modal feedback-modal modal-bounce-in">
+        {isFirstPage && <div id="first-page" className="modal feedback-modal modal-bounce-in">
           <header>
             <h3 className="title" data-l10n-id="emailOptInDialogTitle">Welcome to Test Pilot!</h3>
           </header>
           <form>
             <div className="modal-content modal-form centered">
               <p data-l10n-id="emailOptInMessage" className="">Find out about new experiments and see test results for experiments you've tried.</p>
-              {!isValidEmail && <p className="error" data-hook="invalid-email" data-l10n-id="emailValidationError" >Please use a valid email address!</p>}
-              <input data-hook="email" data-l10n-id="emailOptInInput" placeholder="email goes here :)"
+              {!isValidEmail && <p className="error" data-l10n-id="emailValidationError" >Please use a valid email address!</p>}
+              <input data-l10n-id="emailOptInInput" placeholder="email goes here :)"
                      onChange={e => this.handleEmailChange(e)}
                      value={this.state.email} />
             </div>
             <div className="modal-actions">
-              <button onClick={e => this.submit(e)} data-hook="submit-email" data-l10n-id="emailOptInButton" className="submit button large default">Sign me up</button>
-              <a onClick={e => this.skip(e)} data-hook="cancel-modal" data-l10n-id="emailOptInSkip" className="cancel modal-escape" href="">Skip</a>
+              <button onClick={e => this.submit(e)} data-l10n-id="emailOptInButton" className="submit button large default">Sign me up</button>
+              <a onClick={e => this.skip(e)} data-l10n-id="emailOptInSkip" className="cancel modal-escape" href="">Skip</a>
             </div>
           </form>
         </div>}
-        {!isFirstPage && <div data-hook="second-page" className="modal">
+        {!isFirstPage && <div id="second-page" className="modal">
           <header>
             <h3 className="title" data-l10n-id="emailOptInConfirmationTitle">Email Sent</h3>
           </header>
           <div className="modal-content centered">
             <div className="envelope"></div>
             <p data-l10n-id="emailOptInSuccessMessage2">Thank you!</p>
-            <button onClick={e => this.continue(e)} className="button default" data-hook="continue" data-l10n-id="emailOptInConfirmationClose">On to the experiments...</button>
+            <button id="email-success-continue" onClick={e => this.continue(e)} className="button default" data-l10n-id="emailOptInConfirmationClose">On to the experiments...</button>
           </div>
         </div>}
       </div>

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -22,7 +22,7 @@ export default class ExperimentRowCard extends React.Component {
     const isCompleted = isAfterCompletedDate(experiment);
 
     return (
-      <Link data-hook="show-detail" to={`/experiments/${slug}`} onClick={(evt) => this.openDetailPage(evt)}
+      <Link id="show-detail" to={`/experiments/${slug}`} onClick={(evt) => this.openDetailPage(evt)}
         className={classnames('experiment-summary', {
           enabled,
           'just-launched': this.justLaunched(),
@@ -35,7 +35,7 @@ export default class ExperimentRowCard extends React.Component {
           {this.justLaunched() && <div data-l10n-id="experimentListJustLaunchedTab" className="tab just-launched-tab"></div>}
           {this.justUpdated() && <div data-l10n-id="experimentListJustUpdatedTab" className="tab just-updated-tab"></div>}
         </div>
-        <div className="experiment-icon-wrapper" data-hook="bg"
+        <div className="experiment-icon-wrapper"
           style={{
             backgroundColor: experiment.gradient_start,
             backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop}`

--- a/frontend/src/app/components/Header.js
+++ b/frontend/src/app/components/Header.js
@@ -31,21 +31,21 @@ export default class Header extends React.Component {
   renderSettingsMenu() {
     if (this.shouldRenderSettingsMenu()) {
       return (
-        <div data-hook="settings">
-          <div className="settings-contain" data-hook="active-user">
+        <div id="settings">
+          <div className="settings-contain">
              <div className={classnames(['button', 'outline', 'settings-button'], { active: this.showSettingsMenu() })}
                   onClick={e => this.toggleSettings(e)}
-                  data-hook="settings-button" data-l10n-id="menuTitle">Settings</div>
+                  data-l10n-id="menuTitle">Settings</div>
                {this.showSettingsMenu() && <div className="settings-menu" onClick={e => this.settingsClick(e)}>
                <ul>
-                 <li><a onClick={e => this.wiki(e)} data-l10n-id="menuWiki" data-hook="wiki"
+                 <li><a onClick={e => this.wiki(e)} data-l10n-id="menuWiki"
                     href="https://wiki.mozilla.org/Test_Pilot" target="_blank">Test Pilot Wiki</a></li>
-                 <li><a onClick={e => this.discuss(e)} data-l10n-id="menuDiscuss" data-hook="discuss"
+                 <li><a onClick={e => this.discuss(e)} data-l10n-id="menuDiscuss"
                     href="https://discourse.mozilla-community.org/c/test-pilot" target="_blank">Discuss Test Pilot</a></li>
-                 <li><a onClick={e => this.fileIssue(e)} data-l10n-id="menuFileIssue" data-hook="issue"
+                 <li><a onClick={e => this.fileIssue(e)} data-l10n-id="menuFileIssue"
                     href="https://github.com/mozilla/testpilot/issues/new" target="_blank">File an Issue</a></li>
                  <li><hr /></li>
-                 <li><a onClick={e => this.retire(e)} data-l10n-id="menuRetire" data-hook="retire">Uninstall Test Pilot</a></li>
+                 <li><a onClick={e => this.retire(e)} data-l10n-id="menuRetire">Uninstall Test Pilot</a></li>
                </ul>
              </div>}
           </div>

--- a/frontend/src/app/components/RetireConfirmationDialog.js
+++ b/frontend/src/app/components/RetireConfirmationDialog.js
@@ -15,7 +15,7 @@ export default class RetireConfirmationDialog extends React.Component {
               <p data-l10n-id="retireEmailMessage" className="centered small">To opt out of email updates, simply click the <em>unsubscribe</em> link on any Test Pilot email.</p>
             </div>
             <div className="modal-actions">
-              <button onClick={e => this.proceed(e)} data-hook="submit-feedback" data-l10n-id="retireSubmitButton" className="submit button warning large">Proceed</button>
+              <button onClick={e => this.proceed(e)} data-l10n-id="retireSubmitButton" className="submit button warning large">Proceed</button>
               <a onClick={e => this.cancel(e)} data-l10n-id="retireCancelButton" className="cancel modal-escape" href="">Cancel</a>
             </div>
           </form>

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -233,7 +233,7 @@ export class ExperimentDetail extends React.Component {
     }
 
     return (
-      <section id="details" data-hook="experiment-page">
+      <section id="experiment-page">
 
         {showEmailDialog &&
           <EmailDialog {...this.props}
@@ -266,7 +266,7 @@ export class ExperimentDetail extends React.Component {
 
         <View {...this.props}>
 
-        {!hasAddon && <section data-hook="testpilot-promo">
+        {!hasAddon && <section id="testpilot-promo">
           <div className="experiment-promo">
             <div className="reverse-split-banner responsive-content-wrapper">
               <div className="copter-wrapper fly-up">
@@ -286,18 +286,18 @@ export class ExperimentDetail extends React.Component {
         </section>}
 
         <div className="default-background">
-          <div data-hook="has-status" className={classnames(
+          <div className={classnames(
               'details-header-wrapper',
               { 'has-status': !!statusType, stick: useStickyHeader })
             }>
-            <div data-hook="status-type" className={classnames('status-bar', statusType)}>
-              {(statusType === 'enabled') && <span data-hook="enabled-msg" data-l10n-id="isEnabledStatusMessage" data-l10n-args={JSON.stringify({ title })}><span data-hook="title">{title}</span> is enabled.</span>}
-              {(statusType === 'error') && <span data-hook="error-msg" data-l10n-id="installErrorMessage" data-l10n-args={JSON.stringify({ title })}>Uh oh. <span data-hook="title">{title}</span> could not be enabled. Try again later.</span>}
+            <div className={classnames('status-bar', statusType)}>
+              {(statusType === 'enabled') && <span data-l10n-id="isEnabledStatusMessage" data-l10n-args={JSON.stringify({ title })}><span>{title}</span> is enabled.</span>}
+              {(statusType === 'error') && <span data-l10n-id="installErrorMessage" data-l10n-args={JSON.stringify({ title })}>Uh oh. <span>{title}</span> could not be enabled. Try again later.</span>}
             </div>
             <div className="details-header responsive-content-wrapper">
               <header>
-                <h1 data-hook="title">{title}</h1>
-                {subtitle && <h4 data-hook="subtitle" className="subtitle" data-l10n-id={this.l10nId('subtitle')}>{subtitle}</h4>}
+                <h1>{title}</h1>
+                {subtitle && <h4 className="subtitle" data-l10n-id={this.l10nId('subtitle')}>{subtitle}</h4>}
               </header>
               { this.renderExperimentControls() }
               { this.renderMinimumVersionNotice(title, hasAddon, min_release) }
@@ -305,29 +305,29 @@ export class ExperimentDetail extends React.Component {
           </div>
           <div className="sticky-header-sibling" style={{ height: `${stickyHeaderSiblingHeight}px` }} ></div>
 
-          <div data-hook="details">
+          <div id="details">
               <div className="details-content responsive-content-wrapper">
                 <div className="details-overview">
-                  <div className="experiment-icon-wrapper" data-hook="bg"
+                  <div className="experiment-icon-wrapper"
                        style={{
                          backgroundColor: `${experiment.gradient_start}`,
                          backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop})`
                        }}>
-                    <img className="experiment-icon" data-hook="thumbnail" src={thumbnail}></img>
+                    <img className="experiment-icon" src={thumbnail}></img>
                   </div>
                   <div className="details-sections">
                     <section className="user-count">
                       { this.renderInstallationCount() }
                     </section>
-                    {!hasAddon && <div data-hook="inactive-user">
-                      {!!introduction && <section className="introduction" data-hook="introduction-container">
+                    {!hasAddon && <div>
+                      {!!introduction && <section className="introduction">
                       {!graduated &&
-                        <div data-l10n-id={this.l10nId('introduction')} data-hook="introduction-html" dangerouslySetInnerHTML={createMarkup(introduction)}></div>
+                        <div data-l10n-id={this.l10nId('introduction')} dangerouslySetInnerHTML={createMarkup(introduction)}></div>
                       }
                       </section>}
                     </div>}
                     {!graduated && <div>
-                      {hasAddon && <section className="stats-section" data-hook="active-user">
+                      {hasAddon && <section className="stats-section">
                         <table className="stats"><tbody>
                           <tr>
                             <td data-l10n-id="tour">Tour</td>
@@ -336,22 +336,22 @@ export class ExperimentDetail extends React.Component {
                           {changelog_url && <tr>
                             <td data-l10n-id="changelog">Changelog</td>
                             <td>
-                             {changelog_url && <a data-hook="changelog-url" href={changelog_url}>{changelog_url}</a>}
+                             {changelog_url && <a href={changelog_url}>{changelog_url}</a>}
                             </td>
                           </tr>}
                           <tr>
                             <td data-l10n-id="contribute">Contribute</td>
-                            <td><a data-hook="contribute-url" href={contribute_url}>{contribute_url}</a></td>
+                            <td><a href={contribute_url}>{contribute_url}</a></td>
                           </tr>
 
                           <tr>
                             <td data-l10n-id="bugReports">Bug Reports</td>
-                            <td><a data-hook="bug-report-url" href={bug_report_url}>{bug_report_url}</a></td>
+                            <td><a href={bug_report_url}>{bug_report_url}</a></td>
                           </tr>
 
                           <tr>
                             <td data-l10n-id="discourse">Discourse</td>
-                            <td><a data-hook="discourse-url" href={discourse_url}>{discourse_url}</a></td>
+                            <td><a href={discourse_url}>{discourse_url}</a></td>
                           </tr>
                         </tbody></table>
                       </section>}
@@ -361,10 +361,10 @@ export class ExperimentDetail extends React.Component {
                       <ul className="contributors">
                         {contributors.map((contributor, idx) => (
                           <li key={idx}>
-                            <img className="avatar" data-hook="avatar" width="56" height="56" src={contributor.avatar} />
+                            <img className="avatar" width="56" height="56" src={contributor.avatar} />
                             <div className="contributor">
-                              <p data-hook="name" className="name">{contributor.display_name}</p>
-                              {contributor.title && <p data-hook="title" className="title" data-l10n-id={this.l10nId(['contributors', idx, 'title'])}>{contributor.title}</p>}
+                              <p className="name">{contributor.display_name}</p>
+                              {contributor.title && <p className="title" data-l10n-id={this.l10nId(['contributors', idx, 'title'])}>{contributor.title}</p>}
                             </div>
                           </li>
                         ))}
@@ -378,12 +378,12 @@ export class ExperimentDetail extends React.Component {
                     }
                     </section>
                     {!graduated && <div>
-                      {hasAddon && <div data-hook="active-user">
-                        {measurements && <section data-hook="measurements-container"
-                            className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
+                      {hasAddon && <div>
+                        {measurements && <section
+                              className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
                           <h3 data-l10n-id="measurements">Your privacy</h3>
-                          <div data-hook="measurements-html" data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
-                          {privacy_notice_url && <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-l10n-args={JSON.stringify({ title })} data-hook="privacy-notice-url" href={privacy_notice_url}>You can learn more about the data collection for <span data-hook="title">{title}</span> here.</a>}
+                          <div data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
+                          {privacy_notice_url && <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-l10n-args={JSON.stringify({ title })} href={privacy_notice_url}>You can learn more about the data collection for <span>{title}</span> here.</a>}
                         </section>}
                       </div>}
                     </div>}
@@ -394,30 +394,30 @@ export class ExperimentDetail extends React.Component {
                   {this.renderEolBlock()}
                   {this.renderIncompatibleAddons()}
                   {this.renderLocaleWarning()}
-                  {hasAddon && <div data-hook="active-user">
-                    {!!introduction && <section className="introduction" data-hook="introduction-container">
-                      <div data-hook="introduction-html" data-l10n-id={this.l10nId('description')} dangerouslySetInnerHTML={createMarkup(introduction)}></div>
+                  {hasAddon && <div>
+                    {!!introduction && <section className="introduction">
+                      <div data-l10n-id={this.l10nId('description')} dangerouslySetInnerHTML={createMarkup(introduction)}></div>
                     </section>}
                   </div>}
                   <div className="details-list">
                     {details.map((detail, idx) => (
                      <div key={idx}>
-                       <div data-hook="details" className="details-image">
-                         <img data-hook="detail-image" width="680" src={detail.image} />
+                       <div className="details-image">
+                         <img width="680" src={detail.image} />
                          <p className="caption">
-                           {detail.headline && <strong data-hook="detail-headline" data-l10n-id={this.l10nId(['details', idx, 'headline'])}>{detail.headline}</strong>}
-                           {detail.copy && <span data-hook="detail-copy" data-l10n-id={this.l10nId(['details', idx, 'copy'])} dangerouslySetInnerHTML={createMarkup(detail.copy)}></span>}
+                           {detail.headline && <strong data-l10n-id={this.l10nId(['details', idx, 'headline'])}>{detail.headline}</strong>}
+                           {detail.copy && <span data-l10n-id={this.l10nId(['details', idx, 'copy'])} dangerouslySetInnerHTML={createMarkup(detail.copy)}></span>}
                          </p>
                        </div>
                      </div>
                     ))}
                   </div>
-                  {hasAddon && <div data-hook="active-user">
-                    {measurements && <section data-hook="measurements-container"
+                  {hasAddon && <div>
+                    {measurements && <section
                           className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
                       <h3 data-l10n-id="measurements">Your privacy</h3>
-                      <div data-hook="measurements-html" data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
-                      {privacy_notice_url && <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-l10n-args={JSON.stringify({ title })} data-hook="privacy-notice-url" href={privacy_notice_url}>You can learn more about the data collection for <span data-hook="title">{title}</span> here.</a>}
+                      <div data-l10n-id={this.l10nId('measurements')} className="measurement" dangerouslySetInnerHTML={createMarkup(measurements)}></div>
+                      {privacy_notice_url && <a className="privacy-policy" data-l10n-id="experimentPrivacyNotice" data-l10n-args={JSON.stringify({ title })} href={privacy_notice_url}>You can learn more about the data collection for <span data-hook="title">{title}</span> here.</a>}
                     </section>}
                   </div>}
                   </div>}
@@ -428,9 +428,9 @@ export class ExperimentDetail extends React.Component {
               </div>
             </div>
           </div>
-          {!hasAddon && <div data-hook="inactive-user">
+          {!hasAddon && <div>
             <h2 className="card-list-header" data-l10n-id="otherExperiments">Try out these experiments as well</h2>
-            <div className="responsive-content-wrapper delayed-fade-in" data-hook="experiment-list">
+            <div className="responsive-content-wrapper delayed-fade-in">
               <ExperimentCardList {...this.props}
                                   experiments={currentExperiments}
                                   except={experiment.slug}

--- a/frontend/src/app/containers/HomePageNoAddon.js
+++ b/frontend/src/app/containers/HomePageNoAddon.js
@@ -16,7 +16,7 @@ export default class HomePageNoAddon extends React.Component {
     const currentExperiments = experiments.filter(x => !isAfterCompletedDate(x));
 
     return (
-      <section data-hook="landing-page">
+      <section id="landing-page">
         <View {...this.props}>
           <div className="split-banner responsive-content-wrapper">
             <div className="copter-wrapper fly-up">
@@ -39,7 +39,7 @@ export default class HomePageNoAddon extends React.Component {
           <div className="transparent-container">
             <div className="responsive-content-wrapper delayed-fade-in">
               <h2 className="card-list-header" data-l10n-id="landingExperimentsTitle">Try out the latest experimental features</h2>
-              <div data-hook="experiment-list">
+              <div>
                 <ExperimentCardList {...this.props} experiments={currentExperiments} eventCategory="HomePage Interactions" />
               </div>
             </div>

--- a/frontend/src/app/containers/NotFoundPage.js
+++ b/frontend/src/app/containers/NotFoundPage.js
@@ -8,7 +8,7 @@ export default class NotFoundPage extends React.Component {
     return (
       <View centered={true} showNewsletterFooter={false} showFooter={false} showHeader={false}
             {...this.props}>
-        <div data-hook="no-found-page">
+        <div id="not-found-page">
           <div className="centered-banner">
             <div id="four-oh-four" className="modal delayed-fade-in">
               <h1 data-l10n-id="notFoundHeader" className="title">Four Oh Four!</h1>

--- a/frontend/src/app/containers/RetirePage.js
+++ b/frontend/src/app/containers/RetirePage.js
@@ -50,7 +50,7 @@ export default class RetirePage extends React.Component {
                 <p data-l10n-id="retirePageMessage">Hope you had fun experimenting with us. <br /> Come back any time.</p>
               </div>
               <div className="modal-actions">
-                <a onClick={() => this.takeSurvey()} data-l10n-id="retirePageSurveyButton" data-hook="take-survey" href="https://qsurvey.mozilla.com/s3/test-pilot" target="_blank" className="button default large">Take a quick survey</a>
+                <a onClick={() => this.takeSurvey()} data-l10n-id="retirePageSurveyButton" href="https://qsurvey.mozilla.com/s3/test-pilot" target="_blank" className="button default large">Take a quick survey</a>
                 <Link to="/"  data-l10n-id="home" className="modal-escape">Home</Link>
               </div>
             </div>

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -37,7 +37,7 @@ ReactDOM.render(
   <Provider store={store}>
     <Routes history={history} />
   </Provider>,
-  document.querySelector('div[data-hook=page-container]')
+  document.querySelector('div#page-container')
 );
 
 // HACK: For debugging fun

--- a/frontend/src/styles/modules/_experiment-details.scss
+++ b/frontend/src/styles/modules/_experiment-details.scss
@@ -431,7 +431,7 @@
 }
 
 @include respond-to('small') {
-  [data-hook='experiment-page'] {
+  #experiment-page {
     .card-list {
       margin: 0 0 $grid-unit;
     }

--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -27,7 +27,7 @@
 </head>
 <body class="blue">
   <div class="stars"></div>
-  <div data-hook="page-container">
+  <div id="page-container">
     <noscript>
       <div class="full-page-wrapper centered">
         <div class="centered-banner">

--- a/frontend/test/app/components/EmailDialog-test.js
+++ b/frontend/test/app/components/EmailDialog-test.js
@@ -82,7 +82,7 @@ describe('app/components/EmailDialog', () => {
     const message = subject.findWhere(el => 'emailOptInSuccessMessage2' === el.props()['data-l10n-id']);
     expect(message).to.have.length(1);
 
-    const button = subject.findWhere(el => 'continue' === el.props()['data-hook']);
+    const button = subject.findWhere(el => 'email-success-continue' === el.props()['id']);
     expect(button).to.have.length(1);
 
     button.simulate('click', mockClickEvent);

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -199,7 +199,6 @@ describe('app/components/ExperimentRowCard', () => {
     const link = subject.find('Link');
     expect(link).to.not.be.a('null');
     expect(link.props()).to.contain.all({
-      'data-hook': 'show-detail',
       to: `/experiments/${mockExperiment.slug}`,
       className: 'experiment-summary'
     });


### PR DESCRIPTION
Copying from https://github.com/mozilla/testpilot/pull/1933 to diagnose missing CI.

---

I got really sick of looking at these things. Fixes #1586

NB. There are two places where these stayed in: 
- React uses a data-hook to mount the app
- in the email component, a data-hook is used in a test