### PR TITLE
migrate simplestorage data from addon v0.9 to v1.0 format

### DIFF
--- a/addon/src/lib/configureStore.js
+++ b/addon/src/lib/configureStore.js
@@ -10,11 +10,12 @@ import reducers from './reducers';
 import { storage } from 'sdk/simple-storage';
 import { createStore, applyMiddleware } from 'redux';
 import createLogger from 'redux-logger';
+import { migrate } from './migrations';
 import type Hub from './middleware/Hub';
 import type { Environment } from './actionCreators/env';
 import type { ReduxStore, AddonState } from 'testpilot/types';
 
-const initialState = (Object.assign({}, storage.root): AddonState);
+const initialState = (migrate(storage): AddonState);
 
 export default function configureStore(
   { hub, startEnv }: { hub: Hub, startEnv: Environment }

--- a/addon/src/lib/migrations/index.js
+++ b/addon/src/lib/migrations/index.js
@@ -1,0 +1,64 @@
+/*
+ * This Source Code is subject to the terms of the Mozilla Public License
+ * version 2.0 (the 'License'). You can obtain a copy of the License at
+ * http://mozilla.org/MPL/2.0/.
+ */
+
+// @flow
+
+import typeof { storage } from 'sdk/simple-storage';
+
+export function migrate(store: storage): Object {
+  if (store.root) {
+    // we're >= v1.0.0
+    return Object.assign({}, store.root);
+  }
+  if (store.clientUUID) {
+    // we're < v1.0
+    return v0tov1(store);
+  }
+  // hi, we're new here
+  return {};
+}
+
+function v0tov1(store: storage) {
+  const root = {};
+  root.clientUUID = store.clientUUID;
+  if (store.surveyChecks) {
+    root.ratings = convertSurveys(store.surveyChecks);
+  }
+  if (store.sharePrompt && store.sharePrompt.hasBeenShown) {
+    root.ui = { shareShown: true };
+  }
+  return root;
+}
+
+const surveyIntervals = {
+  twoDaysSent: 2,
+  oneWeekSent: 7,
+  threeWeeksSent: 21,
+  monthAndAHalfSent: 46,
+  eol: 'eol'
+};
+
+function convertSurveys(checks: Object) {
+  const ratings = {};
+  Object.keys(surveyIntervals).forEach(name => {
+    const survey = checks[name];
+    if (survey) {
+      Object.keys(survey).forEach(id => {
+        const addon = ratings[id] || {};
+        // we didn't track this before
+        addon.rating = -1;
+        addon[surveyIntervals[name]] = true;
+        ratings[id] = addon;
+      });
+    }
+  });
+  if (Object.keys(ratings).length > 0) {
+    // we don't know when they last rated, but they have at least once
+    // so we'll use now as a start for the do-not-disturb timer
+    ratings.lastRated = Date.now();
+  }
+  return ratings;
+}

--- a/addon/test/test-migrations.js
+++ b/addon/test/test-migrations.js
@@ -1,0 +1,36 @@
+/* global describe beforeEach it */
+import assert from 'assert';
+import { migrate } from '../src/lib/migrations';
+
+describe('migrate', function() {
+  it('defaults to an empty object', function() {
+    assert.equal(Object.keys(migrate({})).length, 0);
+  });
+
+  it('copies store.root when available', function() {
+    const store = { root: { clientUUID: 'test', what: 'ever', else: true } };
+    const copy = migrate(store);
+    assert.deepEqual(store.root, copy);
+  });
+
+  it('copies old clientUUID', function() {
+    const old = { clientUUID: 'test' };
+    const neu = migrate(old);
+    assert.equal(old.clientUUID, neu.clientUUID);
+  });
+
+  it('converts surveyChecks', function() {
+    const old = {
+      clientUUID: 'test',
+      surveyChecks: { twoDaysSent: { x: true } }
+    };
+    const neu = migrate(old);
+    assert.deepEqual(neu.ratings.x, { '2': true, rating: -1 });
+  });
+
+  it('converts sharePrompt', function() {
+    const old = { clientUUID: 'test', sharePrompt: { hasBeenShown: true } };
+    const neu = migrate(old);
+    assert.equal(neu.ui.shareShown, true);
+  });
+});


### PR DESCRIPTION
This will transform some of the simplestorage data on an upgrade, specifically the `clientUUID`, whether the share dialog has been shown, and what surveys have been show.