### PR TITLE
fix miscolored button on win-10 addon

### DIFF
--- a/addon/lib/survey.js
+++ b/addon/lib/survey.js
@@ -217,7 +217,7 @@ function showSurveyButton(options) {
     }
     const button = box.getElementsByClassName('notification-button')[0];
     if (button) {
-      button.setAttribute('style', 'background: #0095dd; color: #fff; height: 30px; font-size: 13px; border-radius: 2px; border: 0px; text-shadow: 0 0px; box-shadow: 0 0px;');
+      button.setAttribute('style', 'background: #0095dd; color: #fff; height: 30px; font-size: 13px; border-radius: 2px; border: 0px; text-shadow: 0 0px; box-shadow: 0 0 0 20px #0095dd inset');
     }
   });
 }


### PR DESCRIPTION
Fixes #2007 

Uses an inset box-shadow to git around windows weird dislike of colored XUL buttons