### PR TITLE
Fix #1795 Don't call preventDefault and navigateTo in the onclick handler on card tiles

### DIFF
--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -132,17 +132,14 @@ export default class ExperimentRowCard extends React.Component {
   }
 
   openDetailPage(evt) {
-    const { navigateTo, eventCategory, experiment, sendToGA } = this.props;
+    const { eventCategory, experiment, sendToGA } = this.props;
     const { title } = experiment;
-
-    evt.preventDefault();
 
     sendToGA('event', {
       eventCategory,
       eventAction: 'Open detail page',
       eventLabel: title
     });
-    navigateTo(`/experiments/${experiment.slug}`);
   }
 
 }

--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -131,7 +131,7 @@ export default class ExperimentRowCard extends React.Component {
     return '';
   }
 
-  openDetailPage(evt) {
+  openDetailPage() {
     const { eventCategory, experiment, sendToGA } = this.props;
     const { title } = experiment;
 

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -182,17 +182,14 @@ describe('app/components/ExperimentRowCard', () => {
     expect(findByL10nID('experimentCardManage')).to.have.property('length', 1);
   })
 
-  it('should ping GA and open the detail page when clicked', () => {
+  it('should ping GA when clicked', () => {
     subject.find('.experiment-summary').simulate('click', mockClickEvent);
 
-    expect(mockClickEvent.preventDefault.called).to.be.true;
     expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
       eventCategory: props.eventCategory,
       eventAction: 'Open detail page',
       eventLabel: mockExperiment.title
     }]);
-    expect(props.navigateTo.lastCall.args[0])
-      .to.equal(`/experiments/${mockExperiment.slug}`);
   });
 
   it('should have an anchor component with the right properties', () => {


### PR DESCRIPTION
This allows the native anchor handling behavior to happen, meaning
control-click on windows, command-click on mac, and middle click should
all open the experiment page in a new tab. I tested that command-click
works on the mac.