### PR TITLE
Add annotation to indicate CSRF token isnt needed

### DIFF
--- a/frontend/src/app/components/NewsletterForm.js
+++ b/frontend/src/app/components/NewsletterForm.js
@@ -92,7 +92,7 @@ export default class NewsletterForm extends React.Component {
   render() {
     return (
       <form className={ classnames('newsletter-form', { 'newsletter-form-modal': this.props.isModal }) }
-            onSubmit={this.handleSubmit}>
+            onSubmit={this.handleSubmit} data-no-csrf>
         {this.renderEmailField()}
         {this.renderPrivacyField()}
         {this.renderSubmitButton()}


### PR DESCRIPTION
This is to indicate to the ZAP baseline scan (and any other tools) that a CSRF token is not needed on this form. This is an approach we've used in AMO (https://github.com/mozilla/addons-server/pull/4235/files)
r? @relud 