### PR TITLE
[ref #1950] Add `launch_date` to Cliqz product page

### DIFF
--- a/content-src/experiments/cliqz.yaml
+++ b/content-src/experiments/cliqz.yaml
@@ -1,6 +1,7 @@
 id: 9
 title: 'Cliqz'
 slug: cliqz
+launch_date: '2017-01-11T00:00:00.00Z'
 incompatible:
   '@activity-streams': 'Activity Stream'
   'cliqz@cliqz.com': 'CLIQZ- search directly in your browser'


### PR DESCRIPTION
The goal is for the page to be live on production at [4 PM PST on January 10th](http://www.worldtimebuddy.com/?pl=1&lid=8,100,2950159&h=8&date=1/10/2017%7C3) to allow for some PST folks to be able to confirm things are looking okay before public promotion begins at 6 AM Berlin time on the 11th. 

Note: [`launch_date`](https://github.com/mozilla/testpilot/blob/master/docs/content/reference.md#launch_date) is only considered on stage or production. If you want to test this locally you'll have to set [`isDev` to false in config.js](https://github.com/mozilla/testpilot/blob/4ab8fdacc9f1a796115ba3dc54c95d6a9066db6a/frontend/src/app/config.js#L2).

Ref #1950.