### PR TITLE
Fix #2592 Make the experiment.thumbnail icon paths absolute again, allowing gulp-rev-all to add hashes to them again.

### DIFF
--- a/frontend/tasks/content.js
+++ b/frontend/tasks/content.js
@@ -166,7 +166,7 @@ function buildExperimentsData() {
 }
 
 .experiment-icon-${experiment.slug} {
-  background-image: url(../..${experiment.thumbnail});
+  background-image: url(${experiment.thumbnail});
 }
 `);
 


### PR DESCRIPTION
This breaks storybook for now, but that's not a super high priority at
the moment.