### PR TITLE
Get system info from a less expensive Telemetry API

### DIFF
--- a/addon/src/lib/Telemetry.js
+++ b/addon/src/lib/Telemetry.js
@@ -15,6 +15,9 @@ import { storage } from 'sdk/simple-storage';
 import {
   TelemetryController
 } from 'resource://gre/modules/TelemetryController.jsm';
+import {
+  TelemetryEnvironment
+} from 'resource://gre/modules/TelemetryEnvironment.jsm';
 
 import type { ReduxStore } from 'testpilot/types';
 
@@ -92,19 +95,17 @@ export default class Telemetry {
   ) {
     // A little work is required to replicate the ping sent to Telemetry
     // via the `submitExternalPing('testpilot', payload, opts)` call:
-    const pcPing = TelemetryController.getCurrentPingData();
-    pcPing.type = 'testpilot';
-    pcPing.payload = payload;
+    const env = TelemetryEnvironment.currentEnvironment;
     const pcPayload = {
       event_type: event,
       object: object,
       client_time: makeTimestamp(time),
       addon_id: self.id,
       addon_version: self.version,
-      firefox_version: pcPing.environment.build.version,
-      os_name: pcPing.environment.system.os.name,
-      os_version: pcPing.environment.system.os.version,
-      locale: pcPing.environment.settings.locale,
+      firefox_version: env.build.version,
+      os_name: env.system.os.name,
+      os_version: env.system.os.version,
+      locale: env.settings.locale,
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'

--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -15,6 +15,9 @@ import { storage } from 'sdk/simple-storage';
 import {
   TelemetryController
 } from 'resource://gre/modules/TelemetryController.jsm';
+import {
+  TelemetryEnvironment
+} from 'resource://gre/modules/TelemetryEnvironment.jsm';
 import { Request } from 'sdk/request';
 
 import type Variants from './variants';
@@ -61,9 +64,7 @@ function experimentPing(event: ExperimentPingData) {
     });
 
     // TODO: DRY up this ping centre code here and in lib/Telemetry.
-    const pcPing = TelemetryController.getCurrentPingData();
-    pcPing.type = 'testpilot';
-    pcPing.payload = payload;
+    const env = TelemetryEnvironment.currentEnvironment;
     const pcPayload = {
       // 'method' is used by testpilot-metrics library.
       // 'event' was used before that library existed.
@@ -71,10 +72,10 @@ function experimentPing(event: ExperimentPingData) {
       client_time: makeTimestamp(parsed.timestamp || timestamp),
       addon_id: subject,
       addon_version: addon.version,
-      firefox_version: pcPing.environment.build.version,
-      os_name: pcPing.environment.system.os.name,
-      os_version: pcPing.environment.system.os.version,
-      locale: pcPing.environment.settings.locale,
+      firefox_version: env.build.version,
+      os_name: env.system.os.name,
+      os_version: env.system.os.version,
+      locale: env.settings.locale,
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'

--- a/addon/test/test-metricsexperiment.js
+++ b/addon/test/test-metricsexperiment.js
@@ -30,17 +30,15 @@ const Services = {
 };
 const storage = {};
 const TelemetryController = {
-  submitExternalPing: sinon.spy(),
-  getCurrentPingData: () => {
-    return {
-      environment: {
-        build: { version: 'environment.build.version' },
-        system: {
-          os: { name: 'system.os.name', version: 'system.os.version' }
-        },
-        settings: { locale: 'en-US' }
-      }
-    };
+  submitExternalPing: sinon.spy()
+};
+const TelemetryEnvironment = {
+  currentEnvironment: {
+    build: { version: 'environment.build.version' },
+    system: {
+      os: { name: 'system.os.name', version: 'system.os.version' }
+    },
+    settings: { locale: 'en-US' }
   }
 };
 
@@ -60,6 +58,10 @@ const Experiment = proxyquire('../src/lib/metrics/experiment', {
   'sdk/simple-storage': { storage, '@noCallThru': true },
   'resource://gre/modules/TelemetryController.jsm': {
     TelemetryController,
+    '@noCallThru': true
+  },
+  'resource://gre/modules/TelemetryEnvironment.jsm': {
+    TelemetryEnvironment,
     '@noCallThru': true
   }
 }).default;

--- a/flow-typed/sdk.js
+++ b/flow-typed/sdk.js
@@ -427,7 +427,6 @@ declare module 'resource://gre/modules/TelemetryController.jsm' {
   declare module.exports: {
     TelemetryController: {
       Constants: Object,
-      getCurrentPingData: any,
       // observe: (subject: string, topic: string, data: any) => any,
       submitExternalPing: (type: string, payload: Object, options?: {
         addClientId?: boolean,
@@ -435,6 +434,31 @@ declare module 'resource://gre/modules/TelemetryController.jsm' {
         overrideEnvironment?: Object
       }) => Promise<string>
       // TODO
+    }
+  }
+}
+
+declare module 'resource://gre/modules/TelemetryEnvironment.jsm' {
+  declare module.exports: {
+    TelemetryEnvironment: {
+      currentEnvironment: {
+        addons: any,
+        build: {
+          version: string,
+        },
+        experiments: any,
+        partner: any,
+        profile: any,
+        settings: {
+          locale: string
+        },
+        system: {
+          os: {
+            name: string,
+            version: string
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #2422.

See #2422 and the linked [bugzilla bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1360702) for background info.

Per [the last comment](https://github.com/mozilla/testpilot/issues/2422#issuecomment-301232382) in 2422, I'm not caching the value of `TelemetryEnvironment.currentEnvironment`, but just re-fetching it with each ping.

I haven't yet figured out how to A/B test performance profiles to verify that this fixes the bug, but the commenters in the bug seemed confident that this change would greatly reduce the amount of work done with each ping submission.