### PR TITLE
Add ping centre

### DIFF
--- a/addon/flow-typed/sdk.js
+++ b/addon/flow-typed/sdk.js
@@ -430,6 +430,7 @@ declare module 'resource://gre/modules/TelemetryController.jsm' {
   declare module.exports: {
     TelemetryController: {
       Constants: Object,
+      getCurrentPingData: any,
       // observe: (subject: string, topic: string, data: any) => any,
       submitExternalPing: (type: string, payload: Object, options?: {
         addClientId?: boolean,
@@ -438,5 +439,11 @@ declare module 'resource://gre/modules/TelemetryController.jsm' {
       }) => Promise<string>
       // TODO
     }
+  }
+}
+
+declare module 'resource://gre/modules/ClientID.jsm' {
+  declare module.exports: {
+    ClientID: any
   }
 }

--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/addon/src/lib/actionCreators/InstallManager.js
+++ b/addon/src/lib/actionCreators/InstallManager.js
@@ -60,6 +60,8 @@ export default class InstallManager {
 
   selfLoaded(reason: string) {
     const { dispatch } = this.store;
+    dispatch(actions.BROWSER_STARTUP());
+
     if (reason === 'install') {
       dispatch(actions.SELF_INSTALLED());
     } else if (reason === 'enable') {

--- a/addon/src/lib/actions.js
+++ b/addon/src/lib/actions.js
@@ -126,3 +126,4 @@ export const UNINSTALL_EXPERIMENT = createAction('UNINSTALL_EXPERIMENT', [
 export const UNINSTALL_SELF = createAction('UNINSTALL_SELF', []);
 export const GET_INSTALLED = createAction('GET_INSTALLED', []);
 export const SET_BASE_URL = createAction('SET_BASE_URL', [ 'url' ]);
+export const BROWSER_STARTUP = createAction('BROWSER_STARTUP', []);

--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -7,6 +7,7 @@
 // @flow
 
 import { AddonManager } from 'resource://gre/modules/AddonManager.jsm';
+import { ClientID } from 'resource://gre/modules/ClientID.jsm';
 import Events from 'sdk/system/events';
 import self from 'sdk/self';
 import { Services } from 'resource://gre/modules/Services.jsm';
@@ -34,6 +35,13 @@ function makeTimestamp(timestamp: Date) {
 function experimentPing(event: ExperimentPingData) {
   const timestamp = new Date();
   const { subject, data } = event;
+  let parsed;
+  try {
+    parsed = JSON.parse(data);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    return console.error(`Dropping bad metrics packet: ${err}`);
+  }
 
   AddonManager.getAddonByID(subject, addon => {
     const payload = {
@@ -44,12 +52,46 @@ function experimentPing(event: ExperimentPingData) {
         subject in storage.experimentVariants
         ? storage.experimentVariants[subject]
         : null,
-      payload: JSON.parse(data)
+      payload: parsed
     };
     TelemetryController.submitExternalPing('testpilottest', payload, {
       addClientId: true,
       addEnvironment: true
     });
+
+    // TODO: DRY up this ping centre code here and in lib/Telemetry.
+    const pcPing = TelemetryController.getCurrentPingData();
+    pcPing.type = 'testpilot';
+    pcPing.payload = payload;
+    const pcPayload = {
+      // 'method' is used by testpilot-metrics library.
+      // 'event' was used before that library existed.
+      event_type: parsed.event || parsed.method,
+      client_time: makeTimestamp(parsed.timestamp || timestamp),
+      addon_id: subject,
+      addon_version: addon.version,
+      firefox_version: pcPing.environment.build.version,
+      os_name: pcPing.environment.system.os.name,
+      os_version: pcPing.environment.system.os.version,
+      locale: pcPing.environment.settings.locale,
+      raw: JSON.stringify(pcPing),
+      // Note: these two keys are normally inserted by the ping-centre client.
+      client_id: ClientID.getCachedClientID(),
+      topic: 'testpilot',
+    };
+    // Add any other extra top-level keys from the payload, possibly including
+    // 'object' or 'category', among others.
+    Object.keys(parsed).forEach(f => {
+      // Ignore the keys we've already added to `pcPayload`.
+      const ignored = ['event', 'method', 'timestamp'];
+      if (!ignored.includes(f)) {
+        pcPayload[f] = parsed[f];
+      }
+    });
+
+    Services.appShell.hiddenDOMWindow.navigator.sendBeacon(
+      'https://onyx_tiles.stage.mozaws.net/v3/links/ping-centre',
+      JSON.stringify(pcPayload));
   });
 }
 

--- a/addon/src/lib/reducers/sideEffects.js
+++ b/addon/src/lib/reducers/sideEffects.js
@@ -8,6 +8,8 @@
 
 import * as actions from '../actions';
 import WebExtensionChannels from '../metrics/webextension-channels';
+import { activeExperiments } from './experiments';
+import { Services } from 'resource://gre/modules/Services.jsm';
 
 import typeof self from 'sdk/self';
 import typeof tabs from 'sdk/tabs';
@@ -179,6 +181,20 @@ export function reducer(
     case actions.ADDONS_CHANGED.type:
       return ({ installManager }) => {
         installManager.syncInstalled();
+      };
+
+    case actions.BROWSER_STARTUP.type:
+      return ({ telemetry, getState }) => {
+
+        telemetry.sendGAEvent({
+          t: 'event',
+          ec: 'add-on Interactions',
+          ea: 'browser startup',
+          el: Object.keys(activeExperiments(getState())).length
+        });
+        Services.obs.addObserver(() => {
+          telemetry.ping('daily', Object.keys(activeExperiments(getState())).length);
+        }, 'idle-daily', false);
       };
 
     default:

--- a/addon/src/main.js
+++ b/addon/src/main.js
@@ -6,7 +6,6 @@
 
 // @flow
 
-import { activeExperiments } from './lib/reducers/experiments';
 import AddonListener from './lib/actionCreators/AddonListener';
 import configureStore from './lib/configureStore';
 import createExperimentMetrics from './lib/metrics';
@@ -71,12 +70,6 @@ export function main({ loadReason }: { loadReason: string }) {
   notificationManager.schedule();
   feedbackManager.schedule();
   feedbackManager.maybeShare();
-  telemetry.sendGAEvent({
-    t: 'event',
-    ec: 'add-on Interactions',
-    ea: 'browser startup',
-    el: Object.keys(activeExperiments(store.getState())).length
-  });
 }
 
 export function onUnload(reason: string) {

--- a/addon/test/test-installmanager.js
+++ b/addon/test/test-installmanager.js
@@ -97,31 +97,48 @@ describe('InstallManager', function() {
   });
 
   describe('selfLoaded', function() {
-    it('dispatches SELF_INSTALLED when reason is install', function() {
+    it('dispatches SELF_INSTALLED and BROWSER_STARTUP when reason is install',
+      function() {
       const s = {
         dispatch: sinon.spy(),
         getState: sinon.stub().returns({ baseUrl: 'base' })
       };
       const i = new InstallManager(s);
       i.selfLoaded('install');
-      assert.ok(s.dispatch.calledOnce);
-      assert.ok(s.dispatch.firstCall.args[0].type, actions.SELF_INSTALLED.type);
+      assert.ok(s.dispatch.calledTwice);
+      assert.ok(
+        s.dispatch.firstCall.args[0].type,
+        actions.BROWSER_STARTUP.type
+      );
+      assert.ok(
+        s.dispatch.secondCall.args[0].type,
+        actions.SELF_INSTALLED.type
+      );
     });
 
-    it('dispatches SELF_ENABLED when reason is enable', function() {
+    it('dispatches SELF_ENABLED and BROWSER_STARTUP when reason is enable',
+      function() {
       const i = new InstallManager(store);
       i.selfLoaded('enable');
-      assert.ok(store.dispatch.calledOnce);
+      assert.ok(store.dispatch.calledTwice);
       assert.ok(
         store.dispatch.firstCall.args[0].type,
+        actions.BROWSER_STARTUP.type
+      );
+      assert.ok(
+        store.dispatch.secondCall.args[0].type,
         actions.SELF_ENABLED.type
       );
     });
 
-    it('does nothing otherwise', function() {
+    it('dispatches BROWSER_STARTUP otherwise', function() {
       const i = new InstallManager(store);
       i.selfLoaded('anything');
-      assert.ok(!store.dispatch.called);
+      assert.ok(store.dispatch.calledOnce);
+      assert.ok(
+        store.dispatch.firstCall.args[0].type,
+        actions.BROWSER_STARTUP.type
+      );
     });
   });
 

--- a/addon/test/test-metricsexperiment.js
+++ b/addon/test/test-metricsexperiment.js
@@ -12,7 +12,9 @@ const EVENT_SEND_VARIANTS = 'testpilot::receive-variants';
 const AddonManager = {
   getAddonByID: sinon.stub().callsArgWith(1, { version: '0' })
 };
-
+const ClientID = {
+  getCachedClientID: sinon.stub().returns('12345')
+};
 const Events = {
   emit: sinon.spy(),
   on: sinon.spy(),
@@ -20,14 +22,30 @@ const Events = {
   '@noCallThru': true
 };
 const Services = {
-  startup: { getStartupInfo: sinon.stub().returns({ process: new Date() }) }
+  startup: { getStartupInfo: sinon.stub().returns({ process: new Date() }) },
+  appShell: { hiddenDOMWindow: { navigator: { sendBeacon: sinon.stub() } } }
 };
 const storage = {};
-const TelemetryController = { submitExternalPing: sinon.spy() };
+const TelemetryController = {
+  submitExternalPing: sinon.spy(),
+  getCurrentPingData: () => {
+    return {
+      environment: {
+        build: { version: 'environment.build.version' },
+        system: { os: { name: 'system.os.name', version: 'system.os.version' } },
+        settings: { locale: 'en-US' }
+      }
+    };
+  }
+};
 
 const Experiment = proxyquire('../src/lib/metrics/experiment', {
   'resource://gre/modules/AddonManager.jsm': {
     AddonManager,
+    '@noCallThru': true
+  },
+  'resource://gre/modules/ClientID.jsm': {
+    ClientID,
     '@noCallThru': true
   },
   'sdk/system/events': Events,

--- a/addon/test/test-reducers.js
+++ b/addon/test/test-reducers.js
@@ -3,9 +3,15 @@ import assert from 'assert';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
+const Services = {
+  '@noCallThru': true,
+  '@global': true,
+  obs: { addObserver: sinon.stub() }
+};
 const reducers = proxyquire('../src/lib/reducers', {
   'sdk/util/uuid': { uuid: () => 'uuid', '@noCallThru': true, '@global': true },
-  '../metrics/webextension-channels': { '@noCallThru': true, '@global': true }
+  '../metrics/webextension-channels': { '@noCallThru': true, '@global': true },
+  'resource://gre/modules/Services.jsm': Services
 }).default;
 
 import * as actions from '../src/lib/actions';

--- a/addon/test/test-sideeffects.js
+++ b/addon/test/test-sideeffects.js
@@ -5,8 +5,10 @@ import sinon from 'sinon';
 
 const spies = { add: sinon.spy(), remove: sinon.spy(), '@noCallThru': true };
 const hacks = { enabled: sinon.spy(), disabled: sinon.spy() };
+const Services = { '@noCallThru': true, obs: { addObserver: sinon.stub() }};
 
 const sideEffects = proxyquire('../src/lib/reducers/sideEffects', {
+  'resource://gre/modules/Services.jsm': Services,
   '../metrics/webextension-channels': spies
 });
 const { reducer, nothing } = sideEffects;


### PR DESCRIPTION
There are some open issues with using the ping-centre npm client in an addon context. I ran out of time for this sprint, so fell back to just pinging the staging endpoint directly with `sendBeacon`.

The commit messages pretty much tell the story. Starting with the Ping Centre staging environment for this sprint. If everything looks good, we can graduate to production next sprint.

I've fixed the tests, but not added new tests. Happy to add more tests in a followup PR, but I'd really like to land this PR in sprint 18, if possible.

-----
Integrate Ping Centre staging environment

- Send an event to Ping Centre whenever `lib/Telemetry#ping` or
  `lib/metrics/experiment#experimentPing` is called.

- Integrate Ping Centre by directly firing a network request, to be
  replaced with the `ping-centre` npm package when it's fully working.

- Make sure `beacon.enabled` is preffed on, so that `sendBeacon` will
  work.
-----
Send a daily ping to Ping Centre for DAU calculations

Telemetry code uses the 'idle-daily' nsIObserver event to trigger the
daily ping submission. Listen for that same event, then send a 'daily'
ping to Ping Centre and Telemetry, via lib/Telemetry.

-----

To verify this code is working:

- install the addon via `npm start` 
- fire up the browser toolbox, open the network tab
- disable the Test Pilot add-on in `about:addons`
    - you should see a GA `disabled` ping and a ping-centre `disabled` ping (have a look in the params tab)
- re-enable the Test Pilot add-on in `about:addons`
    - you should see a GA `browser-startup` ping, a ping-centre `enabled` ping, and a GA `enabled` ping
- in the console, fire the `idle-daily` event via: `Services.obs.notifyObservers(false, 'idle-daily', '')`
    - you should see a GA `daily` ping and a ping-centre `daily` ping
- next, install an addon from the testpilot website
    - you should see POSTs including a GA `enabled` ping and a ping-centre `enabled` ping

You get the idea.

The telemetry pings are viewable from `about:telemetry`: choose the 'archived ping data' radio button, then the 'raw JSON' radio button, then look at the list of submitted pings in the **Ping** select dropdown. 