### PR TITLE
Moving Containers launch time to 12pm PST

### DIFF
--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -5,7 +5,7 @@ locales:
   - 'en'
 locale_grantlist:
   - 'en'
-launch_date: '2017-03-01T17:00:00.00Z'
+launch_date: '2017-03-01T21:00:00.00Z'
 min_release: 51
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'


### PR DESCRIPTION
Move this back a bit to make sure S3 deployments are all good. 8am didn't give us much time to react.