### PR TITLE
[fixes #2136] Add completed dates to graduating experiments

### DIFF
--- a/content-src/experiments/no-more-404s.yaml
+++ b/content-src/experiments/no-more-404s.yaml
@@ -84,6 +84,8 @@ contributors:
     avatar: /static/images/experiments/no-more-404s/avatars/adam-miller.jpg
 installation_count: 20377
 created: '2016-08-03T17:25:54.612365Z'
+completed: '2017-02-15T14:00:00.000000Z'
+eol_warning: The No More 404s experiment will not be removed from your browser and the results will be reported here when it ends. Future updates will be available on addons.mozilla.org.
 locale_blocklist:
   - 'de'
 order: 6

--- a/content-src/experiments/tracking-protection.yaml
+++ b/content-src/experiments/tracking-protection.yaml
@@ -88,6 +88,9 @@ contributors_extra: >
 contributors_extra_url: 'https://mzl.la/2fYneDq'
 installation_count: 1
 created: '2016-09-22T00:07:28.847430Z'
+completed: '2017-02-15T14:00:00.000000Z'
+uninstalled: '2017-02-15T14:00:00.000000Z'
+eol_warning: We will automatically disable the Tracking Protection experiment and report the results when it ends.
 locale_blocklist:
   - 'de'
 order: 3


### PR DESCRIPTION
This assumes the following plan:

1. Both TP and NM404s is being removed from Test Pilot on 2/15 (6am PST)
2. We will also be shipping an empty add-on to unship Tracking Protection
3. NM404s is moving to AMO

One question: if we're shipping an add-on to remove TP, why are we configuring an `uninstall` date? @clouserw @dannycoates

Fixes #2136