### PR TITLE
added option in experiment yaml for disabling rating prompts

### DIFF
--- a/addon/src/lib/Experiment.js
+++ b/addon/src/lib/Experiment.js
@@ -15,6 +15,14 @@ function toAbsoluteUrl(baseUrl, path) {
   return path[0] === '/' ? baseUrl + path : path;
 }
 
+function parseOptions(input: ?Object): TestPilotOptions {
+  input = input || {};
+  const options = {};
+  // ratings defaults to enabled
+  options.ratings = input.ratings === 'disabled' ? 'disabled' : 'enabled';
+  return options;
+}
+
 export class Notification {
   id: number;
   title: string;
@@ -27,6 +35,12 @@ export class Notification {
     this.notify_after = object.notify_after;
   }
 }
+
+export type FeatureFlag = 'enabled' | 'disabled';
+
+export type TestPilotOptions = {
+  ratings: FeatureFlag
+};
 
 export class Experiment {
   baseUrl: string;
@@ -47,6 +61,7 @@ export class Experiment {
   launchDate: Date;
   localeGrantlist: Array<string>;
   localeBlocklist: Array<string>;
+  testpilotOptions: TestPilotOptions;
   constructor(object: Object, baseUrl?: string) {
     this.baseUrl = object.baseUrl || baseUrl || '';
     this.id = object.addon_id;
@@ -72,6 +87,7 @@ export class Experiment {
 
     this.localeGrantlist = object.locale_grantlist || [];
     this.localeBlocklist = object.locale_blocklist || [];
+    this.testpilotOptions = parseOptions(object.testpilot_options);
   }
 
   allowsLocale(locale: string) {

--- a/addon/src/lib/actionCreators/FeedbackManager.js
+++ b/addon/src/lib/actionCreators/FeedbackManager.js
@@ -10,7 +10,7 @@ import * as actions from '../actions';
 import {
   activeCompletedExperimentList,
   activeExperiments,
-  randomActiveExperiment
+  ratableExperiments
 } from '../reducers/experiments';
 import { experimentRating } from '../reducers/ratings';
 import { setTimeout, clearTimeout } from 'sdk/timers';
@@ -72,7 +72,8 @@ export default class FeedbackManager {
     if (Date.now() - (state.ratings.lastRated || 0) < this.dnd) {
       return;
     }
-    const experiment = randomActiveExperiment(state);
+    const experiments = ratableExperiments(state);
+    const experiment = experiments[Math.floor(Math.random() * experiments.length)];
     if (!experiment) {
       return;
     }

--- a/addon/src/lib/reducers/experiments.js
+++ b/addon/src/lib/reducers/experiments.js
@@ -61,9 +61,10 @@ export function activeCompletedExperimentList(
     .filter(x => x.completed && new Date(x.completed) < new Date());
 }
 
-export function randomActiveExperiment(state: AddonState): Experiment {
-  const installed = activeExperiments(state);
-  const installedKeys = Object.keys(installed);
-  const id = installedKeys[Math.floor(Math.random() * installedKeys.length)];
-  return installed[id];
+export function ratableExperiments(state: AddonState): Array<Experiment> {
+  const active = activeExperiments(state);
+  const ids = Object.keys(active);
+  return ids
+    .map(id => active[id])
+    .filter(x => x.testpilotOptions.ratings === 'enabled');
 }

--- a/content-src/experiments/dev-example.yaml
+++ b/content-src/experiments/dev-example.yaml
@@ -80,3 +80,5 @@ installation_count: 1
 created: '2016-09-22T00:07:28.847430Z'
 completed: '2016-11-16T20:15:00Z'
 order: 999
+testpilot_options:
+  ratings: disabled

--- a/docs/content/reference.md
+++ b/docs/content/reference.md
@@ -522,3 +522,14 @@ A boolean indicating whether this experiment should only appear in a dev environ
 ```yaml
 dev: false
 ```
+
+## `testpilot_options`
+
+A set of options for configuring testpilot features for this experiment.
+
+Enabling / disabling the rating feedback prompt is the only option right now. Valid values are `enabled` or `disabled`. Defaults to `enabled`.
+
+```yaml
+testpilot_options:
+  ratings: enabled
+```

--- a/docs/content/template.yaml
+++ b/docs/content/template.yaml
@@ -99,3 +99,6 @@ locale_grantlist:
   - 'de'
 
 dev: false
+
+testpilot_options:
+  ratings: enabled


### PR DESCRIPTION
closes #2107 

Disable rating prompts in experiment yaml with:

```yml
testpilot_options:
    ratings: disabled
```

cc @chuckharmston 