### PR TITLE
Switched to shared NewsletterForm in EmailDialog

### DIFF
--- a/frontend/src/app/actions/newsletter-form.js
+++ b/frontend/src/app/actions/newsletter-form.js
@@ -1,7 +1,4 @@
-
-
-export const basketUrl = 'https://basket.mozilla.org/news/subscribe/';
-export const sourceUrl = 'https://testpilot.firefox.com/';
+import { subscribeToBasket } from '../lib/utils';
 
 function makeSimpleActionCreator(type) {
   return (payload) => ({ type, payload });
@@ -15,15 +12,9 @@ const actions = {
   newsletterFormSetSucceeded: makeSimpleActionCreator('NEWSLETTER_FORM_SET_SUCCEEDED')
 };
 
-function newsletterFormSubscribe(dispatch, email, locale) {
+function newsletterFormSubscribe(dispatch, email, source) {
   dispatch(actions.newsletterFormSetSubmitting());
-  fetch(basketUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body: `newsletters=test-pilot&email=${encodeURIComponent(email)}&lang=${encodeURIComponent(locale)}&source_url=${encodeURIComponent(sourceUrl)}`
-  })
+  subscribeToBasket(email, source)
     .then(response => {
       if (response.ok) {
         dispatch(actions.newsletterFormSetSucceeded());

--- a/frontend/src/app/components/NewsletterFooter.js
+++ b/frontend/src/app/components/NewsletterFooter.js
@@ -59,7 +59,7 @@ export default class NewsletterFooter extends React.Component {
           {this.renderError()}
           <LayoutWrapper flexModifier="row-between-breaking">
             {this.renderHeader()}
-          <NewsletterForm {...this.props.newsletterForm} locale={this.props.locale} />
+            <NewsletterForm {...this.props.newsletterForm} />
           </LayoutWrapper>
         </LayoutWrapper>
       </div>
@@ -68,5 +68,5 @@ export default class NewsletterFooter extends React.Component {
 }
 
 NewsletterFooter.propTypes = {
-  locale: PropTypes.string.isRequired
+  getWindowLocation: PropTypes.func.isRequired
 };

--- a/frontend/src/app/components/NewsletterForm.js
+++ b/frontend/src/app/components/NewsletterForm.js
@@ -48,7 +48,7 @@ export default class NewsletterForm extends React.Component {
     return (
       <label className={this.makeRevealedClassNames()} htmlFor={fieldName}>
         <input name={fieldName} type="checkbox" checked={this.props.privacy} required
-               onClick={this.handlePrivacyClick} />
+               onChange={this.handlePrivacyClick} onClick={this.handlePrivacyClick} />
         { this.state.privacyNote ? <span data-l10n-id="newsletterFormPrivacyAgreementRequired" style={{ color: 'red', marginRight: '0.5em' }}></span> : null }
         <span data-l10n-id="newsletterFormPrivacyNotice">
           I'm okay with Mozilla handling by info as explained in
@@ -67,7 +67,7 @@ export default class NewsletterForm extends React.Component {
         </button>
       );
     }
-    return <button data-l10n-id='newsletterFormSubmitButton' className="button outline large">Sign Up Now</button>;
+    return <button data-l10n-id='newsletterFormSubmitButton' className={classnames('button', 'large', this.props.isModal ? 'default' : 'outline')}>Sign Up Now</button>;
   }
 
   renderDisclaimer() {
@@ -85,13 +85,14 @@ export default class NewsletterForm extends React.Component {
       this.setState({ privacyNote: true });
     } else {
       this.setState({ privacyNote: false });
-      this.props.subscribe(this.props.email, this.props.locale);
+      this.props.subscribe(this.props.email);
     }
   }
 
   render() {
     return (
-      <form className='newsletter-form' onSubmit={this.handleSubmit}>
+      <form className={ classnames('newsletter-form', { 'newsletter-form-modal': this.props.isModal }) }
+            onSubmit={this.handleSubmit}>
         {this.renderEmailField()}
         {this.renderPrivacyField()}
         {this.renderSubmitButton()}
@@ -104,8 +105,8 @@ export default class NewsletterForm extends React.Component {
 NewsletterForm.defaultProps = defaultState();
 NewsletterForm.propTypes = {
   email: PropTypes.string.isRequired,
-  locale: PropTypes.string.isRequired,
   privacy: PropTypes.bool.isRequired,
+  isModal: PropTypes.bool,
   subscribe: PropTypes.func,
   setEmail: PropTypes.func,
   setPrivacy: PropTypes.func

--- a/frontend/src/app/components/View.js
+++ b/frontend/src/app/components/View.js
@@ -112,11 +112,6 @@ View.propTypes = {
    */
   centered: PropTypes.bool.isRequired,
 
-  /*
-  * Locale passed in for use in email footer component.
-  */
-  locale: PropTypes.string.isRequired,
-
   /**
    * If true, renders a newsletter subscription form above the footer
    * component. Default: `true`.

--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -124,22 +124,6 @@ function sendToGA(type, dataIn) {
   }
 }
 
-function subscribeToBasket(email, locale, callback) {
-  const url = 'https://basket.mozilla.org/news/subscribe/';
-  fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body: `newsletters=test-pilot&lang=${encodeURIComponent(locale)}&email=${encodeURIComponent(email)}`
-  }).then(callback)
-  .catch(err => {
-    // for now, log the error in the console & do nothing in the UI
-    console && console.error(err); // eslint-disable-line no-console
-  });
-}
-
-
 const mapStateToProps = state => ({
   addon: state.addon,
   experiments: experimentSelector(state),
@@ -185,8 +169,8 @@ const mapDispatchToProps = dispatch => ({
       dispatch(newsletterFormActions.newsletterFormSetEmail(email)),
     setPrivacy: privacy =>
       dispatch(newsletterFormActions.newsletterFormSetPrivacy(privacy)),
-    subscribe: (email, locale) =>
-      dispatch(newsletterFormActions.newsletterFormSubscribe(dispatch, email, locale))
+    subscribe: (email) =>
+      dispatch(newsletterFormActions.newsletterFormSubscribe(dispatch, email, '' + window.location))
   }
 });
 
@@ -198,7 +182,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     installAddon,
     uninstallAddon,
     sendToGA,
-    subscribeToBasket,
     clipboard,
     setPageTitleL10N: (id, args) => {
       if (typeof document === 'undefined') { return; }

--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -2,6 +2,16 @@ import querystring from 'querystring';
 
 import { experimentL10nId, l10nId, l10nIdFormat, lookup } from '../../../tasks/util';
 
+export const basketUrl = 'https://basket.mozilla.org/news/subscribe/';
+
+export function subscribeToBasket(email, source) {
+  const sourceUrl = source || 'https://testpilot.firefox.com/';
+  return fetch(basketUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: `newsletters=test-pilot&email=${encodeURIComponent(email)}&source_url=${encodeURIComponent(sourceUrl)}`
+  });
+}
 
 export function formatDate(date) {
   let out = '';

--- a/frontend/src/styles/components/_NewsletterForm.scss
+++ b/frontend/src/styles/components/_NewsletterForm.scss
@@ -48,3 +48,19 @@
     }
   }
 }
+
+.newsletter-form-modal {
+  input[type='email'] {
+    border: 1px solid $transparent-black-3;
+    // border: 1px solid rgba(0, 0, 0, 0.5);
+  }
+
+  a {
+    color: $default;
+  }
+
+  p.disclaimer {
+    text-align: center;
+    width: 100%;
+  }
+}

--- a/frontend/test/app/actions/newsletter-form-test.js
+++ b/frontend/test/app/actions/newsletter-form-test.js
@@ -3,14 +3,14 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { basketUrl } from '../../../src/app/actions/newsletter-form';
+import { basketUrl } from '../../../src/app/lib/utils';
 
 const FAILED = 'NEWSLETTER_FORM_SET_FAILED';
 const SUBMITTING = 'NEWSLETTER_FORM_SET_SUBMITTING';
 const SUCCEEDED = 'NEWSLETTER_FORM_SET_SUCCEEDED';
 
 const MOCK_EMAIL = 'foo@bar.com';
-const MOCK_LOCALE = 'bz';
+const MOCK_SOURCE = 'https://example.com';
 
 const setUp = responseCode => {
   fetchMock.post(basketUrl, responseCode);
@@ -28,7 +28,7 @@ describe('app/actions/newsletter-form/subscribe', () => {
 
   describe('requests with', () => {
     const { dispatch, subscribe } = setUp(200);
-    subscribe(dispatch, MOCK_EMAIL, MOCK_LOCALE);
+    subscribe(dispatch, MOCK_EMAIL, MOCK_SOURCE);
 
     const url = fetchMock.lastCall(basketUrl)[0];
     const request = fetchMock.lastCall(basketUrl)[1];
@@ -54,8 +54,8 @@ describe('app/actions/newsletter-form/subscribe', () => {
       expect(request.body).to.contain(`email=${encodeURIComponent(MOCK_EMAIL)}`);
     });
 
-    it('the URLencoded locale in the body', () => {
-      expect(request.body).to.contain(`lang=${encodeURIComponent(MOCK_LOCALE)}`);
+    it('has the URL encoded source_url in the body', () => {
+      expect(request.body).to.contain(`source_url=${encodeURIComponent(MOCK_SOURCE)}`);
     });
 
     tearDown();

--- a/frontend/test/app/components/NewsletterFooter-test.js
+++ b/frontend/test/app/components/NewsletterFooter-test.js
@@ -10,6 +10,7 @@ describe('app/components/NewsletterFooter', () => {
 
   const _subject = (form) => {
     const props = {
+      getWindowLocation: sinon.spy(() => 'https://example.com'),
       newsletterForm: {
         subscribe: sinon.spy(),
         setEmail: sinon.spy(),

--- a/frontend/test/app/components/View-test.js
+++ b/frontend/test/app/components/View-test.js
@@ -17,6 +17,7 @@ const mockRequiredProps = {
   uninstallAddon: sinon.spy(),
   sendToGA: sinon.spy(),
   openWindow: sinon.spy(),
+  getWindowLocation: sinon.spy(() => 'https://example.com'),
   newsletterForm: defaultState()
 };
 

--- a/frontend/test/app/containers/ExperimentPage-test.js
+++ b/frontend/test/app/containers/ExperimentPage-test.js
@@ -114,6 +114,7 @@ describe('app/containers/ExperimentPage:ExperimentDetail', () => {
       removeCookie: sinon.spy(),
       userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:51.0) Gecko/20100101 Firefox/51.0',
       newsletterForm: defaultState(),
+      getWindowLocation: sinon.spy(() => 'https://example.com'),
       setPageTitleL10N: sinon.spy()
     };
 

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -73,11 +73,6 @@ notFoundHeader = Four Oh Four!
 [[emailOptIn]]
 emailOptInDialogTitle = Welcome to Test Pilot!
 emailOptInMessage = Find out about new experiments and see test results for experiments you've tried.
-emailValidationError = Please use a valid email address!
-// The ':)' characters in the emailOptInInput placeholder are a smiley face emoticon.
-emailOptInInput
-  .placeholder = email goes here :)
-emailOptInButton = Sign me up
 emailOptInConfirmationTitle = Email Sent
 emailOptInSuccessMessage2 = Thank you!
 emailOptInConfirmationClose = On to the experiments...


### PR DESCRIPTION
- Rework `frontend/src/app/components/EmailDialog` to use
  `NewsletterForm` instead of local form implementation

- Add failure state to `EmailDialog`

- CSS tweaks for `NewsletterForm` when used in a dialog

- Drop lang parameter from Basket POST (#2403)

- Use window.location as source parameter for Basket POST (#2392)

- Move `subscribeToBasket` to shared `app/lib/utils`

- Deleted some now unused strings

- Updated tests to reflect all the above

Fixes #1758.
Fixes #2392.
Fixes #2403.