### PR TITLE
Skip hashing filenames of social media thumbnail images

### DIFF
--- a/frontend/tasks/dist.js
+++ b/frontend/tasks/dist.js
@@ -12,11 +12,13 @@ gulp.task('dist-rev-assets', function() {
       'favicon.ico',
       /static\/addon\/*/,
       /static\/locales\/*/,
+      /static\/images\/experiments\/*\/social\/*/,
       '.html'
     ],
     dontUpdateReference: [
       /static\/addon\/*/,
       /.*\.json/,
+      /static\/images\/experiments\/*\/social\/*/,
       'favicon.ico'
     ]
   });


### PR DESCRIPTION
Issue #2244 

Hopefully this fixes the 404 issue, making rev-all skip hashing filenames for the social thumbnail issues we now reference via absolute URLs. We'll need to manually rename these thumbnail images in the future to update them until/unless we find a way to make rev-all handle absolute URLs