### PR TITLE
Load en-US FTL files to provide fallback for incomplete locales

### DIFF
--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -15,6 +15,7 @@ locale_grantlist:
   - 'ja'
   - 'nl'
   - 'pt-PT'
+  - 'ru'
   - 'sq'
   - 'sv-SE'
   - 'zh-CN'

--- a/content-src/experiments/pulse.yaml
+++ b/content-src/experiments/pulse.yaml
@@ -15,6 +15,7 @@ locale_grantlist:
   - 'ja'
   - 'nl'
   - 'pt-PT'
+  - 'ru'
   - 'sq'
   - 'sv-SE'
   - 'zh-CN'

--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -15,6 +15,7 @@ locale_grantlist:
   - 'ja'
   - 'nl'
   - 'pt-PT'
+  - 'ru'
   - 'sq'
   - 'sv-SE'
   - 'zh-CN'

--- a/frontend/src/templates/index.mustache
+++ b/frontend/src/templates/index.mustache
@@ -9,6 +9,9 @@
     <meta name="defaultLanguage" content="en-US">
     <meta name="availableLanguages" content="{{{ available_locales }}}">
     <meta name="viewport" content="width=device-width">
+    <!-- Load en-US first as fallback for incomplete locales -->
+    <link rel="localization" href="/static/locales/en-US/app.ftl">
+    <link rel="localization" href="/static/locales/en-US/experiments.ftl">
     <link rel="localization" href="/static/locales/{locale}/app.ftl">
     <link rel="localization" href="/static/locales/{locale}/experiments.ftl">
 


### PR DESCRIPTION
This is a good temporary fix for issue #2249, while waiting for l20n to provide fallback.

Also whitelisting Russian for new experiments, since it's complete.