### PR TITLE
[TXP-27] Add feedback buttons to experiment cards

### DIFF
--- a/frontend/src/images/feedback.svg
+++ b/frontend/src/images/feedback.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="15px" height="13px" viewBox="0 0 15 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 44.1 (41455) - http://www.bohemiancoding.com/sketch -->
+    <title>Combined Shape</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <filter x="-5.3%" y="-13.2%" width="110.6%" height="136.8%" filterUnits="objectBoundingBox" id="filter-1">
+            <feOffset dx="0" dy="1" in="SourceAlpha" result="shadowOffsetOuter1"></feOffset>
+            <feGaussianBlur stdDeviation="1" in="shadowOffsetOuter1" result="shadowBlurOuter1"></feGaussianBlur>
+            <feColorMatrix values="0 0 0 0 0   0 0 0 0 0   0 0 0 0 0  0 0 0 0.2 0" type="matrix" in="shadowBlurOuter1" result="shadowMatrixOuter1"></feColorMatrix>
+            <feMerge>
+                <feMergeNode in="shadowMatrixOuter1"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+    </defs>
+    <g id="Feedback" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="1.0-Feedback-button-for-doorhanger_final" transform="translate(-690.000000, -401.000000)" fill="#FFFFFF">
+            <g id="Feedback-icon" transform="translate(688.000000, 397.000000)">
+                <g id="Group" filter="url(#filter-1)">
+                    <path d="M12.2740682,13.1932944 C11.4252321,13.6839061 10.3992412,13.9707584 9.29417141,13.9707584 C6.37028128,13.9707584 4,11.9625858 4,9.48537922 C4,7.00817268 6.37028128,5 9.29417141,5 C12.2180615,5 14.5883428,7.00817268 14.5883428,9.48537922 C14.5883428,10.3282478 14.3139358,11.1168163 13.8366818,11.7904573 L14.4143683,14 L12.2740682,13.1932944 Z M6.29074724,10.2329424 C6.71246217,10.2329424 7.05432966,9.89824697 7.05432966,9.48537922 C7.05432966,9.07251146 6.71246217,8.73781601 6.29074724,8.73781601 C5.86903232,8.73781601 5.52716483,9.07251146 5.52716483,9.48537922 C5.52716483,9.89824697 5.86903232,10.2329424 6.29074724,10.2329424 Z M9.3450769,10.2329424 C9.76679182,10.2329424 10.1086593,9.89824697 10.1086593,9.48537922 C10.1086593,9.07251146 9.76679182,8.73781601 9.3450769,8.73781601 C8.92336198,8.73781601 8.58149449,9.07251146 8.58149449,9.48537922 C8.58149449,9.89824697 8.92336198,10.2329424 9.3450769,10.2329424 Z M12.3994066,10.2329424 C12.8211215,10.2329424 13.162989,9.89824697 13.162989,9.48537922 C13.162989,9.07251146 12.8211215,8.73781601 12.3994066,8.73781601 C11.9776916,8.73781601 11.6358241,9.07251146 11.6358241,9.48537922 C11.6358241,9.89824697 11.9776916,10.2329424 12.3994066,10.2329424 Z" id="Combined-Shape"></path>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/frontend/src/styles/_variables.scss
+++ b/frontend/src/styles/_variables.scss
@@ -88,6 +88,10 @@ $bright-blue: #1e98f5;
 $dark-over-darkest-blue: #163875;
 $dark-over-darkest-blue-highlight: #0a75ba;
 
+// feedback button blue
+$feedback-button-blue: #0a84ff;
+$feedback-button-shadow: #0060df;
+
 // End-of-life (eol) oranges
 $eol-dark-orange: #f46323;
 $eol-orange: #ff9300;

--- a/frontend/src/styles/modules/_experiment-list.scss
+++ b/frontend/src/styles/modules/_experiment-list.scss
@@ -39,9 +39,40 @@
   }
 
   header {
-    @include flex-container(column, space-between, flex-start);
+    @include flex-container(row, space-between, flex-start);
     margin-bottom: $grid-unit * .5;
     width: 100%;
+  }
+
+  header > div {
+    @include flex-container(column, space-between, flex-start);
+  }
+
+  .experiment-feedback {
+    background-color: $feedback-button-blue;
+    background-image: url('../images/feedback.svg');
+    background-position: 4px 4px;
+    background-repeat: no-repeat;
+    background-size: 14px;
+    border: 1px solid $feedback-button-blue;
+    border-radius: 3px;
+    box-shadow: 0 1px 2px $feedback-button-shadow;
+    color: $white;
+    cursor: pointer;
+    display: block;
+    float: right;
+    font-size: 10px;
+    line-height: 12px;
+    padding: 4px 4px 4px 22px;
+
+    &:hover,
+    &:focus {
+      background-color: darken($feedback-button-blue, 4);
+    }
+
+    &:active {
+      background-color: darken($feedback-button-blue, 6);
+    }
   }
 
   h3 {

--- a/frontend/test/app/components/ExperimentRowCard-test.js
+++ b/frontend/test/app/components/ExperimentRowCard-test.js
@@ -82,6 +82,25 @@ describe('app/components/ExperimentRowCard', () => {
     expect(subject.find('.enabled-tab')).to.have.property('length', 1);
   });
 
+  it('should display a feedback button if the experiment is enabled', () => {
+    expect(subject.find('.experiment-feedback')).to.have.property('length', 0);
+
+    subject.setProps({ enabled: true });
+
+    expect(subject.find('.experiment-feedback')).to.have.property('length', 1);
+  });
+
+  it('should ping GA when feedback is clicked', () => {
+    subject.setProps({ enabled: true });
+    subject.find('.experiment-feedback').simulate('click', mockClickEvent);
+
+    expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: props.eventCategory,
+      eventAction: 'Give Feedback',
+      eventLabel: mockExperiment.title
+    }]);
+  });
+
   it('should display "just launched" banner if created date within 2 weeks, never seen, and not enabled', () => {
     expect(subject.find('.experiment-summary').hasClass('just-launched')).to.be.false;
     expect(subject.find('.just-launched-tab')).to.have.property('length', 0);
@@ -182,7 +201,7 @@ describe('app/components/ExperimentRowCard', () => {
     expect(findByL10nID('experimentCardManage')).to.have.property('length', 1);
   })
 
-  it('should ping GA when clicked', () => {
+  it('should ping GA when manage is clicked', () => {
     subject.find('.experiment-summary').simulate('click', mockClickEvent);
 
     expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {

--- a/frontend/test/ui/pages/desktop/home.py
+++ b/frontend/test/ui/pages/desktop/home.py
@@ -45,7 +45,7 @@ class Home(Base):
         class Experiments(Region):
             """Represents the experiments region"""
             _name_locator = (By.CSS_SELECTOR, '.experiment-information > \
-                             header > h3')
+                             header > div > h3')
 
             @property
             def name(self):

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -94,6 +94,8 @@ experimentListHeader = Pick your experiments!
 
 // An individual experiment in the listing of all Test Pilot experiments.
 [[experimentCard]]
+// Small button on experiment card that links to a survey for feedback submission
+experimentCardFeedback = Feedback
 experimentCardManage = Manage
 experimentCardGetStarted = Get Started
 experimentCardLearnMore = Learn More


### PR DESCRIPTION
Think I have a good first stab at adding the feedback button, including metrics and l10n and all that fun stuff. Some remaining questions:

- [x] Needs a hover state? (/cc @johngruen)

Also added a React Storybook install here. Not perfect, but you should be able to see what it's about like so:

* Start a dev server like usual with `npm start`
* In a second shell, start Storybook with `npm run storybook`
* Visit http://localhost:6006/ to hopefully see this:

![capture](https://user-images.githubusercontent.com/21687/27490333-e249e04c-580b-11e7-8c5f-f36a3309b39e.PNG)
