### PR TITLE
Generate a 404 page for use in S3

### DIFF
--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -7,6 +7,7 @@ import Raven from 'raven-js';
 import './lib/ga-snippet';
 import config from './config';
 
+import notfound from '../pages/notfound.js';
 import error from '../pages/error.js';
 import experiment from '../pages/experiment.js';
 import experiments from '../pages/experiments.js';
@@ -20,6 +21,7 @@ es6Promise.polyfill();
 Raven.config(config.ravenPublicDSN).install();
 
 const routes = {
+  notfound,
   error,
   experiment,
   experiments,

--- a/frontend/src/pages/notfound.js
+++ b/frontend/src/pages/notfound.js
@@ -1,0 +1,8 @@
+import React from 'react';
+
+import inject from '../app/lib/inject'
+import NotFoundPage from '../app/containers/NotFoundPage';
+
+export default function create() {
+  return inject('notfound', <NotFoundPage />);
+}

--- a/frontend/tasks/server.js
+++ b/frontend/tasks/server.js
@@ -16,6 +16,7 @@ const CSP = `default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.n
 const serverOptions = {
   root: config.DEST_PATH,
   livereload: false,
+  fallback: './frontend/build/notfound/index.html',
   host: '0.0.0.0',
   port: config.SERVER_PORT,
   middleware: (connect, ops) => [


### PR DESCRIPTION
- Add `notfound` page for generation

- Use `notfound` page as `fallback` in local dev server for 404s

- Requires follow up in S3 settings to use `notfound/index.html` as
  error page.

Fixes #2446