### PR TITLE
Remove 'raw' field from Ping Centre pings

### DIFF
--- a/addon/src/lib/Telemetry.js
+++ b/addon/src/lib/Telemetry.js
@@ -105,7 +105,6 @@ export default class Telemetry {
       os_name: pcPing.environment.system.os.name,
       os_version: pcPing.environment.system.os.version,
       locale: pcPing.environment.settings.locale,
-      raw: JSON.stringify(pcPing),
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'

--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -75,7 +75,6 @@ function experimentPing(event: ExperimentPingData) {
       os_name: pcPing.environment.system.os.name,
       os_version: pcPing.environment.system.os.version,
       locale: pcPing.environment.settings.locale,
-      raw: JSON.stringify(pcPing),
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'


### PR DESCRIPTION
Only potential issue here is that the [corresponding ping-centre PR](https://github.com/mozilla/ping-centre/pull/60) needs to be released before this change. I'll work with the Ping Centre team to orchestrate the change.

Related to #2313 and mozilla/ping-centre#58.