### PR TITLE
2434 reinstate loading indicator

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -39,7 +39,7 @@ ONE_YEAR="31536000"
 HPKP="\"Public-Key-Pins\": \"max-age=300;pin-sha256=\\\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\\\";pin-sha256=\\\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\\\";pin-sha256=\\\"YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=\\\";pin-sha256=\\\"sRHdihwgkaib1P1gxX8HFszlD+7/gTfNvuAybgLPNis=\\\";\""
 
 # HACK: If this is changed, be sure to update the CSP constant in frontend/tasks/server.js
-CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'unsafe-inline' 'self' code.cdn.mozilla.net; report-uri /__cspreport__;\""
+CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'self' code.cdn.mozilla.net; report-uri /__cspreport__;\""
 HSTS="\"strict-transport-security\": \"max-age=${ONE_YEAR}; includeSubDomains; preload\""
 TYPE="\"x-content-type-options\": \"nosniff\""
 XSS="\"x-xss-protection\": \"1; mode=block\""
@@ -51,7 +51,7 @@ if [ "$DEST" = "dev" ]; then
     ONE_YEAR="15"
 
     # HACK: If this is changed, be sure to update the CSP constant in frontend/tasks/server.js
-    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'unsafe-inline' 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
+    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;\""
 fi
 
 # build version.json if it isn't provided

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -16,7 +16,7 @@ export default class ExperimentRowCard extends React.Component {
   render() {
     const { hasAddon, experiment, enabled, isAfterCompletedDate } = this.props;
 
-    const { description, title, thumbnail, subtitle, slug } = experiment;
+    const { description, title, subtitle, slug } = experiment;
     const installation_count = (experiment.installation_count) ? experiment.installation_count : 0;
     const isCompleted = isAfterCompletedDate(experiment);
 
@@ -34,14 +34,8 @@ export default class ExperimentRowCard extends React.Component {
           {this.justLaunched() && <div data-l10n-id="experimentListJustLaunchedTab" className="tab just-launched-tab"></div>}
           {this.justUpdated() && <div data-l10n-id="experimentListJustUpdatedTab" className="tab just-updated-tab"></div>}
         </div>
-        <div className="experiment-icon-wrapper"
-          style={{
-            backgroundColor: experiment.gradient_start,
-            backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop})`
-          }}>
-          <div className="experiment-icon" style={{
-            backgroundImage: `url(${thumbnail})`
-          }}></div>
+        <div className={`experiment-icon-wrapper-${experiment.slug} experiment-icon-wrapper`}>
+          <div className={`experiment-icon-${experiment.slug} experiment-icon`}></div>
         </div>
       <div className="experiment-information">
         <header>

--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -92,7 +92,12 @@ class App extends Component {
       locale: (navigator.language || '').split('-')[0]
     });
     this.props.chooseTests();
-    this.props.fetchUserCounts(config.usageCountsURL);
+    this.props.fetchUserCounts(config.usageCountsURL).then(() => {
+      const staticNode = document.getElementById('static-root');
+      if (staticNode) {
+        staticNode.parentNode.removeChild(staticNode);
+      }
+    });
     this.measurePageview();
   }
 

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -323,11 +323,7 @@ export class ExperimentDetail extends React.Component {
           <div id="details">
               <LayoutWrapper helperClass="details-content" flexModifier="details-content">
                 <div className="details-overview">
-                  <div className="experiment-icon-wrapper"
-                       style={{
-                         backgroundColor: `${experiment.gradient_start}`,
-                         backgroundImage: `linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop})`
-                       }}>
+                  <div className={`experiment-icon-wrapper-${experiment.slug} experiment-icon-wrapper`}>
                     <img className="experiment-icon" src={thumbnail}></img>
                   </div>
                   <div className="details-sections">

--- a/frontend/src/styles/modules/_experiment-list.scss
+++ b/frontend/src/styles/modules/_experiment-list.scss
@@ -157,7 +157,6 @@
 
 .experiment-icon-wrapper {
   @include flex-container(row, center, center);
-  background: $transparent-black-2;
   border-radius: $small-border-radius $small-border-radius 0 0;
   box-shadow: 0 -2px 2px $transparent-white-1 inset;
   height: $grid-unit * 7;

--- a/frontend/tasks/content.js
+++ b/frontend/tasks/content.js
@@ -26,6 +26,7 @@ function buildExperimentsData() {
   const index = {results: []};
   const strings = [];
   const counts = {};
+  const cssStrings = [];
 
   function findLocalizableStrings(obj, pieces = [], experiment = null) {
     if (!experiment) {
@@ -62,6 +63,17 @@ function buildExperimentsData() {
       // Exclude dev content if it's not enabled in config
       return cb();
     }
+
+    cssStrings.push(`
+.experiment-icon-wrapper-${experiment.slug} {
+  background-color: ${experiment.gradient_start};
+  background-image: linear-gradient(135deg, ${experiment.gradient_start}, ${experiment.gradient_stop});
+}
+
+.experiment-icon-${experiment.slug} {
+  background-image: url(${experiment.thumbnail});
+}
+`);
 
     // Auto-generate some derivative API values expected by the frontend.
     Object.assign(experiment, {
@@ -101,6 +113,10 @@ function buildExperimentsData() {
     this.push(new gutil.File({
       path: 'api/experiments/usage_counts.json',
       contents: new Buffer(JSON.stringify(counts, null, 2))
+    }));
+    this.push(new gutil.File({
+      path: 'static/styles/experiments.css',
+      contents: new Buffer(cssStrings.join('\n'))
     }));
     cb();
   }

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -9,6 +9,8 @@ const through = require('through2');
 const YAML = require('yamljs');
 const ReactDOMServer = require('react-dom/server');
 
+import Loading from '../src/app/components/Loading';
+
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
@@ -52,7 +54,6 @@ gulp.task('pages-build', [
 ]);
 
 gulp.task('pages-watch', () => {
-  gulp.watch(config.SRC_PATH + 'generate-static-html.js', ['pages-build', 'pages-compiled']);
   gulp.watch(config.SRC_PATH + 'app.js', ['pages-build']);
   gulp.watch([config.SRC_PATH + 'pages/**/*.md'], ['pages-compiled']);
 });
@@ -193,6 +194,7 @@ function generateStaticPage(prepareForClient, pageName, pageParam, component, {
     <meta charSet="utf-8" />
     <link rel="shortcut icon" href="/static/images/favicon.ico" />
     <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
+    <link rel="stylesheet" href="/static/styles/experiments.css" />
     <link rel="stylesheet" href="/static/styles/main.css" />
 
     <meta name="defaultLanguage" content="en-US" />
@@ -216,7 +218,7 @@ function generateStaticPage(prepareForClient, pageName, pageParam, component, {
     <meta name="twitter:image" content={ image_twitter } />
     <meta property="og:url" content="https://testpilot.firefox.com" />
   </head>;
-  const bodyComponent = <div>
+  const bodyComponent = <div id="static-root">
     <noscript>
       <div className="full-page-wrapper centered">
         <div className="layout-wrapper layout-wrapper--column-center">
@@ -235,6 +237,7 @@ function generateStaticPage(prepareForClient, pageName, pageParam, component, {
         </div>
       </div>
     </noscript>
+    <Loading />
     { prepareForClient ? <script src="/static/app/vendor.js"></script> : null }
     { enable_pontoon ? <script src="https://pontoon.mozilla.org/pontoon.js"></script> : null }
   </div>;

--- a/frontend/tasks/server.js
+++ b/frontend/tasks/server.js
@@ -11,7 +11,7 @@ const pcert = fs.readFileSync('./frontend/certs/server/my-server.crt.pem');
 const pca = fs.readFileSync('./frontend/certs/server/my-private-root-ca.crt.pem');
 
 // HACK: CSP copied from bin/deploy.sh
-const CSP = `default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'unsafe-inline' 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;`;
+const CSP = `default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org https://analysis-output.telemetry.mozilla.org; font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__;`;
 
 const serverOptions = {
   root: config.DEST_PATH,


### PR DESCRIPTION
Fix #2434 Reinstate the loading indicator for now.

  - Remove the inline styles on the experiment cards, by creating experiments.css ahead of time from the yaml files

  - Remove the inline styles from the experiment details pages as well.

  - Remove unsafe-inline from the CSP again.