### PR TITLE
wait on hasAddon for single-click-install

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -690,7 +690,7 @@ export class ExperimentDetail extends React.Component {
         let i = 0;
         const interval = setInterval(() => {
           i++;
-          if (window.navigator.testpilotAddon) {
+          if (this.props.hasAddon) {
             clearInterval(interval);
             resolve();
           } else if (i > 100) {


### PR DESCRIPTION
helps #2051

In my testing `navigator.testpilotAddon` becomes true several ticks before `props.hasAddon`. Now, reading the code, it still looks *possible* for there to be a window where `install-experiment` might not work. Guaranteeing the timing works 100% will require a larger patch, but this has turned the issue from easily reproducible to  not reproducible for me.