### PR TITLE
2350 reload window on disconnect

### DIFF
--- a/frontend/src/app/lib/addon.js
+++ b/frontend/src/app/lib/addon.js
@@ -78,11 +78,8 @@ export function setupAddonConnection(store) {
 }
 
 let disconnectTimer = 0;
-function addonDisconnected(store) {
-  if (parseFloat(window.navigator.testpilotAddonVersion) > 0.8) {
-    store.dispatch(addonActions.setHasAddon(false));
-    pollAddon();
-  }
+function addonDisconnected() {
+  window.location.reload();
 }
 
 let pollTimer = 0;


### PR DESCRIPTION
This runs everything from scratch, preventing a situation where moving
the test pilot window to a new firefox window would double-poll the
test pilot addon for experiment state, causing infinite reloading