### PR TITLE
Fix parameters passed to generateStaticPage() via generateStaticPageFromMarkdown()

### DIFF
--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -278,6 +278,6 @@ function generateStaticPageFromMarkdown(pageName, pageParam, markdown, params) {
   </div>;
 
   return generateStaticPage(
-    false, pageName, pageParam, body, JSON.stringify(markdown), params
+    false, pageName, pageParam, body, params
   );
 }


### PR DESCRIPTION
This ensures `available_locales` makes it into the appropriate header,
which the locale redirect code uses on Markdown pages like /terms

Fixes #2455.