### PR TITLE
added 'uninstalled' date to experiment yaml

### DIFF
--- a/addon/src/lib/Experiment.js
+++ b/addon/src/lib/Experiment.js
@@ -42,6 +42,7 @@ export class Experiment {
   created: string;
   modified: string;
   completed: string;
+  uninstalled: string;
   active: boolean;
   installDate: ?Date;
   launchDate: Date;
@@ -63,6 +64,7 @@ export class Experiment {
     this.created = object.created;
     this.modified = object.modified;
     this.completed = object.completed;
+    this.uninstalled = object.uninstalled;
 
     this.active = object.active || false;
     this.installDate = object.installDate;

--- a/addon/src/lib/reducers/sideEffects.js
+++ b/addon/src/lib/reducers/sideEffects.js
@@ -74,7 +74,13 @@ export function reducer(
       };
 
     case actions.EXPERIMENTS_LOADED.type:
-      return ({ loader }) => loader.schedule();
+      return ({ dispatch, loader }) => {
+        loader.schedule();
+        Object.keys(payload.experiments)
+          .map(id => payload.experiments[id])
+          .filter(x => x.uninstalled && new Date(x.uninstalled) < new Date())
+          .forEach(experiment => dispatch(actions.UNINSTALL_EXPERIMENT({ experiment })))
+      }
 
     case actions.INSTALL_EXPERIMENT.type:
       return ({ installManager }) =>

--- a/addon/test/test-sideeffects.js
+++ b/addon/test/test-sideeffects.js
@@ -25,11 +25,25 @@ describe('side effects', function() {
       hacks.disabled.reset();
     });
 
-    it('handles EXPERIMENTS_LOADED', function(done) {
-      const action = { type: actions.EXPERIMENTS_LOADED.type };
-      const loader = { schedule: done };
+    it('handles EXPERIMENTS_LOADED', function() {
+      const action = {
+        type: actions.EXPERIMENTS_LOADED.type,
+        payload: {
+          experiments: {
+            x: new Experiment({
+              uninstalled: '2016-12-31'
+            }),
+            y: new Experiment({})
+          }
+        }
+      };
+      const loader = { schedule: sinon.spy() };
+      const dispatch = sinon.spy();
       const state = reducer(null, action);
-      state({ loader });
+      state({ dispatch, loader });
+      assert.ok(loader.schedule.calledOnce);
+      assert.ok(dispatch.calledOnce);
+      assert.equal(dispatch.firstCall.args[0].type, 'UNINSTALL_EXPERIMENT');
     });
 
     it('handles EXPERIMENTS_LOAD_ERROR', function() {

--- a/content-src/experiments/dev-example.yaml
+++ b/content-src/experiments/dev-example.yaml
@@ -79,4 +79,5 @@ contributors:
 installation_count: 1
 created: '2016-09-22T00:07:28.847430Z'
 completed: '2016-11-16T20:15:00Z'
+uninstalled: '2017-02-05T00:00:00Z'
 order: 999

--- a/docs/content/reference.md
+++ b/docs/content/reference.md
@@ -221,6 +221,13 @@ UTM-formatted date indicating the time the experiment will be retired. Used to c
 completed: '2016-01-01T00:00:00.000000Z'
 ```
 
+## `uninstalled`
+
+UTM-formatted date indicating the time the experiment will be automatically uninstalled.
+
+```yaml
+uninstalled: '2016-01-01T00:00:00.000000Z'
+```
 
 ## `launch_date`
 

--- a/docs/content/template.yaml
+++ b/docs/content/template.yaml
@@ -24,6 +24,7 @@ addon_id: 'experiment-name@mozilla.com'
 
 created: '2016-01-01T00:00:00.000000Z'
 completed: '2016-01-01T00:00:00.000000Z'
+uninstalled: '2016-01-02T00:00:00.000000Z'
 launch_date: '2016-01-01T00:00:00.000000Z'
 
 changelog_url: 'https://www.github.com/mozilla/experiment-name/blob/master/docs/changelog.md'


### PR DESCRIPTION
Adding an `uninstalled` date to an experiment yaml will trigger the addon to uninstall the experiment after that date.

see #2136 