### PR TITLE
Skip Integration tests on pontoon commits.

### DIFF
--- a/bin/circleci/install-test-dependencies.sh
+++ b/bin/circleci/install-test-dependencies.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -ex
 
+IS_PONTOON=$(git show -s --format=%s | grep -q 'Pontoon:' && echo 'true' || echo '')
+if [[ $IS_PONTOON ]]; then
+  echo "Skipping Integration Tests on Pontoon commit.";
+  exit 0;
+fi
+
 GECKODRIVER_URL=$(
   curl -s 'https://api.github.com/repos/mozilla/geckodriver/releases/latest' |
   python -c "import sys, json; r = json.load(sys.stdin); print([a for a in r['assets'] if 'linux64' in a['name']][0]['browser_download_url']);"

--- a/bin/circleci/test-firefox-dev.sh
+++ b/bin/circleci/test-firefox-dev.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -ex
 
+# Skip builds for Pontoon commits
+IS_PONTOON=$(git show -s --format=%s | grep -q 'Pontoon:' && echo 'true' || echo '')
+if [[ $IS_PONTOON ]]; then
+  echo "Skipping Integration Tests on Pontoon commit.";
+  exit 0;
+fi
+
 mozinstall $(ls -t /home/ubuntu/firefox-downloads/firefox_dev/*.tar.bz2 | head -1)
 firefox --version
 export PYTEST_ADDOPTS=--html=integration-test-results/ui-test-dev.html

--- a/bin/circleci/test-firefox-nightly.sh
+++ b/bin/circleci/test-firefox-nightly.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -ex
 
+# Skip builds for Pontoon commits
+IS_PONTOON=$(git show -s --format=%s | grep -q 'Pontoon:' && echo 'true' || echo '')
+if [[ $IS_PONTOON ]]; then
+  echo "Skipping Integration Tests on Pontoon commit.";
+  exit 0;
+fi
+
 mozinstall $(ls -t /home/ubuntu/firefox-downloads/firefox_nightly/*.tar.bz2 | head -1)
 firefox --version
 export PYTEST_ADDOPTS=--html=integration-test-results/ui-test-nightly.html

--- a/bin/circleci/test-firefox-release.sh
+++ b/bin/circleci/test-firefox-release.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -ex
 
+# Skip builds for Pontoon commits
+IS_PONTOON=$(git show -s --format=%s | grep -q 'Pontoon:' && echo 'true' || echo '')
+if [[ $IS_PONTOON ]]; then
+  echo "Skipping Integration Tests on Pontoon commit.";
+  exit 0;
+fi
+
 mozinstall $(ls -t /home/ubuntu/firefox-downloads/firefox/*.tar.bz2 | head -1)
 firefox --version
 export PYTEST_ADDOPTS=--html=integration-test-results/ui-test-release.html


### PR DESCRIPTION
I gave this a try again, seems to work. Build times are down about half as I am skipping everything to do with the integration tests.