### PR TITLE
Add /docs/ to data_dictionary.md link

### DIFF
--- a/content-src/experiments/activity-stream.yaml
+++ b/content-src/experiments/activity-stream.yaml
@@ -15,7 +15,7 @@ changelog_url: 'https://github.com/mozilla/activity-stream/blob/master/CHANGELOG
 contribute_url: 'https://github.com/mozilla/activity-stream'
 bug_report_url: 'https://github.com/mozilla/activity-stream/issues'
 discourse_url: 'https://discourse.mozilla-community.org/c/test-pilot/activity-stream'
-privacy_notice_url: 'https://github.com/mozilla/activity-stream/blob/master/data_dictionary.md'
+privacy_notice_url: 'https://github.com/mozilla/activity-stream/blob/master/docs/data_dictionary.md'
 measurements:
   - >
     We collect basic usage data regarding how you interact with experimental


### PR DESCRIPTION
Looks like this may have been changed by https://github.com/mozilla/activity-stream/pull/2121

Fixes #2160 