### PR TITLE
Updated circle to have python 3.6 as well

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
     example.com: 127.0.0.1
   node:
     version: 6.9.1
-  post
+  post:
     - pyenv global 2.7.12 3.6.1
 
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ machine:
     example.com: 127.0.0.1
   node:
     version: 6.9.1
-  python:
-    version: 2.7.11
+  post
+    - pyenv global 2.7.12 3.6.1
 
 dependencies:
   cache_directories:

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ skipsdist = True
 
 [testenv:ui-tests]
 passenv = DISPLAY PYTEST_ADDOPTS
+basepython = python3.6
 deps = -rfrontend/test/ui/requirements/requirements.txt
 commands =
     bash bin/circleci/run-integration-tests.sh


### PR DESCRIPTION
Had to update the branch as I missed the new push.

This is for generating the html report as python 2.7 does not encode the ```driver.log``` correctly and causes an error.