### PR TITLE
Replace sendBeacon with Fetch

### DIFF
--- a/addon/src/lib/Telemetry.js
+++ b/addon/src/lib/Telemetry.js
@@ -111,9 +111,11 @@ export default class Telemetry {
       topic: 'testpilot'
     };
 
-    Services.appShell.hiddenDOMWindow.navigator.sendBeacon(
-      'https://tiles.services.mozilla.com/v3/links/ping-centre',
-      JSON.stringify(pcPayload)
-    );
+    const req = new Request({
+      url: 'https://tiles.services.mozilla.com/v3/links/ping-centre',
+      contentType: 'application/json',
+      content: JSON.stringify(pcPayload)
+    });
+    req.post();
   }
 }

--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -15,6 +15,7 @@ import { storage } from 'sdk/simple-storage';
 import {
   TelemetryController
 } from 'resource://gre/modules/TelemetryController.jsm';
+import { Request } from 'sdk/request';
 
 import type Variants from './variants';
 
@@ -92,10 +93,12 @@ function experimentPing(event: ExperimentPingData) {
       }
     });
 
-    Services.appShell.hiddenDOMWindow.navigator.sendBeacon(
-      'https://tiles.services.mozilla.com/v3/links/ping-centre',
-      JSON.stringify(pcPayload)
-    );
+    const req = new Request({
+      url: 'https://tiles.services.mozilla.com/v3/links/ping-centre',
+      contentType: 'application/json',
+      content: JSON.stringify(pcPayload)
+    });
+    req.post();
   });
 }
 

--- a/addon/test/test-metricsexperiment.js
+++ b/addon/test/test-metricsexperiment.js
@@ -21,9 +21,12 @@ const Events = {
   off: sinon.spy(),
   '@noCallThru': true
 };
+function Request() {
+  return { post: sinon.stub() };
+}
+
 const Services = {
-  startup: { getStartupInfo: sinon.stub().returns({ process: new Date() }) },
-  appShell: { hiddenDOMWindow: { navigator: { sendBeacon: sinon.stub() } } }
+  startup: { getStartupInfo: sinon.stub().returns({ process: new Date() }) }
 };
 const storage = {};
 const TelemetryController = {
@@ -51,6 +54,7 @@ const Experiment = proxyquire('../src/lib/metrics/experiment', {
     '@noCallThru': true
   },
   'sdk/system/events': Events,
+  'sdk/request': { Request, '@noCallThru': true },
   'sdk/self': { id: 'self-id', '@noCallThru': true },
   'resource://gre/modules/Services.jsm': { Services, '@noCallThru': true },
   'sdk/simple-storage': { storage, '@noCallThru': true },


### PR DESCRIPTION
Fixes #2231.

I'm swallowing errors and responses here, because `sendBeacon` did, but we could log them or introduce sentry to the addon.