### PR TITLE
Add locales to Snooze Tabs content

### DIFF
--- a/content-src/experiments/snooze-tabs.yaml
+++ b/content-src/experiments/snooze-tabs.yaml
@@ -1,8 +1,7 @@
 id: 10
 title: 'Snooze Tabs'
 slug: snooze-tabs
-locales:
-  - 'en'
+locales: ['en', 'cs', 'de', 'dsb', 'es', 'fr', 'fy', 'hsb', 'hu', 'id', 'it', 'ja', 'kab', 'nl', 'pt', 'ru', 'sk', 'sl', 'sq', 'sv', 'tr', 'zh']
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
 thumbnail: /static/images/experiments/snooze-tabs/icon/thumbnail.png


### PR DESCRIPTION
Snooze Tabs is available in a pile of locales since the last release. This should add the languages. Weird that the YAML key is called "locales" but we only look at languages, though. Been awhile since I looked at this code, so I could be missing something.