### PR TITLE
Message about containers

### DIFF
--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -3,6 +3,8 @@ title: 'Containers'
 slug: containers
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:

--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -9,12 +9,12 @@ launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
-  'snoozetabs@mozilla.com': 'Snooze Tabs'
 thumbnail: /static/images/experiments/containers/icon/thumbnail.png
 description: >
   Contain yourselves! Create different containers for each of your online lives -  
   your work self, your social self, your personal self - to stay organized and maintain privacy.
 introduction: >
+  <div class="warning"><strong>Note: Because of the security properties of Containers, Test Pilot experiments such as Page Shot, Snooze Tabs, and Pulse will not work from within Container tabs. Remember, this is experimental technology!</strong></div>
   Containers let you create profiles in Firefox for all of your online lives. Custom 
   labels and color-coded tabs help keep different activities — like online shopping, 
   travel planning, or checking work email — separate.  Because Containers store cookies 

--- a/content-src/experiments/pulse.yaml
+++ b/content-src/experiments/pulse.yaml
@@ -3,6 +3,8 @@ title: 'Pulse'
 slug: pulse
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:

--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -3,6 +3,8 @@ title: 'Snooze Tabs'
 slug: snooze-tabs
 locales:
   - 'en'
+locale_grantlist:
+  - 'en'
 launch_date: '2017-02-22T17:00:00.00Z'
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'

--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -8,7 +8,6 @@ locale_grantlist:
 launch_date: '2017-02-22T17:00:00.00Z'
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
-  '@testpilot-containers': 'Containers'
 thumbnail: /static/images/experiments/snooze-tabs/icon/thumbnail.png
 description: >
   Right website, wrong time?  Snooze it until you need it. Snooze Tabs let you 


### PR DESCRIPTION
This was done on top of the locales grantlist PR as a mitiagation for Testpilot-Containers issue 242: https://github.com/mozilla/testpilot-containers/issues/242

This does the following: 

- adds a plain English warning string to the containers experiment
- removes the other warning from snooze tabs and containers since the new warning is more clear.

- as a follow on, we might want to add a plain language warning field to the experimentDetails container so we don't have HTML in yaml

https://pageshot.net/to0JQPIg2gbCbsHI/example.com