### PR TITLE
increase site speed reports from 1% to 100%

### DIFF
--- a/frontend/src/app/lib/ga-snippet.js
+++ b/frontend/src/app/lib/ga-snippet.js
@@ -7,7 +7,11 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','https://ssl.google-analytics.com/analytics.js','ga');
 
 if (typeof(ga) !== 'undefined') {
-  ga('create', 'UA-49796218-34', 'auto');
+  ga('create', {
+      trackingId: 'UA-49796218-34',
+      cookieDomain: 'auto',
+      siteSpeedSampleRate: '100'
+  });
 } else {
   console.warn( // eslint-disable-line no-console
     'You have google analytics blocked. We understand. Take a ' +


### PR DESCRIPTION
I was checking out our site speed in GA (https://analytics.google.com/analytics/web/#report/content-site-speed/a49796218w102356107p106368739/) and saw there were only 3 reports.  https://support.google.com/analytics/answer/1205784?hl=en says it defaults to 1% of traffic.  Since we're relatively low traffic, let's get reports from everyone.