### PR TITLE
Bump line-height in newsletter email input field

### DIFF
--- a/frontend/src/styles/components/_NewsletterForm.scss
+++ b/frontend/src/styles/components/_NewsletterForm.scss
@@ -5,7 +5,7 @@
   button {
     border-radius: $small-border-radius;
     box-shadow: none;
-    line-height: $font-unit * 1.5;
+    line-height: $font-unit * 1.6;
     margin-bottom: $grid-unit * .5;
     padding: ($grid-unit * .75) ($grid-unit * .5);
     width: 100%;


### PR DESCRIPTION
Avoids cutting off '@' character on windows.

Fixes #2443.