### PR TITLE
Disable survey feedback prompts

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Test Pilot",
   "name": "testpilot-addon",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/addon/src/main.js
+++ b/addon/src/main.js
@@ -61,8 +61,8 @@ export function main({ loadReason }: { loadReason: string }) {
   env.subscribe(store);
   sideEffects.enable(store);
   loader.loadExperiments(startEnv.name, startEnv.baseUrl);
-  feedbackManager.schedule();
-  feedbackManager.maybeShare();
+  // feedbackManager.schedule();
+  // feedbackManager.maybeShare();
   if (loadReason === 'install' || loadReason === 'enable') {
     telemetry.setPrefs();
     telemetry.ping(self.id, 'enabled');


### PR DESCRIPTION
Comments out the initialization code triggering the survey prompts and interval checks.

Does not remove the code altogether, but that's probably okay since I'm rewriting it altogether for #2423 and omitting any survey prompts so far.

Issue #2561