### PR TITLE
add sourcemaps; fixes #1892

### DIFF
--- a/frontend/tasks/scripts.js
+++ b/frontend/tasks/scripts.js
@@ -48,9 +48,9 @@ gulp.task('scripts-watch', () => {
 
 gulp.task('scripts-misc', () => {
   return gulp.src(config.SRC_PATH + 'scripts/**/*')
-    .pipe(gulpif(config.IS_DEBUG, sourcemaps.init({loadMaps: true})))
+    .pipe(sourcemaps.init({loadMaps: true}))
     .pipe(gulpif(!config.IS_DEBUG, uglify()))
-    .pipe(gulpif(config.IS_DEBUG, sourcemaps.write('./')))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest(config.DEST_PATH + 'static/scripts'));
 });
 
@@ -94,10 +94,10 @@ function commonBrowserify(sourceName, b) {
     .bundle()
     .pipe(source(sourceName))
     .pipe(buffer())
-    .pipe(gulpif(config.IS_DEBUG, sourcemaps.init({loadMaps: true})))
+    .pipe(sourcemaps.init({loadMaps: true}))
      // don't uglify in development. eases build chain debugging
     .pipe(gulpif(!config.IS_DEBUG, uglify()))
     .on('error', gutil.log)
-    .pipe(gulpif(config.IS_DEBUG, sourcemaps.write('./')))
+    .pipe(sourcemaps.write('./'))
     .pipe(gulp.dest(config.DEST_PATH + 'static/app/'));
 }


### PR DESCRIPTION
It looks like we specifically avoided generating the sourcemaps in production and I'm not sure why.  I ran this locally and got the sourcemaps, but I'm not sure if we'd have to do anything else to get them out there.

r? @lmorchard at a minimum since I think he wrote the original code

it looks like it generates maps with the hashes in the name (off the JS files with those hashes) but it also generates the files without the hashes.  I'm not sure which one the browser loads and currently the CDN will cache .map files forever.  Happy to add the patch that expires .map files in a reasonable amount of time if needed.