### PR TITLE
l10n files should not be cached forever with immutable

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -109,6 +109,16 @@ aws s3 sync \
   --acl "public-read" \
   dist/ s3://${TESTPILOT_BUCKET}/
 
+# l10n files; short cache;
+aws s3 sync \
+    --cache-control "max-age=${TEN_MINUTES}" \
+    --exclude "*" \
+    --include "*.ftl" \
+    --metadata "{${HPKP}, ${HSTS}, ${TYPE}}" \
+    --metadata-directive "REPLACE" \
+    --acl "public-read" \
+  dist/ s3://${TESTPILOT_BUCKET}/
+
 # SVG; cache forever, assign correct content-type
 aws s3 sync \
   --cache-control "max-age=${ONE_YEAR}, immutable" \


### PR DESCRIPTION
Since the last deploy I added `immutable` to our long lived, hashed assets in #2081. Unfortunately, FTL files are in that group despite not being hashed or immutable. This would break future changes to strings. FTL files must not get the immutable cache-control flag.

@ckprice this needs to be merged before we deploy to production.