### PR TITLE
copy contribute.json back into build

### DIFF
--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -37,9 +37,15 @@ gulp.task('pages-compiled', () => {
              .pipe(gulp.dest(config.DEST_PATH));
 });
 
+gulp.task('pages-contributing', () => {
+  gulp.src('./contribute.json')
+    .pipe(gulp.dest(config.DEST_PATH));
+});
+
 gulp.task('pages-build', [
   'pages-misc',
   'pages-experiments',
+  'pages-contributing',
   'pages-compiled'
 ]);
 


### PR DESCRIPTION
@lmorchard this may be a naive approach to adding this back into public view, but it seems to work.