### PR TITLE
Fix #2103 Hack a fix for the privacy link being empty after localization.

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -40,6 +40,13 @@ ExperimentPage.propTypes = {
 };
 
 
+const EXPERIMENT_MEASUREMENT_URLS = [
+  null,
+  null,
+  null,
+  'https://www.mozilla.org/privacy/websites'
+];
+
 export class ExperimentDetail extends React.Component {
 
   constructor(props) {
@@ -395,7 +402,9 @@ export class ExperimentDetail extends React.Component {
                             </p>
                             <ul>
                               {measurements.map((note, idx) => (
-                                <li data-l10n-id={this.l10nId(['measurements', idx])} key={idx}>{note}</li>
+                                <li data-l10n-id={this.l10nId(['measurements', idx])} key={idx}>{note}{
+                                  EXPERIMENT_MEASUREMENT_URLS[idx] === null ? null : <a href={EXPERIMENT_MEASUREMENT_URLS[idx]}></a>
+                                }</li>
                               ))}
                             </ul>
                           </div>
@@ -441,7 +450,9 @@ export class ExperimentDetail extends React.Component {
                         </p>
                         <ul>
                           {measurements.map((note, idx) => (
-                            <li data-l10n-id={this.l10nId(['measurements', idx])} key={idx}>{note}</li>
+                            <li data-l10n-id={this.l10nId(['measurements', idx])} key={idx}>{note}{
+                              EXPERIMENT_MEASUREMENT_URLS[idx] === null ? null : <a href={EXPERIMENT_MEASUREMENT_URLS[idx]}></a>
+                            }</li>
                           ))}
                         </ul>
                       </div>


### PR DESCRIPTION
If anyone has a better suggestion of where to store the url instead of
in a module global, let me know.