### PR TITLE
Stop using cache-busting hashes for stable feed URLs

### DIFF
--- a/frontend/tasks/dist.js
+++ b/frontend/tasks/dist.js
@@ -13,14 +13,18 @@ gulp.task('dist-rev-assets', function() {
       /static\/addon\/*/,
       /static\/locales\/*/,
       /static\/images\/experiments\/[^]*\/social\/*/,
-      '.html'
+      '.html',
+      '.rss',
+      '.atom'
     ],
     dontUpdateReference: [
       /static\/addon\/*/,
       /static\/locales\/*/,
       /.*\.json/,
       /static\/images\/experiments\/[^]*\/social\/*/,
-      'favicon.ico'
+      'favicon.ico',
+      /.*\.rss/,
+      /.*\.atom/
     ]
   });
   return gulp.src(config.DEST_PATH + '**')


### PR DESCRIPTION
We left these resources out of the exceptions in the distribution tasks, so the URLs would change every time the feeds were updated. Let's not do that.