### PR TITLE
Add eslint config to /addon/

### DIFF
--- a/addon/.eslintignore
+++ b/addon/.eslintignore
@@ -1,0 +1,4 @@
+.nyc_output
+coverage
+flow-typed
+data/bundle.js

--- a/addon/.eslintrc.yml
+++ b/addon/.eslintrc.yml
@@ -1,0 +1,27 @@
+ecmaFeatures:
+  jsx: true
+  modules: true
+
+env:
+  browser: true
+  es6: true
+  node: true
+
+extends:
+  - eslint:recommended
+  - plugin:flowtype/recommended
+  - plugin:react/recommended
+
+parser: babel-eslint
+
+plugins:
+  - flowtype
+  - react
+
+root: true
+
+rules:
+  eqeqeq: error
+  no-console: warn
+  no-var: error
+  prefer-const: error

--- a/addon/package.json
+++ b/addon/package.json
@@ -32,6 +32,8 @@
     "babel-preset-stage-2": "^6.17.0",
     "babel-register": "^6.16.3",
     "cross-env": "^3.1.3",
+    "eslint": "^3.14.1",
+    "eslint-plugin-flowtype": "^2.30.0",
     "flow-bin": "^0.38.0",
     "flow-coverage-report": "^0.2.0",
     "flow-typed": "^2.0.0",
@@ -60,6 +62,7 @@
     "package-win": "npm run bundle && jpm xpi && move testpilot-addon.xpi addon.xpi && move @testpilot-addon-%npm_package_version%.update.rdf update.rdf",
     "sign": "cd .. && npm run addon:locales && cd addon && npm run bundle && ./bin/update-version && ./bin/sign",
     "tools": "cd tools/control-panel; webpack",
+    "lint": "eslint .",
     "slow-test": "flow --quiet && cross-env NODE_ENV=test nyc mocha --reporter min",
     "test": "mocha --compilers js:babel-register --reporter min",
     "coverage": "flow-coverage-report -i 'src/lib/**/*.js' -t html -o coverage/flow && npm run slow-test"

--- a/addon/src/lib/actionCreators/FeedbackManager.js
+++ b/addon/src/lib/actionCreators/FeedbackManager.js
@@ -94,7 +94,7 @@ export default class FeedbackManager {
         Math.random() * eligibles.length
       )];
       if (experiment) {
-        tabs.once('open', tab => {
+        tabs.once('open', () => {
           setTimeout(
             () => this.promptRating({ interval: 'eol', experiment }),
             1000

--- a/addon/src/lib/actionCreators/InstallManager.js
+++ b/addon/src/lib/actionCreators/InstallManager.js
@@ -48,6 +48,7 @@ export default class InstallManager {
   uninstallAll() {
     const { getState } = this.store;
     const active = activeExperiments(getState());
+    // eslint-disable-next-line prefer-const
     for (let id of Object.keys(active)) {
       this.uninstallExperiment(active[id]);
     }

--- a/addon/src/lib/actionCreators/Loader.js
+++ b/addon/src/lib/actionCreators/Loader.js
@@ -35,6 +35,7 @@ function fetchExperiments(baseUrl, path): Promise<Experiments> {
         const userLocale = Services.appShell.hiddenDOMWindow.navigator.language;
         const xs = {};
         if (res.status === 200) {
+          // eslint-disable-next-line prefer-const
           for (let o of res.json.results) {
             const x = new Experiment(o, baseUrl);
             if (x.allowsLocale(userLocale)) {
@@ -51,10 +52,12 @@ function fetchExperiments(baseUrl, path): Promise<Experiments> {
 }
 
 function mergeAddonState(experiments: Experiments, addons) {
+  // eslint-disable-next-line prefer-const
   for (let id of Object.keys(experiments)) {
     experiments[id].active = false;
   }
 
+  // eslint-disable-next-line prefer-const
   for (let addon of addons) {
     const x = experiments[addon.id];
     if (x) {
@@ -107,11 +110,13 @@ export default class Loader {
         const { experiments, ui: { clicked } } = getState();
 
         const newExperiments = diffExperimentList(experiments, xs);
+        // eslint-disable-next-line prefer-const
         for (let experiment of newExperiments) {
           if (experiment.launchDate.getTime() > clicked) {
             dispatch(actions.SET_BADGE({ text: _('new_badge') }));
           }
         }
+        // eslint-disable-next-line prefer-const
         for (let id of Object.keys(xs)) {
           const experiment = xs[id];
           if (experiment.active) {

--- a/addon/src/lib/actionCreators/NotificationManager.js
+++ b/addon/src/lib/actionCreators/NotificationManager.js
@@ -56,6 +56,7 @@ export default class NotificationManager {
     this.timeout = setTimeout(
       () => {
         const { experiments } = getState();
+        // eslint-disable-next-line prefer-const
         for (let id of Object.keys(experiments)) {
           this.maybeNotify(experiments[id]);
         }

--- a/addon/src/lib/metrics/webextension-channels.js
+++ b/addon/src/lib/metrics/webextension-channels.js
@@ -70,7 +70,8 @@ export default class WebExtensionChannel {
   handleEvent: Function;
   static channels: Map<string, WebExtensionChannel> = new Map();
   static destroy() {
-    for (const id of WebExtensionChannel.channels.keys()) {
+    // eslint-disable-next-line prefer-const
+    for (let id of WebExtensionChannel.channels.keys()) {
       WebExtensionChannel.remove(id);
     }
   }
@@ -133,6 +134,7 @@ export default class WebExtensionChannel {
   }
 
   notifyPing(data: any, sender: { addonId: string }) {
+    // eslint-disable-next-line prefer-const
     for (let pingListener of this.pingListeners) {
       try {
         pingListener({

--- a/addon/src/lib/middleware/Hub.js
+++ b/addon/src/lib/middleware/Hub.js
@@ -41,6 +41,7 @@ export default class Hub {
         action.meta = action.meta || {};
         action.meta.src = action.meta.src || 'addon';
         if (action.meta.src === 'addon') {
+          // eslint-disable-next-line prefer-const
           for (let port of this.ports) {
             try {
               port.emit('action', action);

--- a/addon/test/.eslintrc.yml
+++ b/addon/test/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+  no-console: off

--- a/addon/test/test-addonlistener.js
+++ b/addon/test/test-addonlistener.js
@@ -48,6 +48,7 @@ describe('AddonListener', function() {
       ]);
       const listener = new AddonListener(s);
 
+      // eslint-disable-next-line prefer-const
       for (let [ event, action ] of listeners) {
         listener[event](addon);
         if (addon.id === 'x') {

--- a/addon/test/test-hub.js
+++ b/addon/test/test-hub.js
@@ -120,7 +120,7 @@ describe('Hub', function() {
     h.connect(p);
     const middleware = h.middleware();
     const a = { type: 'test' };
-    const next = action => {
+    const next = () => {
       assert.equal(h.ports.size, 0);
       done();
     };

--- a/addon/test/test-installlistener.js
+++ b/addon/test/test-installlistener.js
@@ -7,7 +7,7 @@ import InstallListener from '../src/lib/actionCreators/InstallListener';
 const dispatch = sinon.spy();
 const experiment = { addon_id: 'x' };
 const addonInstall = {};
-let listener = new InstallListener({ dispatch, experiment });
+const listener = new InstallListener({ dispatch, experiment });
 
 describe('InstallListener', function() {
   beforeEach(function() {


### PR DESCRIPTION
Still a couple warnings (`no-console`) and a couple of errors, but I don't think that our Travis-CI is running /addon/tests/ yet, so shouldn't break the CI build.

```
$ [addon/] npm run lint

> testpilot-addon@1.0.0 lint /Users/pdehaan/dev/github/mozilla/testpilot/addon
> eslint .


/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/actionCreators/env.js
  19:32  warning  Unexpected console statement  no-console

/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/actionCreators/InstallManager.js
  64:15  error  'baseUrl' is assigned a value but never used  no-unused-vars

/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/metrics/webextension-channels.js
  145:9  warning  Unexpected console statement  no-console

/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/middleware/Hub.js
  18:7  warning  Unexpected console statement  no-console

/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/reducers/clientUUID.js
  13:50  error  'action' is defined but never used  no-unused-vars

/Users/pdehaan/dev/github/mozilla/testpilot/addon/src/lib/Telemetry.js
  51:5  warning  Unexpected console statement  no-console

/Users/pdehaan/dev/github/mozilla/testpilot/addon/tools/control-panel/main.js
  15:3  warning  Unexpected console statement  no-console

✖ 7 problems (2 errors, 5 warnings)
```

r? @dannycoates 

Fixes #2115
