### PR TITLE
Add back python 3.6 for html reporting

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ machine:
     example.com: 127.0.0.1
   node:
     version: 6.9.1
-  python:
-    version: 2.7.11
+  post:
+    - pyenv global 2.7.11 3.6.1
 
 dependencies:
   cache_directories:

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 
 [testenv:ui-tests]
 passenv = DISPLAY PYTEST_ADDOPTS
+basepython = python3.6
 deps = -rfrontend/test/ui/requirements/requirements.txt
 commands =
     bash bin/circleci/run-integration-tests.sh


### PR DESCRIPTION
This was removed due to some circleci wonkiness but it is needed to correctly create an html report.

I will run this a few times to make sure it passes.