### PR TITLE
Fix for addon bundle under windows

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -56,7 +56,7 @@
   "scripts": {
     "bash": "bash",
     "format": "prettier --parser flow --single-quote --write 'data/*.js' 'tools/**/*.js' 'test/*.js' 'src/**/*.js'",
-    "bundle": "cd ..; npm run addon:locales; cd addon/src; cross-env NODE_ENV=production webpack; cd ..;",
+    "bundle": "cd .. && npm run addon:locales && cd addon/src && cross-env NODE_ENV=production webpack && cd ..",
     "start": "npm run bundle && jpm post --post-url http://127.0.0.1:8888",
     "package": "npm run bundle && jpm xpi && mv testpilot-addon.xpi addon.xpi && mv @testpilot-addon-$npm_package_version.update.rdf update.rdf",
     "package-win": "npm run bundle && jpm xpi && move testpilot-addon.xpi addon.xpi && move @testpilot-addon-%npm_package_version%.update.rdf update.rdf",


### PR DESCRIPTION
Turns out that `&&` works in npm scripts under Windows, but `; ` doesn't