### PR TITLE
Set minimum Firefox version to 49

### DIFF
--- a/frontend/src/app/components/MainInstallButton.js
+++ b/frontend/src/app/components/MainInstallButton.js
@@ -80,7 +80,7 @@ export default class MainInstallButton extends React.Component {
           {!isFirefox ? (
               <span data-l10n-id="landingDownloadFirefoxDesc" className="parens">(Test Pilot is available for Firefox on Windows, OS X and Linux)</span>
             ) : (
-              <span className="parens" data-l10n-id="landingUpgradeDesc">Test Pilot requires Firefox 45 or higher.</span>
+              <span className="parens" data-l10n-id="landingUpgradeDesc">Test Pilot requires Firefox 49 or higher.</span>
             )
           }
           {!isMobile && <a href="https://www.mozilla.org/firefox" className="button primary download-firefox">

--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -1,6 +1,6 @@
 const defaultConfig = {
   isDev: true,
-  minFirefoxVersion: 45,
+  minFirefoxVersion: 49,
   experimentsURL: '/api/experiments.json',
   usageCountsURL: 'https://analysis-output.telemetry.mozilla.org/testpilot/data/installation-counts/latest.json',
   ravenPublicDSN: 'https://5ceef9a20a6e4cdd93cc9a935be78c73@sentry.prod.mozaws.net/169'

--- a/locales/ar/app.ftl
+++ b/locales/ar/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = اختر مميزاتك و خصائصك المفضلة
 
 landingRequiresDesktop = الاختبار التجريبي يتطلب نسخة فيرفكس لسطح المكتب على ويندوز، ماك أو لينكس
 landingDownloadFirefoxDesc = (الاختبار التجريبي متاح لفيرفكس على أنظمة التشغيل Windows, OS X و Linux)
-landingUpgradeDesc = يتطلب الاختبار التجريبي نسخة فيرفكس 45 أو أعلى.
+landingUpgradeDesc = يتطلب الاختبار التجريبي نسخة فيرفكس 49 أو أعلى.
 landingDownloadFirefoxTitle = فيرفكس
 landingUpgradeFirefoxTitle = ترقية فيرفكس
 landingDownloadFirefoxSubTitle = تحميل مجاني

--- a/locales/ast/app.ftl
+++ b/locales/ast/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = Escueyi les tos carauterístiques
 
 landingRequiresDesktop = Test Pilot rique Firefox pa escritoriu en Linux, Windows o Mac
 landingDownloadFirefoxDesc = (Test Pilot ta disponible pa Firefox en Linux, Windows y MacOS)
-landingUpgradeDesc = Test Pilot riqe Firefox 45 o mayor.
+landingUpgradeDesc = Test Pilot riqe Firefox 49 o mayor.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Anovar Firefox
 landingDownloadFirefoxSubTitle = Descarga de baldre

--- a/locales/bn-BD/app.ftl
+++ b/locales/bn-BD/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = আপনার ফিচারটি বেছে ন�
 
 landingRequiresDesktop = Test Pilot এর জন্য Windows, Mac অথবা Linux এ ডেস্কটপের জন্য Firefox প্রয়োজন
 landingDownloadFirefoxDesc = (Windows, OS X and Linux এ Firefox এর জন্য Test Pilot পাওয়া যাচ্ছে)
-landingUpgradeDesc = Test Pilot ব্যবহার করতে Firefox 45 বা পরবর্তী সংস্করণ প্রয়োজন।
+landingUpgradeDesc = Test Pilot ব্যবহার করতে Firefox 49 বা পরবর্তী সংস্করণ প্রয়োজন।
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox হালানাগাদ করুন
 landingDownloadFirefoxSubTitle = বিনামূল্যে ডাউনলোড

--- a/locales/cs/app.ftl
+++ b/locales/cs/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Povolit { $title }
 
 landingRequiresDesktop = Test Pilot potřebuje Firefox pro počítače na platformě Windows, Mac nebo Linux
 landingDownloadFirefoxDesc = (Test Pilot je dostupný pro Firefox pro Windows, OS X a Linux)
-landingUpgradeDesc = Test Pilot vyžaduje Firefox 45 nebo novější.
+landingUpgradeDesc = Test Pilot vyžaduje Firefox 49 nebo novější.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Aktualizovat Firefox
 landingDownloadFirefoxSubTitle = Stáhnout zdarma

--- a/locales/de/app.ftl
+++ b/locales/de/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } aktivieren
 
 landingRequiresDesktop = Test Pilot erfordert Firefox für Desktop unter Windows, Mac oder Linux
 landingDownloadFirefoxDesc = (Test Pilot gibt es nur für Firefox unter Windows, OS X und Linux)
-landingUpgradeDesc = Test Pilot benötigt Firefox 45 oder höher.
+landingUpgradeDesc = Test Pilot benötigt Firefox 49 oder höher.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox aktualisieren
 landingDownloadFirefoxSubTitle = Kostenloser Download

--- a/locales/dsb/app.ftl
+++ b/locales/dsb/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } zmóžniś
 
 landingRequiresDesktop = Test Pilot pomina se Firefox za desktop na Windows, Mac abo Linux
 landingDownloadFirefoxDesc = (Test Pilot jo za Firefox na Windows, OS X a Linux k dispoziciji)
-landingUpgradeDesc = Test Pilot pomina se Firefox 45 abo nowšy.
+landingUpgradeDesc = Test Pilot pomina se Firefox 49 abo nowšy.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox aktualizěrowaś
 landingDownloadFirefoxSubTitle = Dermotne ześěgnjenje

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -48,7 +48,7 @@ oneClickInstallMajorCta = Enable {$title}
 [[landingFirefox]]
 landingRequiresDesktop = Test Pilot requires Firefox for Desktop on Windows, Mac or Linux
 landingDownloadFirefoxDesc = (Test Pilot is available for Firefox on Windows, OS X and Linux)
-landingUpgradeDesc = Test Pilot requires Firefox 45 or higher.
+landingUpgradeDesc = Test Pilot requires Firefox 49 or higher.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Upgrade Firefox
 landingDownloadFirefoxSubTitle = Free Download

--- a/locales/es-AR/app.ftl
+++ b/locales/es-AR/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Habilitar { $title }
 
 landingRequiresDesktop = Test Pilot necesita Firefox para escritorio para Windows, Mac o Linux
 landingDownloadFirefoxDesc = (Test Pilot está disponible para Firefox en Windows, OS X y Linux)
-landingUpgradeDesc = Test Pilot requiere Firefox 45 o superior.
+landingUpgradeDesc = Test Pilot requiere Firefox 49 o superior.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Actualizar Firefox
 landingDownloadFirefoxSubTitle = Descarga gratuita

--- a/locales/es-CL/app.ftl
+++ b/locales/es-CL/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = Elige tus funciones
 
 landingRequiresDesktop = Test Pilot requiere Firefox para Escritorio en Windows, Mac o Linux
 landingDownloadFirefoxDesc = (Test Pilot esta disponible para Firefox en Windows, OS X y Linux)
-landingUpgradeDesc = Test Pilot requiere Firefox 45 o superior.
+landingUpgradeDesc = Test Pilot requiere Firefox 49 o superior.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Actualiza Firefox
 landingDownloadFirefoxSubTitle = Bájalo gratis

--- a/locales/es-ES/app.ftl
+++ b/locales/es-ES/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Activar { $title }
 
 landingRequiresDesktop = Test Pilot requiere Firefox para escritorio en Windows, Mac o Linux
 landingDownloadFirefoxDesc = (Test Pilot está disponible para Firefox en Windows, OS X y Linux)
-landingUpgradeDesc = Test Pilot requiere Firefox 45 o superior.
+landingUpgradeDesc = Test Pilot requiere Firefox 49 o superior.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Actualizar Firefox
 landingDownloadFirefoxSubTitle = Descarga gratuita

--- a/locales/es-MX/app.ftl
+++ b/locales/es-MX/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Habilitar { $title }
 
 landingRequiresDesktop = Test Pilot requiere Firefox para escritorio en Windows, Mac o Linux
 landingDownloadFirefoxDesc = (Test Pilot está disponible para Firefox en Windows, OS X y Linux)
-landingUpgradeDesc = Test Pilot requiere Firefox 45 o superior.
+landingUpgradeDesc = Test Pilot requiere Firefox 49 o superior.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Actualizar Firefox
 landingDownloadFirefoxSubTitle = Descargar gratis

--- a/locales/fa/app.ftl
+++ b/locales/fa/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = امکانات خود را انتخاب کنید
 
 landingRequiresDesktop = خلبان آزمایشی نیاز به فایرفاکس برای رومیزی بر روی ویندوز، مک یا لینوکس دارد
 landingDownloadFirefoxDesc = (خلبان آزمایشی برای فایرفاکس ویندوز، OS X و لینوکس موجو است)
-landingUpgradeDesc = خلبان آزمایشی نیاز به فایرفاکس ۴۵ و بالاتر دارد
+landingUpgradeDesc = خلبان آزمایشی نیاز به فایرفاکس ۴۹ و بالاتر دارد
 landingDownloadFirefoxTitle = فایرفاکس
 landingUpgradeFirefoxTitle = ارتقا فایرفاکس
 landingDownloadFirefoxSubTitle = دریافت رایگان

--- a/locales/fr/app.ftl
+++ b/locales/fr/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = activer { $title }
 
 landingRequiresDesktop = Pour utiliser Test Pilot il vous faut Firefox pour ordinateur sur Windows, Mac ou Linux
 landingDownloadFirefoxDesc = (Test Pilot est disponible pour Firefox sous Windows, OS X et Linux)
-landingUpgradeDesc = Test Pilot nécessite Firefox 45 ou supérieur.
+landingUpgradeDesc = Test Pilot nécessite Firefox 49 ou supérieur.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Mettez Firefox à jour
 landingDownloadFirefoxSubTitle = Téléchargement gratuit

--- a/locales/fy-NL/app.ftl
+++ b/locales/fy-NL/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } ynskeakelje
 
 landingRequiresDesktop = Test Pilot fereasket Firefox foar desktop op Windows, Mac of Linux
 landingDownloadFirefoxDesc = (Test Pilot is beskikber foar Firefox op Windows, OS X en Linux)
-landingUpgradeDesc = Test Pilot fereasket Firefox 45 of heger.
+landingUpgradeDesc = Test Pilot fereasket Firefox 49 of heger.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox fernije
 landingDownloadFirefoxSubTitle = Fergeze download

--- a/locales/hsb/app.ftl
+++ b/locales/hsb/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } zmóžnić
 
 landingRequiresDesktop = Test Pilot sej Firefox za desktop na Windows, Mac abo Linux wužaduje
 landingDownloadFirefoxDesc = (Test Pilot je za Firefox na Windows, OS X a Linux k dispoziciji)
-landingUpgradeDesc = Test Pilot sej Firefox 45 abo nowši wužaduje.
+landingUpgradeDesc = Test Pilot sej Firefox 49 abo nowši wužaduje.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox aktualizować
 landingDownloadFirefoxSubTitle = Darmotne sćehnjenje

--- a/locales/hu/app.ftl
+++ b/locales/hu/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } bekapcsolása
 
 landingRequiresDesktop = A Tesztpilótához asztali Firefox szükséges Windowson, Macen vagy Linuxon
 landingDownloadFirefoxDesc = (A Tesztpilóta a Windowsos, OS X-es és Linuxos Firefoxhoz érhető el)
-landingUpgradeDesc = A Tesztpilótához Firefox 45 vagy újabb szükséges.
+landingUpgradeDesc = A Tesztpilótához Firefox 49 vagy újabb szükséges.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox frissítése
 landingDownloadFirefoxSubTitle = Ingyenes letöltés

--- a/locales/it/app.ftl
+++ b/locales/it/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Attiva { $title }
 
 landingRequiresDesktop = Test Pilot è compatibile con Firefox per computer Windows, Mac o Linux.
 landingDownloadFirefoxDesc = (Test Pilot è disponibile per Firefox su Windows, OS X e Linux)
-landingUpgradeDesc = Test Pilot è compatibile con Firefox 45 o versioni successive.
+landingUpgradeDesc = Test Pilot è compatibile con Firefox 49 o versioni successive.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Aggiorna Firefox
 landingDownloadFirefoxSubTitle = Download gratuito

--- a/locales/ja/app.ftl
+++ b/locales/ja/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } を有効化
 
 landingRequiresDesktop = Test Pilot を試すには Windows、Mac または Linux 向けのデスクトップ版 Firefox が必要です
 landingDownloadFirefoxDesc = Test Pilot は Windows、OS X および Linux 版の Firefox に対応しています)
-landingUpgradeDesc = Test Pilot を試すには Firefox 45 以降が必要です。
+landingUpgradeDesc = Test Pilot を試すには Firefox 49 以降が必要です。
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox をアップグレード
 landingDownloadFirefoxSubTitle = 無料ダウンロード

--- a/locales/kab/app.ftl
+++ b/locales/kab/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Rmed { $title }
 
 landingRequiresDesktop = Akken ad tesqedceḍ Test Pilot yessefk ad tesbeddeḍ Firefox ɣef uselkim inek Windows, Mac ou Linux
 landingDownloadFirefoxDesc = (Test Pilot yella kan i Firefox Windows, OS X akked Linux)
-landingUpgradeDesc = Test Pilot yesra Firefox 45 neɣ ugar.
+landingUpgradeDesc = Test Pilot yesra Firefox 49 neɣ ugar.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Leqqem Firefox
 landingDownloadFirefoxSubTitle = Asider baṭel

--- a/locales/nl/app.ftl
+++ b/locales/nl/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = { $title } inschakelen
 
 landingRequiresDesktop = Test Pilot vereist Firefox voor desktop in Windows, Mac of Linux
 landingDownloadFirefoxDesc = (Test Pilot is beschikbaar voor Firefox in Windows, OS X en Linux)
-landingUpgradeDesc = Test Pilot vereist Firefox 45 of hoger.
+landingUpgradeDesc = Test Pilot vereist Firefox 49 of hoger.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Upgrade Firefox
 landingDownloadFirefoxSubTitle = Gratis download

--- a/locales/pt-BR/app.ftl
+++ b/locales/pt-BR/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Habilitar { $title }
 
 landingRequiresDesktop = O Test Pilot requer o Firefox para Windows, Mac ou Linux
 landingDownloadFirefoxDesc = (O Test Pilot está disponível para o Firefox no Windows, macOS e Linux)
-landingUpgradeDesc = O Test Pilot requer o Firefox 45 ou mais atual.
+landingUpgradeDesc = O Test Pilot requer o Firefox 49 ou mais atual.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Atualize o Firefox
 landingDownloadFirefoxSubTitle = Baixe gratuitamente

--- a/locales/pt-PT/app.ftl
+++ b/locales/pt-PT/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Ativar { $title }
 
 landingRequiresDesktop = O Piloto de Teste requer o Firefox para Computador no Windows, Mac ou Linux
 landingDownloadFirefoxDesc = (O Piloto de Teste está disponível para o Firefox no Windows, OS X e Linux)
-landingUpgradeDesc = O Piloto de Teste requer o Firefox 45 ou superior.
+landingUpgradeDesc = O Piloto de Teste requer o Firefox 49 ou superior.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Atualizar o Firefox
 landingDownloadFirefoxSubTitle = Descarga gratuita
@@ -109,7 +109,7 @@ emailOptInMessage = Conheça novas experiências e consulte os resultados dos te
 emailValidationError = Por favor introduza um endereço de email válido!
 
 # LOCALIZATION NOTE: The ':)' characters in the emailOptInInput placeholder are a smiley face emoticon.
-emailOptInInput = 
+emailOptInInput =
   [html/placeholder] o email é aqui :)
 emailOptInButton = Inscreva-me
 emailOptInConfirmationTitle = Email enviado
@@ -144,7 +144,7 @@ experimentCardLearnMore = Saiba mais
 
 feedbackSubmitButton = Responda a um questionário rápido
 feedbackUninstallTitle = Obrigado!
-feedbackUninstallCopy = 
+feedbackUninstallCopy =
   | A sua participação no Piloto de Teste do Firefox significa
   | muito! Por favor, consulte as nossas outras experiências,
   | e fique atento para o que está para vir!
@@ -259,7 +259,7 @@ incompatibleSubheader = Recomendamos <a>desativar estes extras</a> antes de ativ
 # A form prompting the user to sign up for the Test Pilot Newsletter.
 [[ newsletterForm ]]
 
-newsletterFormEmailPlaceholder = 
+newsletterFormEmailPlaceholder =
   [html/placeholder] O seu email aqui
 newsletterFormDisclaimer = Nós só iremos enviar-lhe informação relacionada sobre o Piloto de Teste.
 newsletterFormPrivacyNotice = Concordo que a Mozilla faça a gestão da minha informação tal como explicado neste <a>aviso de privacidade</a>.
@@ -310,4 +310,3 @@ noScriptLink = Saiba porquê
 
 viewPastExperiments = Ver experiências passadas
 hidePastExperiments = Esconder experiências passadas
-

--- a/locales/ro/app.ftl
+++ b/locales/ro/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = Alege funcțiile tale
 
 landingRequiresDesktop = Test Pilot funcționează pe Firefox pentru desktop pe Windows, Mac sau Linux
 landingDownloadFirefoxDesc = (Test Pilot este disponibil pentru Firefox pe Windows, OSX și Linux)
-landingUpgradeDesc = Test Pilot are nevoie de Firefox 45 sau mai recent.
+landingUpgradeDesc = Test Pilot are nevoie de Firefox 49 sau mai recent.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Actualizează Firefox
 landingDownloadFirefoxSubTitle = Descarcă gratuit

--- a/locales/ru/app.ftl
+++ b/locales/ru/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Включить { $title }
 
 landingRequiresDesktop = Лётчику-испытателю требуется Firefox для компьютера на Windows, Mac или Linux
 landingDownloadFirefoxDesc = (Лётчик-испытатель доступен для Firefox на Windows, OS X и Linux)
-landingUpgradeDesc = Лётчику-испытателю необходим Firefox 45 или выше.
+landingUpgradeDesc = Лётчику-испытателю необходим Firefox 49 или выше.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Обновить Firefox
 landingDownloadFirefoxSubTitle = Загрузить бесплатно

--- a/locales/sk/app.ftl
+++ b/locales/sk/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Aktivovať { $title }
 
 landingRequiresDesktop = Test Pilot vyžaduje Firefox pre počítače v systéme Windows, Mac alebo Linux
 landingDownloadFirefoxDesc = (Test Pilot je dostupný pre Firefox pre Windows, OS X a Linux)
-landingUpgradeDesc = Test Pilot vyžaduje Firefox 45 alebo novší.
+landingUpgradeDesc = Test Pilot vyžaduje Firefox 49 alebo novší.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Aktualizovať Firefox
 landingDownloadFirefoxSubTitle = Prevziať zadarmo

--- a/locales/sl/app.ftl
+++ b/locales/sl/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = omogoči { $title }
 
 landingRequiresDesktop = Test Pilot zahteva Firefox za namizja in sistem Windows, Mac ali Linux
 landingDownloadFirefoxDesc = (Test Pilot je na voljo za Firefox v sistemih Windows, OS X in Linux)
-landingUpgradeDesc = Test Pilot zahteva Firefox 45 ali novejšega.
+landingUpgradeDesc = Test Pilot zahteva Firefox 49 ali novejšega.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Nadgradi Firefox
 landingDownloadFirefoxSubTitle = Brezplačen prenos

--- a/locales/sq/app.ftl
+++ b/locales/sq/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Aktivizo { $title }
 
 landingRequiresDesktop = Piloti i Testeve lyp Firefox për Desktop në Windows, Mac ose Linux
 landingDownloadFirefoxDesc = (Pilot i Testeve mund të përdoret te Firefox-i në Windows, OS X dhe Linux)
-landingUpgradeDesc = Piloti i testeve lyp Firefox 45 ose më të ri.
+landingUpgradeDesc = Piloti i testeve lyp Firefox 49 ose më të ri.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Përmirësojeni Firefox-in
 landingDownloadFirefoxSubTitle = Shkarkim Falas

--- a/locales/sv-SE/app.ftl
+++ b/locales/sv-SE/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = Aktivera { $title }
 
 landingRequiresDesktop = Test Pilot kräver Firefox för datorer i Windows, Mac eller Linux
 landingDownloadFirefoxDesc = (Test Pilot är tillgänglig för Firefox på Windows, OS X och Linux)
-landingUpgradeDesc = Test Pilot kräver Firefox 45 eller högre.
+landingUpgradeDesc = Test Pilot kräver Firefox 49 eller högre.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Uppgradera Firefox
 landingDownloadFirefoxSubTitle = Gratis nedladdning

--- a/locales/tr/app.ftl
+++ b/locales/tr/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = Özelliklerinizi seçin
 
 landingRequiresDesktop = Test Pilotu için Firefox'un masaüstü Windows, Mac veya Linux sürümü gerekir
 landingDownloadFirefoxDesc = (Test Pilotu Firox'un Windows, OS X ve Linux sürümlerinde çalışır.)
-landingUpgradeDesc = Test Pilotu için Firefox 45 veya daha yeni bir sürüm gerekir.
+landingUpgradeDesc = Test Pilotu için Firefox 49 veya daha yeni bir sürüm gerekir.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Firefox'u yükseltin
 landingDownloadFirefoxSubTitle = Ücretsiz indirin

--- a/locales/uk/app.ftl
+++ b/locales/uk/app.ftl
@@ -60,7 +60,7 @@ landingInstalledButton = Оберіть ваші функції
 
 landingRequiresDesktop = Test Pilot потребує Firefox на Windows, Mac чи Linux
 landingDownloadFirefoxDesc = (Test Pilot доступний для Firefox на Windows, OS X та Linux)
-landingUpgradeDesc = Test Pilot потребує Firefox 45 або вище.
+landingUpgradeDesc = Test Pilot потребує Firefox 49 або вище.
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Оновити Firefox
 landingDownloadFirefoxSubTitle = Безкоштовне завантаження

--- a/locales/zh-CN/app.ftl
+++ b/locales/zh-CN/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = 启用 { $title }
 
 landingRequiresDesktop = Test Pilot 需要在 Windows、Mac 或 Linux 上的 Firefox 桌面版中运行
 landingDownloadFirefoxDesc = （Test Pilot 可用于 Windows、Mac 或 Linux 上运行的 Firefox）
-landingUpgradeDesc = Test Pilot 需要 Firefox 45 或更高版本。
+landingUpgradeDesc = Test Pilot 需要 Firefox 49 或更高版本。
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = 升级 Firefox
 landingDownloadFirefoxSubTitle = 免费下载

--- a/locales/zh-TW/app.ftl
+++ b/locales/zh-TW/app.ftl
@@ -68,7 +68,7 @@ oneClickInstallMajorCta = 開啟 { $title }
 
 landingRequiresDesktop = 需要使用 Windows、Mac 或 Linux 的 Firefox 才能安裝 Test Pilot
 landingDownloadFirefoxDesc = （Test Pilot 可供 Windows、OS X 及 Linux 版 Firefox 使用）
-landingUpgradeDesc = 需要安裝 Firefox 45 或更新版本才能使用 Test Pilot。
+landingUpgradeDesc = 需要安裝 Firefox 49 或更新版本才能使用 Test Pilot。
 landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = 升級 Firefox
 landingDownloadFirefoxSubTitle = 免費下載


### PR DESCRIPTION
Step 1: prevent new folks from installing the addon with Firefox < 49
Step 2: (later) inform folks with the addon and < 49 that they'll need to upgrade to continue using testpilot.

This patch is just step 1. Folks who already have the addon are unaffected.

I broke the rule about changing strings since I was able to do the substitution en masse. (Persian was fun)