### PR TITLE
Fixes #2294, #2304 in Doorhanger Close in Settings component

### DIFF
--- a/frontend/src/app/components/Header.js
+++ b/frontend/src/app/components/Header.js
@@ -69,21 +69,6 @@ export default class Header extends React.Component {
     if (this.closeTimer) { clearTimeout(this.closeTimer); }
   }
 
-  // HACK: We want to close the settings menu on any click outside the menu.
-  // However, a manually-attached event listener on document.body seems to fire
-  // the 'close' event before any other clicks register inside the settings
-  // menu. So, here's a kludge to schedule a menu close on any click, but
-  // cancel if the click was inside the menu. Sounds backwards, but it works.
-
-  componentDidMount() {
-    document.body.addEventListener('click', this.close);
-  }
-
-  componentWillUnmount() {
-    if (this.closeTimer) { clearTimeout(this.closeTimer); }
-    document.body.removeEventListener('click', this.close);
-  }
-
   render() {
     return (
       <div>

--- a/frontend/src/app/components/Settings.js
+++ b/frontend/src/app/components/Settings.js
@@ -87,6 +87,22 @@ export default class Settings extends React.Component {
        </div>
     );
   }
+
+  // HACK: We want to close the settings menu on any click outside the menu.
+  // However, a manually-attached event listener on document.body seems to fire
+  // the 'close' event before any other clicks register inside the settings
+  // menu. So, here's a kludge to schedule a menu close on any click, but
+  // cancel if the click was inside the menu. Sounds backwards, but it works.
+
+  componentDidMount() {
+    document.body.addEventListener('click', this.props.close);
+  }
+
+  componentWillUnmount() {
+    if (this.closeTimer) { clearTimeout(this.closeTimer); }
+    document.body.removeEventListener('click', this.props.close);
+  }
+
 }
 
 Settings.propTypes = {

--- a/frontend/test/app/components/Header-test.js
+++ b/frontend/test/app/components/Header-test.js
@@ -54,6 +54,7 @@ describe('app/components/Header', () => {
     });
 
     describe('and showSettings=true', () => {
+      let dom;
       beforeEach(() => {
         subject.setState({ showSettings: true });
       });

--- a/frontend/test/app/components/Header-test.js
+++ b/frontend/test/app/components/Header-test.js
@@ -54,7 +54,6 @@ describe('app/components/Header', () => {
     });
 
     describe('and showSettings=true', () => {
-      let dom;
       beforeEach(() => {
         subject.setState({ showSettings: true });
       });


### PR DESCRIPTION
This commit allows the Settings doorhanger to close on click anywhere outside the Settings component, as expected.