### PR TITLE
Disable Redux logger middleware

### DIFF
--- a/frontend/src/app/store.js
+++ b/frontend/src/app/store.js
@@ -1,6 +1,4 @@
-
 import { applyMiddleware, combineReducers, compose, createStore } from 'redux';
-import createLogger from 'redux-logger';
 import promise from 'redux-promise';
 
 import addonReducer from './reducers/addon';
@@ -42,8 +40,7 @@ export const initialState = {
 export function createMiddleware() {
   return compose(
     applyMiddleware(
-      promise,
-      createLogger()
+      promise
     ),
     (typeof window !== 'undefined' && window.devToolsExtension) ? window.devToolsExtension() : f => f
   );


### PR DESCRIPTION
This thing is noisy on both client-side and during server-side build
process. Since [Redux DevTools][1] is a thing, let's turn off this logger.

[1]: https://github.com/gaearon/redux-devtools