### PR TITLE
Updates minimum version of Firefox for Containers.

### DIFF
--- a/content-src/experiments/containers.yaml
+++ b/content-src/experiments/containers.yaml
@@ -4,7 +4,7 @@ slug: containers
 locales:
   - 'en'
 launch_date: '2017-03-01T21:00:00.00Z'
-min_release: 51
+min_release: 53
 incompatible:
   'blok@mozilla.org': 'Tracking Protection'
 thumbnail: /static/images/experiments/containers/icon/thumbnail.png


### PR DESCRIPTION
Per @jonathanKingston in [a Discourse thread](https://discourse.mozilla-community.org/t/what-min-firefox-version-required/16910/2), Containers now requires Firefox 53.

https://github.com/mozilla/testpilot/blob/master/docs/content/reference.md#min_release