### PR TITLE
Instruct github to ignore .ftl and markdown when parsing repo language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+locales/* linguist-documentation
+docs/* linguist-documentation


### PR DESCRIPTION
Emailed github support to ask about the repo stats bug with .ftl files, which are parsed as 'freemarker', some kind of Java templating language. They sent me a link to the linguist library, which is used to generate programming language stats for repos. This should get rid of the 'freemarker' language in the testpilot stats (see screenshots below). I also marked the docs as docs since I was in there anyway.

See the linguist docs for more: https://github.com/github/linguist#overrides

----- 
<img width="238" alt="screen shot 2017-01-17 at 5 05 45 pm" src="https://cloud.githubusercontent.com/assets/96396/22046684/34c08660-dcd7-11e6-9545-f4376cc7c8d8.png">

----- 
<img width="527" alt="screen shot 2017-01-17 at 5 06 14 pm" src="https://cloud.githubusercontent.com/assets/96396/22046697/45a27b1e-dcd7-11e6-831f-ec5ea693e979.png">

----- 
