### PR TITLE
Do not copy ui-tests.html to CIRCLE_ARTIFACTS if it has not been generated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,7 +39,8 @@ test:
     - ./bin/circleci/test-frontend.sh
   post:
     - bash <(curl -s https://codecov.io/bash)
-    - cp ui-tests.html $CIRCLE_ARTIFACTS
+    - >
+      [ -e ui-tests.html ] && cp ui-tests.html $CIRCLE_ARTIFACTS || echo 'No ui-tests.html'
 
 deployment:
   static_development:


### PR DESCRIPTION
Looks like this little bit breaks master branch tests after integration tests were disabled