### PR TITLE
Simplify Telemetry ping message for WebExtension experiments

### DIFF
--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -20,7 +20,7 @@ import type Variants from './variants';
 
 export type ExperimentPingData = {
   subject: string,
-  data: string /* JSON { senderAddonId: string, testpilotPingData: any }*/
+  data: string /* JSON { any } */
 };
 
 const EVENT_SEND_METRIC = 'testpilot::send-metric';

--- a/addon/src/lib/metrics/webextension-channels.js
+++ b/addon/src/lib/metrics/webextension-channels.js
@@ -16,6 +16,7 @@ type PingListener = (
 ) => void;
 
 const TESTPILOT_TELEMETRY_CHANNEL = 'testpilot-telemetry';
+const BLOK_ADDON_ID = 'blok@mozilla.org';
 
 function createChannelForAddonId(name, addonId) {
   // The BroadcastChannel API allows messaging between different windows that
@@ -136,10 +137,15 @@ export default class WebExtensionChannel {
     // eslint-disable-next-line prefer-const
     for (let pingListener of this.pingListeners) {
       try {
-        pingListener({
-          senderAddonId: sender.addonId,
-          testpilotPingData: data
-        });
+        if (sender.addonId === BLOK_ADDON_ID) {
+          // HACK: Legacy ping format for Tracking Protection experiment
+          pingListener({
+            senderAddonId: sender.addonId,
+            testpilotPingData: data
+          });
+        } else {
+          pingListener(data);
+        }
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('Error executing pingListener', err);

--- a/addon/test/test-webextensionchannel.js
+++ b/addon/test/test-webextensionchannel.js
@@ -3,6 +3,8 @@ import assert from 'assert';
 import proxyquire from 'proxyquire';
 import sinon from 'sinon';
 
+const BLOK_ADDON_ID = 'blok@mozilla.org';
+
 const broadcastChannel = {
   addEventListener: sinon.spy(),
   removeEventListener: sinon.spy(),
@@ -149,14 +151,23 @@ describe('WebExtensionChannel', function() {
   });
 
   describe('notifyPing', function() {
+    it('calls the ping listeners with legacy format for Tracking Protection', function() {
+      const w = new WebExtensionChannel(BLOK_ADDON_ID);
+      const fn = sinon.spy();
+      w.registerPingListener(fn);
+      w.notifyPing('x', { addonId: BLOK_ADDON_ID });
+      assert.ok(fn.calledOnce);
+      assert.equal(fn.firstCall.args[0].senderAddonId, BLOK_ADDON_ID);
+      assert.equal(fn.firstCall.args[0].testpilotPingData, 'x');
+    });
+
     it('calls the ping listeners with the arguments', function() {
       const w = new WebExtensionChannel('foo');
       const fn = sinon.spy();
       w.registerPingListener(fn);
       w.notifyPing('x', { addonId: 'f' });
       assert.ok(fn.calledOnce);
-      assert.equal(fn.firstCall.args[0].senderAddonId, 'f');
-      assert.equal(fn.firstCall.args[0].testpilotPingData, 'x');
+      assert.equal(fn.firstCall.args[0], 'x');
     });
 
     it('catches listener exceptions', function() {


### PR DESCRIPTION
- Retain legacy format for Tracking Protection experiment

- Simplify ping payload for all future WebExtension experiments

- Test updates

Fixes #2197