### PR TITLE
restrict launch to en

### DIFF
--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -3,6 +3,8 @@ title: 'Containers'
 slug: containers
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:

--- a/content-src/experiments/pulse.yaml
+++ b/content-src/experiments/pulse.yaml
@@ -3,6 +3,8 @@ title: 'Pulse'
 slug: pulse
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:

--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -3,6 +3,8 @@ title: 'Snooze Tabs'
 slug: snooze-tabs
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'


### PR DESCRIPTION
Fixes #2223 @ckprice @clouserw we should consider this for launch and then back out as more locales reach 100% coverage. We should confirm that initial marketing push will be en only