### PR TITLE
removed 'any' environment from addon

### DIFF
--- a/addon/data/message-bridge.js
+++ b/addon/data/message-bridge.js
@@ -36,13 +36,6 @@ self.port.on('from-addon-to-web', function(data) {
 });
 
 function onWebToAddon(event) {
-  // HACK: for use with the 'any' environment
-  if (event && event.detail && event.detail.type === 'sync-installed') {
-    self.port.emit('from-web-to-addon', {
-      type: 'base-url',
-      data: window.location.origin
-    });
-  }
   self.port.emit('from-web-to-addon', event.detail);
 }
 

--- a/addon/src/lib/WebApp.js
+++ b/addon/src/lib/WebApp.js
@@ -21,7 +21,7 @@ type WebAppOptions = {
 type PageIncludes = { page: string, beacon: string[] };
 
 function toIncludes(baseUrl: string, whitelist: string): PageIncludes {
-  const page = baseUrl === '*' ? baseUrl : `${baseUrl}/*`;
+  const page = `${baseUrl}/*`;
   const beacon = whitelist.split(',');
   return { page, beacon };
 }

--- a/addon/src/lib/environments.js
+++ b/addon/src/lib/environments.js
@@ -1,7 +1,6 @@
 // @flow
 
 module.exports = {
-  any: { name: 'any', baseUrl: '*', whitelist: '*' },
   local: {
     name: 'local',
     baseUrl: 'https://example.com:8000',

--- a/addon/src/lib/reducers/sideEffects.js
+++ b/addon/src/lib/reducers/sideEffects.js
@@ -106,7 +106,7 @@ export function reducer(
     case actions.SET_BASE_URL.type:
       return ({ dispatch, env }) => {
         const e = env.get();
-        const baseUrl = e.name === 'any' ? payload.url : e.baseUrl;
+        const baseUrl = e.baseUrl;
         dispatch(actions.LOAD_EXPERIMENTS({ envname: e.name, baseUrl }));
       };
 

--- a/addon/src/main.js
+++ b/addon/src/main.js
@@ -66,7 +66,7 @@ export function main({ loadReason }: { loadReason: string }) {
   installManager.selfLoaded(loadReason);
   loader.loadExperiments(
     startEnv.name,
-    startEnv.name === 'any' ? store.getState().baseUrl : startEnv.baseUrl
+    startEnv.baseUrl
   );
   notificationManager.schedule();
   feedbackManager.schedule();

--- a/addon/test/test-env.js
+++ b/addon/test/test-env.js
@@ -55,9 +55,9 @@ describe('env', function() {
     });
 
     it('returns the environment from about:config', function() {
-      aboutConfig.get.returns('any');
+      aboutConfig.get.returns('local');
       const e = env.get();
-      assert.equal(e, environments['any']);
+      assert.equal(e, environments['local']);
     });
   });
 

--- a/addon/test/test-sideeffects.js
+++ b/addon/test/test-sideeffects.js
@@ -229,10 +229,10 @@ describe('side effects', function() {
         type: actions.SET_BASE_URL.type,
         payload: { url: 'it' }
       };
-      const dispatch = a => assert.equal(a.payload.baseUrl, 'it');
+      const dispatch = a => assert.equal(a.payload.baseUrl, 'test');
       const env = {
         get: () => {
-          return { name: 'any' };
+          return { name: 'local', baseUrl: 'test' };
         }
       };
       const state = reducer(null, action);


### PR DESCRIPTION
The 'any' environment was pretty useful in development, but since it allows any origin the opportunity to control the addon it shouldn't be released, even behind an about:config flag.