### PR TITLE
fix addon handling of launch date

### DIFF
--- a/addon/src/lib/Experiment.js
+++ b/addon/src/lib/Experiment.js
@@ -84,7 +84,7 @@ export class Experiment {
     this.active = object.active || false;
     this.installDate = object.installDate;
     this.launchDate = object.launch_date
-      ? new Date(object.launchDate)
+      ? new Date(object.launch_date)
       : new Date(object.created);
 
     this.localeGrantlist = object.locale_grantlist || [];

--- a/content-src/experiments/pulse.yaml
+++ b/content-src/experiments/pulse.yaml
@@ -5,7 +5,6 @@ locales:
   - 'en'
 locale_grantlist:
   - 'en'
-launch_date: '2017-02-22T17:00:00.00Z'
 min_release: 51
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
@@ -84,5 +83,5 @@ contributors:
     title: 'Firefox QA'
     avatar: /static/images/experiments/avatars/peter.jpg
 installation_count: 1
-created: '2017-02-17T00:06:00.00Z'
+created: '2017-02-22T17:00:00.00Z'
 order: 2

--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -5,7 +5,6 @@ locales:
   - 'en'
 locale_grantlist:
   - 'en'
-launch_date: '2017-02-22T17:00:00.00Z'
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
 thumbnail: /static/images/experiments/snooze-tabs/icon/thumbnail.png
@@ -100,5 +99,5 @@ contributors:
     title: 'Softvision QA'
     avatar: /static/images/experiments/avatars/ciprian.jpg
 installation_count: 1
-created: '2017-02-17T00:06:00.00Z'
+created: '2017-02-22T17:00:00.00Z'
 order: 0


### PR DESCRIPTION
Yeah, I effed this up. This will fix it in the future, and by removing the `launch_date` and setting `created` to today we can show the badge on the current broken version.