### PR TITLE
expose clientUUID in the PageMod

### DIFF
--- a/addon/data/message-bridge.js
+++ b/addon/data/message-bridge.js
@@ -9,6 +9,7 @@
 // Page script acts as messaging bridge between addon and web content.
 unsafeWindow.navigator.testpilotAddon = true;
 unsafeWindow.navigator.testpilotAddonVersion = self.options.version;
+unsafeWindow.navigator.testpilotClientUUID = self.options.clientUUID;
 
 // New channel
 self.port.on('action', function(data) {

--- a/addon/src/lib/WebApp.js
+++ b/addon/src/lib/WebApp.js
@@ -14,7 +14,8 @@ type WebAppOptions = {
   hub: Hub,
   baseUrl: string,
   whitelist: string,
-  addonVersion: string
+  addonVersion: string,
+  clientUUID: string
 };
 
 type PageIncludes = { page: string, beacon: string[] };
@@ -28,11 +29,14 @@ function toIncludes(baseUrl: string, whitelist: string): PageIncludes {
 export default class WebApp {
   hub: Hub;
   addonVersion: string;
+  clientUUID: string;
   page: PageMod;
   beacon: PageMod;
-  constructor({ hub, baseUrl, whitelist, addonVersion }: WebAppOptions) {
+  constructor(options: WebAppOptions) {
+    const { hub, baseUrl, whitelist, addonVersion, clientUUID } = options;
     this.hub = hub;
     this.addonVersion = addonVersion;
+    this.clientUUID = clientUUID;
     this.createMods(toIncludes(baseUrl, whitelist));
   }
 
@@ -41,7 +45,10 @@ export default class WebApp {
       include: includes.page,
       contentScriptFile: './message-bridge.js',
       contentScriptWhen: 'start',
-      contentScriptOptions: { version: this.addonVersion },
+      contentScriptOptions: {
+        version: this.addonVersion,
+        clientUUID: this.clientUUID
+      },
       attachTo: [ 'top', 'existing' ],
       onAttach: worker => {
         this.hub.connect(worker.port);

--- a/addon/src/main.js
+++ b/addon/src/main.js
@@ -40,6 +40,7 @@ const webapp = new WebApp({
   baseUrl: startEnv.baseUrl,
   whitelist: startEnv.whitelist,
   addonVersion: self.version,
+  clientUUID: store.getState().clientUUID,
   hub
 });
 


### PR DESCRIPTION
This will allow us to use the `clientUUID` on the frontend w/o messaging the addon.