### PR TITLE
fixes #2199 eol prompt dup

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/addon/src/lib/actionCreators/FeedbackManager.js
+++ b/addon/src/lib/actionCreators/FeedbackManager.js
@@ -99,7 +99,7 @@ export default class FeedbackManager {
       if (experiment) {
         tabs.once('open', () => {
           setTimeout(
-            () => this.promptRating({ interval: 'eol', experiment }),
+            () => this.dispatch(actions.SHOW_RATING_PROMPT({ interval: 'eol', experiment })),
             1000
           );
         });

--- a/addon/test/test-feedbackmanager.js
+++ b/addon/test/test-feedbackmanager.js
@@ -204,7 +204,6 @@ describe('FeedbackManager', function() {
         dispatch: sinon.spy()
       };
       const fm = new FeedbackManager(store);
-      sinon.spy(fm, 'promptRating');
       assert.equal(fm.checkForCompletedExperimentSurveys(), true);
       assert.ok(tabs.once.calledOnce);
       assert.ok(tabs.once.calledWith('open'));
@@ -214,7 +213,8 @@ describe('FeedbackManager', function() {
       assert.ok(timers.setTimeout.calledOnce);
       const callback2 = timers.setTimeout.firstCall.args[0];
       callback2();
-      assert.ok(fm.promptRating.calledOnce);
+      assert.ok(store.dispatch.calledOnce);
+      assert.equal(store.dispatch.firstCall.args[0].type, SHOW_RATING_PROMPT.type);
     });
   });
 


### PR DESCRIPTION
recording that the prompt was shown happens in the ratings reducer on `SHOW_RATING_PROMPT`. The eol prompt was skipping that and directly showing the prompt. Sorry, y'all.