### PR TITLE
WIP: Turn integration tests back on for dev and nightly Firefox

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,8 +33,8 @@ test:
     - ./bin/circleci/test-frontend.sh
     - tox -e flake8
     - ./bin/circleci/test-firefox-release.sh
-    # - ./bin/circleci/test-firefox-dev.sh
-    # - ./bin/circleci/test-firefox-nightly.sh
+    - ./bin/circleci/test-firefox-dev.sh
+    - ./bin/circleci/test-firefox-nightly.sh
   post:
     - bash <(curl -s https://codecov.io/bash)
     - cp ui-tests.html $CIRCLE_ARTIFACTS


### PR DESCRIPTION
With recent changes, it looks like [the tests run in just shy of 10 minutes](https://circleci.com/gh/mozilla/testpilot/4589) with all 3 versions of Firefox turned on. Maybe let's see if that's a stable notion and/or if there are more improvements to make on this branch?

Looks like the biggest time sinks right now are building the static site and the integration tests themselves. We're caching firefox downloads, so that's no longer an issue

connected to Issue #2536 