### PR TITLE
send failure events to the webapp

### DIFF
--- a/addon/src/lib/middleware/webadapter.js
+++ b/addon/src/lib/middleware/webadapter.js
@@ -78,6 +78,20 @@ export function actionToWeb({ payload, type }: Action) {
           version: payload.experiment.version
         }
       };
+    case actions.DOWNLOAD_FAILED.type:
+      return {
+        type: 'addon-install:download-failed',
+        data: {
+          name: payload.install.name
+        }
+      };
+    case actions.INSTALL_FAILED.type:
+      return {
+        type: 'addon-install:install-failed',
+        data: {
+          name: payload.install.name
+        }
+      };
   }
   return NO_ACTION;
 }


### PR DESCRIPTION
The new addon wasn't sending these two events to the webapp. fixes #2163 

see [frontend/src/app/lib/addon.js](https://github.com/mozilla/testpilot/blob/master/frontend/src/app/lib/addon.js#L138-L170) for where it's expecting them.