### PR TITLE
Fix styles-lint warnings

### DIFF
--- a/frontend/src/styles/modules/_modals.scss
+++ b/frontend/src/styles/modules/_modals.scss
@@ -63,8 +63,8 @@
 }
 
 .modal {
-  animation-delay: 250ms;
   animation: fade-in-fly-up 300ms forwards;
+  animation-delay: 250ms;
   background: $white;
   border-radius: $large-border-radius;
   box-shadow: 0 4px $grid-unit $transparent-black-5;


### PR DESCRIPTION
Fixes the two warnings:

```sh
$ npm run lint

> testpilot@1.0.0 lint /Users/pdehaan/dev/github/mozilla/testpilot
> gulp scripts-lint styles-lint

[09:39:46] Using gulpfile ~/dev/github/mozilla/testpilot/gulpfile.js
[09:39:46] Starting 'scripts-lint'...
[09:39:46] Starting 'styles-lint'...

frontend/src/styles/modules/_modals.scss
  66:3  warning  Expected `animation`, found `animation-delay`  property-sort-order
  67:3  warning  Expected `animation-delay`, found `animation`  property-sort-order

✖ 2 problems (0 errors, 2 warnings)

[09:39:49] Finished 'styles-lint' after 3.36 s
[09:39:50] Finished 'scripts-lint' after 4.06 s
```