### PR TITLE
Added config to test 3 versions of firefox

### DIFF
--- a/bin/circleci/run-integration-tests.sh
+++ b/bin/circleci/run-integration-tests.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 end=$((SECONDS+60))
 
+npm run content
 npm start &
 STATIC_SERVER_PID=$!
-
 # Wait until the server is available...
 while [ $SECONDS != $end ]; do
   curl --output /dev/null --silent --head --fail -k https://example.com:8000;

--- a/bin/circleci/test-firefox-dev.sh
+++ b/bin/circleci/test-firefox-dev.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mozdownload --version latest-beta --destination firefox_dev.tar.bz2
+mozinstall firefox_dev.tar.bz2
+firefox --version
+tox

--- a/bin/circleci/test-firefox-nightly.sh
+++ b/bin/circleci/test-firefox-nightly.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mozdownload --version latest --type daily --destination firefox_nightly.tar.bz2
+mozinstall firefox_nightly.tar.bz2
+firefox --version
+tox

--- a/bin/circleci/test-firefox-release.sh
+++ b/bin/circleci/test-firefox-release.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+mozdownload --version latest --destination firefox.tar.bz2
+mozinstall firefox.tar.bz2
+firefox --version
+tox

--- a/circle.yml
+++ b/circle.yml
@@ -27,18 +27,17 @@ dependencies:
 
 test:
   pre:
-    - mozdownload --version latest --destination firefox.tar.bz2
-    - mozinstall firefox.tar.bz2
     - curl -L -o geckodriver.tar.gz `curl -s 'https://api.github.com/repos/mozilla/geckodriver/releases/latest' | python -c "import sys, json; r = json.load(sys.stdin); print([a for a in r['assets'] if 'linux64' in a['name']][0]['browser_download_url']);"`
     - gunzip -c geckodriver.tar.gz | tar xopf -
     - chmod +x geckodriver
     - sudo mv geckodriver /home/ubuntu/bin
-    - firefox --version
     - geckodriver --version
   override:
     - ./bin/circleci/test-addon.sh
     - ./bin/circleci/test-frontend.sh
-    - tox
+    - sh ./bin/circleci/test-firefox-release.sh
+    - sh ./bin/circleci/test-firefox-dev.sh
+    - sh ./bin/circleci/test-firefox-nightly.sh
   post:
     - bash <(curl -s https://codecov.io/bash)
 

--- a/frontend/test/ui/test_homepage.py
+++ b/frontend/test/ui/test_homepage.py
@@ -22,14 +22,14 @@ def test_install_button_loads(base_url, selenium):
 
 @pytest.mark.nondestructive
 def test_number_of_experiments(base_url, selenium):
-    """Test current number experiments"""
+    """Test current number of experiments"""
     page = Home(selenium, base_url).open()
     url = '{0}/{1}'.format(base_url, 'api/experiments.json')
     # Ping api to get current number of completed experiments
     data = requests.get(url, verify=False).json()
     completed_experiments = len(
         [value for value in data['results'] if 'completed' in value and
-            value['completed'] < str(datetime.utcnow())])
+         value['completed'] < str(datetime.utcnow())])
     # Subtract 1 from the experiments found through the api due to locale
     assert len(page.body.experiments) == int(
         len(data['results']) - completed_experiments) - 1


### PR DESCRIPTION
This allows us to run the integration tests against Release, dev, and nightly. Adds about 3-3:30 to total ci run time.