### PR TITLE
Temporarily remove integration tests until stabilized/sped up (connected to #2536).

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -37,9 +37,6 @@ test:
   override:
     - ./bin/circleci/test-addon.sh
     - ./bin/circleci/test-frontend.sh
-    - sh ./bin/circleci/test-firefox-release.sh
-    - sh ./bin/circleci/test-firefox-dev.sh
-    - sh ./bin/circleci/test-firefox-nightly.sh
   post:
     - bash <(curl -s https://codecov.io/bash)
 


### PR DESCRIPTION
I just had [another build](https://circleci.com/gh/mozilla/testpilot/4543) take 20 minutes before timing out. Let's pull back these tests until they're quicker and more stable.