### PR TITLE
Fix #2259 Remove redux-thunk.

### DIFF
--- a/frontend/src/app/store.js
+++ b/frontend/src/app/store.js
@@ -2,7 +2,6 @@ import { routerReducer, routerMiddleware } from 'react-router-redux';
 import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
 import createLogger from 'redux-logger';
 import promise from 'redux-promise';
-import thunk from 'redux-thunk';
 
 import addonReducer from './reducers/addon';
 import browserReducer from './reducers/browser';
@@ -41,7 +40,6 @@ export const initialState = {
 
 export const createMiddleware = history => compose(
   applyMiddleware(
-    thunk,
     promise,
     routerMiddleware(history),
     createLogger()

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "redux-actions": "^1.2.1",
     "redux-logger": "^2.6.1",
     "redux-promise": "^0.5.3",
-    "redux-thunk": "^2.1.0",
     "reselect": "^2.5.4",
     "seedrandom": "^2.4.2"
   },


### PR DESCRIPTION
If you need to dispatch an async action, use redux-promise instead.