### PR TITLE
Marks Pulse as incompatible with Firefox < 51.

### DIFF
--- a/content-src/experiments/pulse.yaml
+++ b/content-src/experiments/pulse.yaml
@@ -4,6 +4,7 @@ slug: pulse
 locales:
   - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
+min_release: 51
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
 thumbnail: /static/images/experiments/pulse/icon/thumbnail.png


### PR DESCRIPTION
As an Embedded WebExtension, it requires a minimum of 51.