### PR TITLE
Remove remarkable dependency

### DIFF
--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -1,7 +1,6 @@
 const gulp = require('gulp');
 const config = require('../config.js');
 const path = require('path');
-const Remarkable = require('remarkable');
 const fs = require('fs');
 const gutil = require('gulp-util');
 const multiDest = require('gulp-multi-dest');
@@ -13,8 +12,6 @@ import Loading from '../src/app/components/Loading';
 
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
-
-const md = new Remarkable({ html: true });
 
 const THUMBNAIL_FACEBOOK = config.PRODUCTION_URL + '/static/images/thumbnail-facebook.png';
 const THUMBNAIL_TWITTER = config.PRODUCTION_URL + '/static/images/thumbnail-twitter.png';

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "node-sass": "^4.5.0",
     "nyc": "^10.1.2",
     "react-addons-test-utils": "^15.4.2",
-    "remarkable": "1.7.1",
     "require-globify": "^1.4.1",
     "run-sequence": "^1.2.2",
     "sass-lint": "1.10.2",


### PR DESCRIPTION
Turns out, we don't need this dependency anymore.

See also: https://github.com/mozilla/testpilot/issues/2420#issuecomment-302747490