### PR TITLE
Do not re-build static site for every integration test run

### DIFF
--- a/bin/circleci/run-integration-tests.sh
+++ b/bin/circleci/run-integration-tests.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 end=$((SECONDS+60))
 
-npm run content
-npm start &
+npm run server &
 STATIC_SERVER_PID=$!
 # Wait until the server is available...
 while [ $SECONDS != $end ]; do

--- a/bin/circleci/test-firefox-dev.sh
+++ b/bin/circleci/test-firefox-dev.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 mozdownload --version latest-beta --destination firefox_dev.tar.bz2
 mozinstall firefox_dev.tar.bz2
 firefox --version

--- a/bin/circleci/test-firefox-nightly.sh
+++ b/bin/circleci/test-firefox-nightly.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 mozdownload --version latest --type daily --destination firefox_nightly.tar.bz2
 mozinstall firefox_nightly.tar.bz2
 firefox --version

--- a/bin/circleci/test-firefox-release.sh
+++ b/bin/circleci/test-firefox-release.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -ex
+
 mozdownload --version latest --destination firefox.tar.bz2
 mozinstall firefox.tar.bz2
 firefox --version

--- a/bin/circleci/test-frontend.sh
+++ b/bin/circleci/test-frontend.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -ex
 
-# build experiments.json
-npm run content
-
 npm run lint
 npm run l10n:check
 npm run flow

--- a/circle.yml
+++ b/circle.yml
@@ -24,6 +24,8 @@ dependencies:
     - google-chrome --version
     - ./bin/circleci/install-node-dependencies.sh
     - ./bin/circleci/build-addon.sh
+    - ./bin/circleci/build-version-json.sh
+    - ./bin/circleci/build-frontend.sh
 
 test:
   pre:
@@ -47,8 +49,6 @@ deployment:
     branch:
       - master
     commands:
-      - ./bin/circleci/build-version-json.sh
-      - ./bin/circleci/build-frontend.sh
       - TESTPILOT_BUCKET=testpilot.dev.mozaws.net ./bin/deploy.sh dev
       - aws configure set preview.cloudfront true
       - aws cloudfront create-invalidation --distribution-id E2ERG47PHCWD0Z --paths '/*'


### PR DESCRIPTION
- Build the site earlier, reuse the result in tests

- Add `set -ex` to test scripts to echo commands & fail fast

Fixes #2525