### PR TITLE
Remove the en and de-DE locales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ media/
 node_modules/
 static/
 tmp/
-locales/en/
-locales/de-DE/
 
 # Files to ignore within specific directories
 addon/*.rdf

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -8,10 +8,9 @@ module.exports = {
   ENABLE_DEV_CONTENT: (process.env.ENABLE_DEV_CONTENT === '1'),
   AVAILABLE_LOCALES: (process.env.ENABLE_DEV_LOCALES === '1') ?
     // All locales on Pontoon for local & dev
-    // en is copied from en-US at build time, so we have to add it special
-    'en,' + fs.readdirSync('./locales').join(',')  :
+    fs.readdirSync('./locales').join(',')  :
     // Enabled locales for stage & production - update as they reach 100%
-    'en-US,en,cs,de,de-DE,dsb,es-ES,es-MX,fr,fy-NL,hsb,hu,it,ja,kab,nl,nn-NO,pt-BR,pt-PT,ru,sk,sq,sr,sv-SE,uk,zh-CN,zh-TW',
+    'en-US,cs,de,dsb,es-ES,es-MX,fr,fy-NL,hsb,hu,it,ja,kab,nl,nn-NO,pt-BR,pt-PT,ru,sk,sq,sr,sv-SE,uk,zh-CN,zh-TW',
 
   // TODO: Move addon build to a better path
   ADDON_SRC_PATH: './addon/',

--- a/frontend/tasks/content.js
+++ b/frontend/tasks/content.js
@@ -22,22 +22,6 @@ gulp.task('content-experiments-data', function generateStaticAPITask() {
     .pipe(gulp.dest(config.DEST_PATH));
 });
 
-// The next two tasks are hacks to copy the en-US locale
-// to an en locale. See issue #2006 for background.
-gulp.task('content-watch-en', () => {
-   gulp.watch('./locales/en-US/**/*', ['content-build-en']);
-});
-
-gulp.task('content-build-en', () => {
-  return gulp.src('./locales/en-US/**/*')
-    .pipe(gulp.dest('./locales/en'));
-});
-
-gulp.task('content-build-de', () => {
-  return gulp.src('./locales/de/**/*')
-    .pipe(gulp.dest('./locales/de-DE'));
-});
-
 gulp.task('import-api-content', (done) => {
   fetch(config.PRODUCTION_EXPERIMENTS_URL)
     .then(response => response.json())

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,8 +34,6 @@ gulp.task('distclean', () => del([
 
 gulp.task('build', done => runSequence(
   'content-build',
-  'content-build-en',
-  'content-build-de',
   'addon-copy-locales',
   'scripts-build',
   'styles-build',
@@ -48,7 +46,6 @@ gulp.task('build', done => runSequence(
 gulp.task('watch', [
   'self-watch',
   'content-watch',
-  'content-watch-en',
   'addon-watch-locales',
   'scripts-watch',
   'styles-watch',


### PR DESCRIPTION
The en and de-DE locales were added in #2149 in order to fix #2017.  The issue was related to the language negotiation done by l20n. It didn't pick en-US nor de for some users.

In #2399 l20n was upgraded to v5.  It uses [fluent-langneg][1] under the hood to conduct the language negotiation.  It now properly selects the best available locale when the user's browser is configured to request de-DE or en.

[1]: https://www.npmjs.com/package/fluent-langneg