### PR TITLE
Enable React Storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+
+import '@storybook/addon-actions/register';
+import '@storybook/addon-links/register';

--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -2,3 +2,4 @@
 
 import '@storybook/addon-actions/register';
 import '@storybook/addon-links/register';
+import '@storybook/addon-knobs/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,0 +1,9 @@
+/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+
+import { configure } from '@storybook/react';
+
+function loadStories() {
+  require('../stories');
+}
+
+configure(loadStories, module);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved, import/extensions */
+import 'l20n';
 
 import { configure } from '@storybook/react';
 

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,22 @@
+
+    <meta charSet="utf-8" />
+
+    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
+
+    <meta name="defaultLanguage" content="en-US" />
+    <meta name="availableLanguages" content="en-US,cs,de,dsb,es-ES,es-MX,fr,fy-NL,hsb,hu,it,ja,kab,nl,nn-NO,pt-BR,pt-PT,ru,sk,sl,sq,sr,sv-SE,uk,zh-CN,zh-TW" />
+    <link rel="localization" href="/static/locales/{locale}/app.ftl" />
+    <link rel="localization" href="/static/locales/{locale}/experiments.ftl" />
+
+    <script type="text/javascript">
+      document.addEventListener('DOMContentLoaded', function () {
+
+        // HACK: Intercept all clicks and prevent default to disable link clicks
+        // navigating away from storybook iframe
+        document.body.addEventListener('click', function (ev) {
+          console.log('click', ev.target, ev);
+          ev.preventDefault();
+        }, false);
+
+      });
+    </script>

--- a/frontend/tasks/server.js
+++ b/frontend/tasks/server.js
@@ -24,17 +24,23 @@ const serverOptions = {
     (req, res, next) => {
       const parsed = url.parse(req.url);
       const { pathname } = parsed;
+
       // If no dot and trailing slash, try rewriting
       if (pathname.indexOf('.') === -1 &&
           pathname.substring(pathname.length - 1) !== '/') {
         parsed.pathname = pathname + '/index.html';
         req.url = url.format(parsed);
       }
+
+      // Skip CSP for storybook
+      if (pathname.indexOf('.storybook')) { return next(); }
+
       // Rewrite /static/addon/latest to /static/addon/addon.xpi
       if (pathname === '/static/addon/latest') {
         parsed.pathname = '/static/addon/addon.xpi';
         req.url = url.format(parsed);
       }
+
       res.setHeader('content-security-policy', CSP);
       next();
     }

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
     "try-require": "1.2.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0",
-    "yamljs": "0.2.8"
+    "yamljs": "0.2.8",
+    "@storybook/react": "^3.1.5"
   },
   "directories": {
     "doc": "docs"
@@ -125,6 +126,8 @@
     "coverage": "cross-env NODE_ENV=test nyc mocha --recursive --require frontend/test-setup.js frontend/test",
     "flow-coverage": "cd frontend && flow-coverage-report --threshold 60 -i 'src/**/*.js' -t html -o coverage/flow",
     "addon:locales": "gulp addon-copy-locales",
-    "content": "gulp content-build"
+    "content": "gulp content-build",
+    "storybook": "start-storybook -p 6006",
+    "build-storybook": "build-storybook"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
     "tos-pp": "https://github.com/mozilla/legal-docs.git"
   },
   "devDependencies": {
+    "@storybook/addon-knobs": "^3.1.5",
+    "@storybook/react": "^3.1.5",
     "babel-core": "6.24.0",
     "babel-eslint": "7.1.1",
     "babel-plugin-istanbul": "4.0.0",
@@ -96,8 +98,7 @@
     "try-require": "1.2.1",
     "vinyl-buffer": "1.0.0",
     "vinyl-source-stream": "1.1.0",
-    "yamljs": "0.2.8",
-    "@storybook/react": "^3.1.5"
+    "yamljs": "0.2.8"
   },
   "directories": {
     "doc": "docs"
@@ -127,7 +128,7 @@
     "flow-coverage": "cd frontend && flow-coverage-report --threshold 60 -i 'src/**/*.js' -t html -o coverage/flow",
     "addon:locales": "gulp addon-copy-locales",
     "content": "gulp content-build",
-    "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "storybook": "start-storybook -s ./frontend/build -p 6006",
+    "build-storybook": "build-storybook -o ./frontend/build/.storybook"
   }
 }

--- a/stories/app/components/ExperimentRowCard-story.js
+++ b/stories/app/components/ExperimentRowCard-story.js
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { withKnobs, object, boolean } from '@storybook/addon-knobs';
+
+import ExperimentRowCard from '../../../frontend/src/app/components/ExperimentRowCard';
+import LayoutWrapper from '../../../frontend/src/app/components/LayoutWrapper';
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+const ONE_WEEK = 7 * ONE_DAY;
+
+const experiment = {
+  title: 'Sample experiment',
+  description: 'This is an example experiment',
+  subtitle: '',
+  slug: 'snooze-tabs',
+  survey_url: 'https://example.com',
+  installation_count: '86753',
+  created: '2010-06-21T12:12:12Z',
+  modified: '2010-06-21T12:12:12Z'
+};
+
+const baseProps = {
+  hasAddon: false,
+  enabled: false,
+  experiment: experiment,
+  eventCategory: 'storybook',
+  getExperimentLastSeen: () => Date.now(),
+  isAfterCompletedDate: () => false,
+  sendToGA: action('sendToGA'),
+  navigateTo: action('navigateTo'),
+  installed: {},
+  clientUUID: '867-5309'
+};
+
+storiesOf('ExperimentRowCard', module)
+  .addDecorator(withKnobs)
+  .addDecorator(story => (
+    <div className="blue" style={{ padding: 10 }} onClick={ action('click') }>
+      <div className="stars"></div>
+      <LayoutWrapper flexModifier="card-list">
+        {story()}
+      </LayoutWrapper>
+    </div>
+  ))
+  .add('base state with knobs', () =>
+    <ExperimentRowCard {...baseProps}
+      hasAddon={boolean('Has Addon', false)}
+      enabled={boolean('Enabled', false)}
+      experiment={object('Experiment', experiment)}
+      />)
+  .add('with subtitle', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, subtitle: 'example subtitle here' }} />)
+  .add('< 100 participants', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, installation_count: 90 }} />)
+  .add('just launched', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, created: Date.now()}}
+      getExperimentLastSeen={() => 0} />)
+  .add('just updated', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, created: Date.now(), modified: Date.now()}}
+      getExperimentLastSeen={() => 0} />)
+  .add('has addon & enabled', () =>
+    <ExperimentRowCard {...baseProps} hasAddon={true} enabled={true} />)
+  .add('has addon & enabled, wrapping title', () =>
+    <ExperimentRowCard {...baseProps} hasAddon={true} enabled={true}
+      experiment={{...experiment, title: 'Sample experiment with long title'}}/>)
+  .add('ending soon', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, completed: Date.now() + ONE_WEEK - 1000}} />)
+  .add('ending tomorrow', () =>
+    <ExperimentRowCard {...baseProps}
+      experiment={{...experiment, completed: Date.now() + ONE_DAY - 1000}} />)
+  .add('after completed date', () =>
+    <ExperimentRowCard {...baseProps} isAfterCompletedDate={ () => true }  />)
+  ;

--- a/stories/index.js
+++ b/stories/index.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { linkTo } from '@storybook/addon-links';
+
+import { Button, Welcome } from '@storybook/react/demo';
+
+storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
+
+storiesOf('Button', module)
+  .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
+  .add('with some emoji', () => <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>);

--- a/stories/index.js
+++ b/stories/index.js
@@ -4,10 +4,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { linkTo } from '@storybook/addon-links';
 
-import { Button, Welcome } from '@storybook/react/demo';
+import '../frontend/build/static/styles/experiments.css';
+import '../frontend/build/static/styles/main.css';
 
-storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
-
-storiesOf('Button', module)
-  .add('with text', () => <Button onClick={action('clicked')}>Hello Button</Button>)
-  .add('with some emoji', () => <Button onClick={action('clicked')}>😀 😎 👍 💯</Button>);
+import './app/components/ExperimentRowCard-story';


### PR DESCRIPTION
Since I've started on two feature branches (#2548, #2546) based on these Storybook commits for the ExperimentRowCard component, maybe it would be interesting to consider this separately. Same instructions to see a base story for the component:

* Start a dev server like usual with `npm start`
* In a second shell, start Storybook with `npm run storybook`
* Visit http://localhost:6006/ 