### PR TITLE
Stop calling getCurrentPingData when sending pings (#2422)

### DIFF
--- a/addon/src/lib/Telemetry.js
+++ b/addon/src/lib/Telemetry.js
@@ -15,6 +15,9 @@ import { storage } from 'sdk/simple-storage';
 import {
   TelemetryController
 } from 'resource://gre/modules/TelemetryController.jsm';
+import {
+  TelemetryEnvironment
+} from 'resource://gre/modules/TelemetryEnvironment.jsm';
 
 import type { ReduxStore } from 'testpilot/types';
 
@@ -61,7 +64,7 @@ export default class Telemetry {
       addEnvironment: true
     });
 
-    this.sendPingCentreEvent(object, event, time, payload);
+    this.sendPingCentreEvent(object, event, time);
 
     this.sendGAEvent({
       t: 'event',
@@ -87,24 +90,21 @@ export default class Telemetry {
   sendPingCentreEvent(
     object: any,
     event: string,
-    time?: number,
-    payload: Object
+    time?: number
   ) {
     // A little work is required to replicate the ping sent to Telemetry
     // via the `submitExternalPing('testpilot', payload, opts)` call:
-    const pcPing = TelemetryController.getCurrentPingData();
-    pcPing.type = 'testpilot';
-    pcPing.payload = payload;
+    const environment = TelemetryEnvironment.currentEnvironment;
     const pcPayload = {
       event_type: event,
       object: object,
       client_time: makeTimestamp(time),
       addon_id: self.id,
       addon_version: self.version,
-      firefox_version: pcPing.environment.build.version,
-      os_name: pcPing.environment.system.os.name,
-      os_version: pcPing.environment.system.os.version,
-      locale: pcPing.environment.settings.locale,
+      firefox_version: environment.build.version,
+      os_name: environment.system.os.name,
+      os_version: environment.system.os.version,
+      locale: environment.settings.locale,
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'

--- a/addon/src/lib/metrics/experiment.js
+++ b/addon/src/lib/metrics/experiment.js
@@ -15,6 +15,9 @@ import { storage } from 'sdk/simple-storage';
 import {
   TelemetryController
 } from 'resource://gre/modules/TelemetryController.jsm';
+import {
+  TelemetryEnvironment
+} from 'resource://gre/modules/TelemetryEnvironment.jsm';
 import { Request } from 'sdk/request';
 
 import type Variants from './variants';
@@ -61,9 +64,7 @@ function experimentPing(event: ExperimentPingData) {
     });
 
     // TODO: DRY up this ping centre code here and in lib/Telemetry.
-    const pcPing = TelemetryController.getCurrentPingData();
-    pcPing.type = 'testpilot';
-    pcPing.payload = payload;
+    const environment = TelemetryEnvironment.currentEnvironment;
     const pcPayload = {
       // 'method' is used by testpilot-metrics library.
       // 'event' was used before that library existed.
@@ -71,10 +72,10 @@ function experimentPing(event: ExperimentPingData) {
       client_time: makeTimestamp(parsed.timestamp || timestamp),
       addon_id: subject,
       addon_version: addon.version,
-      firefox_version: pcPing.environment.build.version,
-      os_name: pcPing.environment.system.os.name,
-      os_version: pcPing.environment.system.os.version,
-      locale: pcPing.environment.settings.locale,
+      firefox_version: environment.build.version,
+      os_name: environment.system.os.name,
+      os_version: environment.system.os.version,
+      locale: environment.settings.locale,
       // Note: these two keys are normally inserted by the ping-centre client.
       client_id: ClientID.getCachedClientID(),
       topic: 'testpilot'

--- a/addon/test/test-metricsexperiment.js
+++ b/addon/test/test-metricsexperiment.js
@@ -30,17 +30,15 @@ const Services = {
 };
 const storage = {};
 const TelemetryController = {
-  submitExternalPing: sinon.spy(),
-  getCurrentPingData: () => {
-    return {
-      environment: {
-        build: { version: 'environment.build.version' },
-        system: {
-          os: { name: 'system.os.name', version: 'system.os.version' }
-        },
-        settings: { locale: 'en-US' }
-      }
-    };
+  submitExternalPing: sinon.spy()
+};
+const TelemetryEnvironment = {
+  currentEnvironment: {
+    build: { version: 'environment.build.version' },
+    system: {
+      os: { name: 'system.os.name', version: 'system.os.version' }
+    },
+    settings: { locale: 'en-US' }
   }
 };
 
@@ -60,6 +58,10 @@ const Experiment = proxyquire('../src/lib/metrics/experiment', {
   'sdk/simple-storage': { storage, '@noCallThru': true },
   'resource://gre/modules/TelemetryController.jsm': {
     TelemetryController,
+    '@noCallThru': true
+  },
+  'resource://gre/modules/TelemetryEnvironment.jsm': {
+    TelemetryEnvironment,
     '@noCallThru': true
   }
 }).default;

--- a/flow-typed/sdk.js
+++ b/flow-typed/sdk.js
@@ -427,6 +427,14 @@ declare module 'resource://gre/modules/TelemetryController.jsm' {
   }
 }
 
+declare module 'resource://gre/modules/TelemetryEnvironment.jsm' {
+  declare module.exports: {
+    TelemetryEnvironment: {
+      currentEnvironment: Object
+    }
+  }
+}
+
 declare module 'resource://gre/modules/ClientID.jsm' {
   declare module.exports: {
     ClientID: any


### PR DESCRIPTION
I ran into this again due to [bug 1369594](https://bugzilla.mozilla.org/show_bug.cgi?id=1369594), so I figured I'd write a patch to switch the code away from calling getCurrentPingData() to instead directly fetch the environment from TelemetryEnvironment.

I've never used flow before, so I just guessed at what the definition for TelemetryEnvironment should look like.