### PR TITLE
Fix Snooze Tabs XPI URL

### DIFF
--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -35,7 +35,7 @@ measurements:
   - >
     Snooze Tabs does NOT collect any information or details about your tabs such 
     as URLs, meta attributes, or page content.
-xpi_url: 'https://testpilot.firefox.com/files/snoozetabs@mozilla/latest'
+xpi_url: 'https://testpilot.firefox.com/files/snoozetabs@mozilla.com/latest'
 addon_id: 'snoozetabs@mozilla.com'
 gradient_start: '#F89612'
 gradient_stop: '#851830'


### PR DESCRIPTION
I noticed that the add-on ID in `package.json` for Snooze Tabs was incorrect. [So, I fixed it.](https://github.com/bwinton/SnoozeTabs/commit/bbd3fafcedcbb73b09d5fb5b9c3a24676cc9818e) 

Turns out that also changes the URL where the add-on gets uploaded to S3 by Jenkins. 

This should fix that.