### PR TITLE
Allow installation of individual experiments without requiring the Test Pilot add-on to already be installed.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -10,7 +10,6 @@ const { AddonManager } = require('resource://gre/modules/AddonManager.jsm');
 const aboutConfig = require('sdk/preferences/service');
 const self = require('sdk/self');
 const store = require('sdk/simple-storage').storage;
-const tabs = require('sdk/tabs');
 const { PrefsTarget } = require('sdk/preferences/event-target');
 const URL = require('sdk/url').URL;
 
@@ -120,13 +119,6 @@ function updatePrefs(environment) {
   } else if (self.loadReason === 'upgrade') {
     app.send('addon-self:upgraded');
   }
-}
-
-function openOnboardingTab() {
-  tabs.open({
-    url: settings.BASE_URL + '/onboarding',
-    inBackground: true
-  });
 }
 
 function experimentsLoaded(experiments) {
@@ -346,10 +338,6 @@ exports.main = function(options) {
   ExperimentNotifications.init(settings);
   SharePrompt.init(settings);
   NoExperiments.init(settings);
-
-  if (reason === 'install') {
-    openOnboardingTab();
-  }
 
   const installedCount = (store.installedAddons) ? Object.keys(store.installedAddons).length : 0;
   Metrics.sendGAEvent({

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -2,7 +2,8 @@
 
 # Development Quickstart
 
-Test Pilot uses Node.js [v6.x LTS](https://nodejs.org/dist/latest-v6.x/) for development. You may be able to get by using
+Test Pilot uses Node.js [v6.x LTS](https://nodejs.org/dist/latest-v6.x/) for
+development. You may be able to get by using
 [the most current release](https://nodejs.org/en/download/current/), but
 earlier versions will definitely result in error messages and problems. [Node
 Version Manager](https://github.com/creationix/nvm/blob/master/README.markdown)
@@ -30,13 +31,14 @@ cd ..
 npm install
 
 # Add hostname alias to /etc/hosts and start up dev webserver
-echo '127.0.0.1 testpilot.dev' | sudo tee -a /etc/hosts
-npm start
+echo '127.0.0.1 example.com' | sudo tee -a /etc/hosts
+USE_HTTPS=1 npm start
 ```
 
 **Note:** While you *will* be able to see the web site locally via
-http://localhost:8000/ - the `testpilot.dev` hostname alias is important to
-several features of this site for local development.
+http://localhost:8000/ - the `example.com` hostname alias is important to
+several features of this site for local development. The domain `example.com`
+is whitelisted and allowed to use the mozAddonManager api to manage add-ons.
 
 These steps will give you a working development web server and file
 watcher that will rebuild site assets as you edit. Just a few more steps and
@@ -55,9 +57,23 @@ you should be on your way:
 
    1. Enter `testpilot.env` for the name.
 
-   1. Enter `local` for the value.
+   1. Enter `example` for the value.
 
-1. View your local site in Firefox Developer Edition at http://testpilot.dev:8000/
+   1. Right click the list of preferences to summon a menu, pick New > Boolean
+      to create a new preference.
+
+   1. Enter `extensions.install.requireBuiltInCerts` for the name.
+
+   1. Enter `false` for the value.
+
+   1. Right click the list of preferences to summon a menu, pick New > Boolean
+      to create a new preference.
+
+   1. Enter `xpinstall.signatures.required` for the name.
+
+   1. Enter `false` for the value.
+
+1. View your local site in Firefox Developer Edition at https://example.com:8000/
 
 [devedition]: https://www.mozilla.org/en-US/firefox/developer/
 [devprefs]: https://addons.mozilla.org/en-US/firefox/addon/devprefs/
@@ -69,7 +85,7 @@ for you to get it working.
 
 ## For Windows hosts
 
-After installing Node.js for Windows, run these commands to get started: 
+After installing Node.js for Windows, run these commands to get started:
 
 ```cmd
 :: Set up add-on environment and build an unsigned package
@@ -86,13 +102,13 @@ Now, open a second command prompt window, this time with admin privileges and ru
 
 ```cmd
 :: Add hostname alias to /etc/hosts and start up dev webserver
-echo 127.0.0.1 testpilot.dev >> %WINDIR%\System32\Drivers\Etc\Hosts
+echo 127.0.0.1 example.com >> %WINDIR%\System32\Drivers\Etc\Hosts
 ```
 
 Go back to the previous command prompt window and run
 
 ```cmd
-npm start
+USE_HTTPS=1 npm start
 ```
 
 Follow the remaining instructions from **Linux & OS X** section and you're all set.

--- a/frontend/src/app/components/MainInstallButton.js
+++ b/frontend/src/app/components/MainInstallButton.js
@@ -10,8 +10,12 @@ export default class MainInstallButton extends React.Component {
     };
   }
 
-  install() {
-    const { requireRestart, sendToGA, eventCategory, hasAddon, installAddon } = this.props;
+  install(e) {
+    const { requireRestart, sendToGA, eventCategory, hasAddon, installAddon, installCallback } = this.props;
+    if (installCallback) {
+      installCallback(e);
+      return;
+    }
     if (hasAddon) { return; }
     this.setState({ isInstalling: true });
     installAddon(requireRestart, sendToGA, eventCategory);
@@ -31,13 +35,21 @@ export default class MainInstallButton extends React.Component {
   }
 
   renderInstallButton(isInstalling, hasAddon) {
+    const { experimentTitle } = this.props;
+    let installButton = null;
+    if (experimentTitle) {
+      installButton = <span className="default-btn-msg" data-l10n-id="landingInstallButtonOneClick" data-l10n-args={ JSON.stringify({ experimentTitle: experimentTitle }) }>
+      </span>;
+    } else {
+      installButton = <span className="default-btn-msg" data-l10n-id="landingInstallButton">
+      </span>;
+    }
     return (
       <div>
         <button onClick={e => this.install(e)}
                 className={classnames('button extra-large primary install', { 'state-change': isInstalling })}>
           {hasAddon && <span className="progress-btn-msg" data-l10n-id="landingInstalledButton">Installed</span>}
-          {!hasAddon && !isInstalling &&
-            <span className="default-btn-msg" data-l10n-id="landingInstallButton">Install the Test Pilot Add-on</span>}
+          {!hasAddon && !isInstalling && installButton}
           {!hasAddon && isInstalling &&
             <span className="progress-btn-msg" data-l10n-id="landingInstallingButton">Installing...</span>}
           <div className="state-change-inner"></div>

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -48,8 +48,9 @@ export function installAddon(requireRestart, sendToGA, eventCategory) {
 
   cookies.set('first-run', 'true');
 
+  let result;
   if (useMozAddonManager) {
-    mozAddonManagerInstall(downloadUrl).then(() => {
+    result = mozAddonManagerInstall(downloadUrl).then(() => {
       gaEvent.dimension7 = RESTART_NEEDED ? 'restart required' : 'no restart';
       sendToGA('event', gaEvent);
       if (RESTART_NEEDED) {
@@ -59,7 +60,9 @@ export function installAddon(requireRestart, sendToGA, eventCategory) {
   } else {
     gaEvent.outboundURL = downloadUrl;
     sendToGA('event', gaEvent);
+    result = Promise.resolve();
   }
+  return result;
 }
 
 export function uninstallAddon() {

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -36,6 +36,7 @@ landingExperimentsTitle = Try out the latest experimental features
 # Related to the installation of the Test Pilot add-on.
 [[landingInstall]]
 landingInstallButton = Install the Test Pilot Add-on
+landingInstallButtonOneClick = Install Test Pilot and Enable {$experimentTitle}
 landingInstallingButton = Installing...
 landingInstalledButton = Choose your features
 
@@ -129,7 +130,7 @@ experimentPreFeedbackLinkCopy = Give feedback about the {$title} experiment
 experimentPromoHeader = Ready for Takeoff?
 experimentPromoSubheader = We're building next-generation features for Firefox. Install Test Pilot to try them!
 
-# The experiment detail page. 
+# The experiment detail page.
 [[experimentPage]]
 isEnabledStatusMessage = {$title} is enabled.
 installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.


### PR DESCRIPTION
This has now been properly localized and the tests and linter pass, so it should be ready to land.

John says there are some things we are going to have to change after this lands to satisfy legal, but he is ok with doing them in separate commits since it is still early in the sprint.
