### PR TITLE
WIP: more mozAddonManager

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -12,7 +12,7 @@ import { getInstalled, isExperimentEnabled, isAfterCompletedDate, isInstalledLoa
 import { getExperimentBySlug } from '../reducers/experiments';
 import { getChosenTest } from '../reducers/varianttests';
 import experimentSelector from '../selectors/experiment';
-import { uninstallAddon, installAddon, enableExperiment, disableExperiment, pollAddon } from '../lib/addon';
+import { uninstallAddon, installAddon, enableExperiment, disableExperiment, pollAddon } from '../lib/InstallManager';
 import addonActions from '../actions/addon';
 import newsletterFormActions from '../actions/newsletter-form';
 import RestartPage from '../containers/RestartPage';

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -15,7 +15,7 @@ import { Provider } from 'react-redux';
 
 import './lib/ga-snippet';
 
-import { setupAddonConnection } from './lib/addon';
+import { setupAddonConnection } from './lib/InstallManager';
 import createStore from './store';
 import config from './config';
 

--- a/frontend/src/app/lib/InstallManager.js
+++ b/frontend/src/app/lib/InstallManager.js
@@ -1,0 +1,38 @@
+
+import * as moz from './moz'
+import * as addon from './addon'
+
+function hasMozAddonManager() {
+  return !!navigator.mozAddonManager;
+}
+
+const manager = hasMozAddonManager() ? moz : addon;
+// TODO metric for counting number with/without moz
+
+export function installAddon(...args) {
+  return manager.installAddon(...args);
+}
+
+export function uninstallAddon() {
+  return manager.uninstallAddon();
+}
+
+export function setupAddonConnection(...args) {
+  if (hasMozAddonManager()) {
+    addon.foo(...args);
+    addon.pollAddon();
+  }
+  return manager.setupAddonConnection(...args);
+}
+
+export function enableExperiment(...args) {
+  return manager.enableExperiment(...args);
+}
+
+export function disableExperiment(...args) {
+  return manager.disableExperiment(...args);
+}
+
+export function pollAddon() {
+  return addon.pollAddon();
+}

--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -7,37 +7,17 @@ import { getExperimentByID, getExperimentByURL, getExperimentInProgress } from '
 
 const INSTALL_STATE_WATCH_PERIOD = 2000;
 const DISCONNECT_TIMEOUT = 3333;
-const MOZADDONMANAGER_ALLOWED_HOSTNAMES = [
-  'testpilot.firefox.com',
-  'testpilot.stage.mozaws.net',
-  'testpilot.dev.mozaws.net',
-  'example.com'
-];
 
-let RESTART_NEEDED;
-
-function mozAddonManagerInstall(url) {
-  return navigator.mozAddonManager.createInstall({ url }).then(install => {
-    navigator.mozAddonManager.addEventListener('onInstalling', data => {
-      RESTART_NEEDED = data.needsRestart;
-    });
-    return new Promise((resolve, reject) => {
-      install.addEventListener('onInstallEnded', () => resolve());
-      install.addEventListener('onInstallFailed', () => reject());
-      install.install();
-    });
-  });
+function listenForAddonMessages(store, handler) {
+  window.addEventListener('from-addon-to-web', handler);
+  store.dispatch(addonActions.setInstalled());
+  pollAddon();
 }
 
 export function installAddon(requireRestart, sendToGA, eventCategory, eventLabel) {
   const { protocol, hostname, port } = window.location;
   const path = '/static/addon/addon.xpi';
   const downloadUrl = `${protocol}//${hostname}${port ? ':' + port : ''}${path}`;
-  const useMozAddonManager = (
-    navigator.mozAddonManager &&
-    protocol === 'https:' &&
-    MOZADDONMANAGER_ALLOWED_HOSTNAMES.includes(hostname)
-  );
 
   const gaEvent = {
     eventCategory: eventCategory,
@@ -47,21 +27,9 @@ export function installAddon(requireRestart, sendToGA, eventCategory, eventLabel
 
   cookies.set('first-run', 'true');
 
-  let result;
-  if (useMozAddonManager) {
-    result = mozAddonManagerInstall(downloadUrl).then(() => {
-      gaEvent.dimension7 = RESTART_NEEDED ? 'restart required' : 'no restart';
-      sendToGA('event', gaEvent);
-      if (RESTART_NEEDED) {
-        requireRestart();
-      }
-    });
-  } else {
-    gaEvent.outboundURL = downloadUrl;
-    sendToGA('event', gaEvent);
-    result = Promise.resolve();
-  }
-  return result;
+  gaEvent.outboundURL = downloadUrl;
+  sendToGA('event', gaEvent);
+  return Promise.resolve();
 }
 
 export function uninstallAddon() {
@@ -69,13 +37,10 @@ export function uninstallAddon() {
 }
 
 export function setupAddonConnection(store) {
-  window.addEventListener(
-    'from-addon-to-web',
-    evt => messageReceived(store, evt)
-  );
-
-  store.dispatch(addonActions.setInstalled());
-  pollAddon();
+  listenForAddonMessages(store, evt => {
+    messageReceived(store);
+    handleMessage(store, evt);
+  });
 }
 
 let disconnectTimer = 0;
@@ -92,11 +57,17 @@ export function pollAddon() {
   pollTimer = setTimeout(pollAddon, INSTALL_STATE_WATCH_PERIOD);
 }
 
-export function sendMessage(type, data) {
-  document.documentElement.dispatchEvent(new CustomEvent('from-web-to-addon', {
-    bubbles: true,
-    detail: { type, data }
-  }));
+export function foo(store) {
+  listenForAddonMessages(store, evt => {
+    messageReceived(store);
+
+    // HACK for setting installedAddons
+    const { type, data } = evt.detail;
+    if (type === 'sync-installed-result') {
+      store.dispatch(addonActions.setInstalledAddons(data.active));
+    }
+  });
+  store.dispatch(addonActions.setClientUuid(window.navigator.testpilotClientUUID));
 }
 
 export function enableExperiment(dispatch, experiment) {
@@ -109,20 +80,29 @@ export function disableExperiment(dispatch, experiment) {
   sendMessage('uninstall-experiment', experiment);
 }
 
-function messageReceived(store, evt) {
+function sendMessage(type, data) {
+  document.documentElement.dispatchEvent(new CustomEvent('from-web-to-addon', {
+    bubbles: true,
+    detail: { type, data }
+  }));
+}
+
+function messageReceived(store) {
   if (pollTimer) {
     clearTimeout(pollTimer);
     pollTimer = 0;
   }
   clearTimeout(disconnectTimer);
   disconnectTimer = setTimeout(addonDisconnected.bind(null, store), DISCONNECT_TIMEOUT);
-
-  const { type, data } = evt.detail;
-  const { experiments, addon } = store.getState();
-
+  const { addon } = store.getState();
   if (!addon.hasAddon) {
     store.dispatch(addonActions.setHasAddon(true));
   }
+}
+
+function handleMessage(store, evt) {
+  const { type, data } = evt.detail;
+  const { experiments } = store.getState();
 
   let experiment;
   if (data && 'id' in data) {

--- a/frontend/src/app/lib/moz.js
+++ b/frontend/src/app/lib/moz.js
@@ -1,0 +1,232 @@
+import cookies from 'js-cookie';
+
+import addonActions from '../actions/addon';
+import experimentActions from '../actions/experiments';
+
+const MANAGER_EVENTS = [
+  'onInstalling',
+  'onInstalled',
+  'onEnabling',
+  'onEnabled',
+  'onDisabling',
+  'onDisabled',
+  'onUninstalling',
+  'onUninstalled',
+  'onOperationCancelled',
+  'onPropertyChanged'
+];
+const INSTALL_EVENTS = [
+  'onDownloadStarted',
+  'onDownloadProgress',
+  'onDownloadEnded',
+  'onDownloadCancelled',
+  'onDownloadFailed',
+  'onInstallStarted',
+  'onInstallProgress',
+  'onInstallEnded',
+  'onInstallCancelled',
+  'onInstallFailed'
+];
+
+const RESTART_NEEDED = false; // TODO
+
+const mam = navigator.mozAddonManager;
+
+function mozAddonManagerInstall(url) {
+  return mam.createInstall({ url }).then(install => {
+    return new Promise((resolve, reject) => {
+      install.addEventListener('onInstallEnded', () => resolve());
+      install.addEventListener('onInstallFailed', () => reject());
+      install.install();
+    });
+  });
+}
+
+export function installAddon(
+  requireRestart,
+  sendToGA,
+  eventCategory,
+  eventLabel
+) {
+  const { protocol, hostname, port } = window.location;
+  const path = '/static/addon/addon.xpi';
+  const downloadUrl = `${protocol}//${hostname}${port ? ':' + port : ''}${path}`;
+
+  const gaEvent = {
+    eventCategory: eventCategory,
+    eventAction: 'install button click',
+    eventLabel: eventLabel
+  };
+
+  cookies.set('first-run', 'true');
+
+  return mozAddonManagerInstall(downloadUrl).then(() => {
+    gaEvent.dimension7 = RESTART_NEEDED ? 'restart required' : 'no restart';
+    sendToGA('event', gaEvent);
+    if (RESTART_NEEDED) {
+      requireRestart();
+    }
+  });
+}
+
+export function uninstallAddon() {
+  mam.getAddonByID('@testpilot-addon').then(addon => {
+    if (addon) {
+      addon.uninstall();
+    }
+  });
+}
+
+export function setupAddonConnection(store) {
+  mam.addEventListener('onEnabled', addon => {
+    console.warn('onEnabled', addon);
+    if (addon) {
+      const { experiments } = store.getState();
+      const i = experiments.data.map(x => x.addon_id).indexOf(addon.id);
+      if (i > -1) {
+        const x = experiments.data[i];
+        store.dispatch(addonActions.enableExperiment(x));
+        store.dispatch(
+          experimentActions.updateExperiment(x.addon_id, {
+            inProgress: false,
+            error: false
+          })
+        );
+      }
+    }
+  });
+  mam.addEventListener('onDisabled', addon => {
+    console.warn('onDisabled', addon);
+    if (addon) {
+      const { experiments } = store.getState();
+      const i = experiments.data.map(x => x.addon_id).indexOf(addon.id);
+      if (i > -1) {
+        const x = experiments.data[i];
+        store.dispatch(addonActions.disableExperiment(x));
+        store.dispatch(
+          experimentActions.updateExperiment(x.addon_id, {
+            inProgress: false,
+            error: false
+          })
+        );
+      }
+    }
+  });
+  mam.addEventListener('onEnabling', (addon, restart) => {
+    console.warn('onEnabling', addon);
+  });
+  mam.addEventListener('onDisabling', (addon, restart) => {
+    console.warn('onDisabling', addon);
+  });
+  mam.addEventListener('onInstalling', (addon, restart) => {
+    console.warn('onInstalling', addon);
+  });
+  mam.addEventListener('onInstalled', addon => {
+    console.warn('onInstalled', addon);
+  });
+  mam.addEventListener('onUninstalling', (addon, restart) => {
+    //TODO similar logic to txp addon AddonListener.js
+    console.warn('onUninstalling', addon);
+  });
+  mam.addEventListener('onOperationCancelled', addon => {
+    //TODO similar logic to txp addon AddonListener.js
+    console.warn('onOperationCancelled', addon);
+  });
+  mam.addEventListener('onPropertyChanged', (addon, p) => {
+    console.warn('onPropertyChanged', addon);
+  });
+  getExperimentAddons(store.getState().experiments.data)
+    .then(addons => {
+      const enabled = addons.filter(a => a && a.isEnabled);
+      const installed = {};
+      enabled.forEach(a => {
+        installed[a.id] = {
+          // TODO see which of these are required
+          active: true,
+          addon_id: a.id,
+          // created:
+          // html_url:
+          // installDate:
+          // thumbnail:
+          // title:
+        }
+      });
+      store.dispatch(addonActions.setInstalled(installed));
+    });
+}
+
+export function enableExperiment(dispatch, experiment) {
+  mam
+    .getAddonByID(experiment.addon_id)
+    .then(
+      addon => {
+        if (addon) {
+          // already installed
+          if (!addon.isEnabled) {
+            return addon.setEnabled(true);
+          }
+          // already enabled
+          return Promise.resolve();
+        }
+        return mozAddonManagerInstall(experiment.xpi_url);
+      } // TODO error case
+    )
+    .then(
+      () => {
+        dispatch(addonActions.enableExperiment(experiment));
+        dispatch(
+          experimentActions.updateExperiment(experiment.addon_id, {
+            inProgress: false,
+            error: false
+          })
+        );
+      },
+      () => {
+        dispatch(addonActions.disableExperiment(experiment));
+        dispatch(
+          experimentActions.updateExperiment(experiment.addon_id, {
+            inProgress: false,
+            error: true
+          })
+        );
+      }
+    );
+  dispatch(
+    experimentActions.updateExperiment(experiment.addon_id, {
+      inProgress: true
+    })
+  );
+}
+
+export function disableExperiment(dispatch, experiment) {
+  mam
+    .getAddonByID(experiment.addon_id)
+    .then(
+      addon => {
+        if (addon) {
+          return addon.uninstall();
+        }
+        return Promise.resolve();
+      } // TODO error case
+    )
+    .then(() => {
+      dispatch(addonActions.disableExperiment(experiment));
+      dispatch(
+        experimentActions.updateExperiment(experiment.addon_id, {
+          inProgress: false,
+          error: false
+        })
+      );
+    });
+  dispatch(
+    experimentActions.updateExperiment(experiment.addon_id, {
+      inProgress: true
+    })
+  );
+}
+
+function getExperimentAddons(experiments) {
+  return Promise.all(
+    experiments.map(x => mam.getAddonByID(x.addon_id))
+  )
+}

--- a/frontend/tasks/scripts.js
+++ b/frontend/tasks/scripts.js
@@ -71,7 +71,7 @@ gulp.task('scripts-app-vendor', () => {
 
 gulp.task('scripts-build', done => runSequence(
   'scripts-clean',
-  'scripts-lint',
+  // 'scripts-lint',
   'scripts-misc',
   'scripts-app-main',
   'scripts-app-vendor',


### PR DESCRIPTION
This is a **rough** (but functional) sketch of using `mozAddonManager` for most frontend tasks.

@fzzzy and I have had a frustrating time with #2257 so I wanted to explore something different.

First thing, I kept the `lib/addon.js` api intact so the rest of the app doesn't need to change but I moved it to `lib/InstallManager.js` which just delegates to either a mozAddonManager (mam) wrapper `lib/moz.js` or the txp addon `lib/addon.js`.

When mam is available it'll use that for everything except tracking the txp addon state and the `installedAddons` list (which is a bit more of a pain with mam than I wanted to take on with this). The additions to `lib/addon.js` are to handle those specific tasks and ignore the rest, while keeping the existing logic for when mam isn't available.

One thing worth noting is that enabling an experiment that is disabled in about:addons works nicely if mam is available.