### PR TITLE
make some ui updates for next launch

### DIFF
--- a/frontend/src/app/components/ExperimentPlatforms.js
+++ b/frontend/src/app/components/ExperimentPlatforms.js
@@ -22,7 +22,7 @@ export default function ExperimentPlatforms({ experiment }) {
     <h4 className="experiment-platform">
       {enabledPlatforms.map(platform =>
         <span key={platform} className={'platform-icon platform-icon-' + platform}>&nbsp;</span>)}
-      <span data-l10n-id={l10nId}>
+      <span data-l10n-id={l10nId} className='platform-copy'>
         Available on {enabledPlatforms.join(' / ')}
       </span>
     </h4>

--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -282,7 +282,7 @@ export class ExperimentDetail extends React.Component {
 
         <View {...this.props}>
 
-        {hasAddon !== null && (!hasAddon && !graduated) && <section id="testpilot-promo">
+        {hasAddon !== null && (!hasAddon && !graduated && !experiment.web_url) && <section id="testpilot-promo">
           <Banner>
               <LayoutWrapper flexModifier="row-between-reverse">
                 <div className="intro-text">
@@ -324,9 +324,11 @@ export class ExperimentDetail extends React.Component {
           <div className="sticky-header-sibling" style={{ height: `${stickyHeaderSiblingHeight}px` }} ></div>
 
           <div id="details">
+              <LayoutWrapper>
+                {experiment.platforms && <ExperimentPlatforms experiment={experiment} />}
+              </LayoutWrapper>
               <LayoutWrapper helperClass="details-content" flexModifier="details-content">
-                <div className="details-overview">
-                  {experiment.platforms && <ExperimentPlatforms experiment={experiment} />}
+                  <div className="details-overview">
                   <div className={`experiment-icon-wrapper-${experiment.slug} experiment-icon-wrapper`}>
                     <img className="experiment-icon" src={thumbnail}></img>
                   </div>
@@ -334,18 +336,10 @@ export class ExperimentDetail extends React.Component {
                     <section className="user-count">
                       { this.renderInstallationCount() }
                     </section>
-                    {!hasAddon && <div>
-                      {!!introduction && <section className="introduction">
-                        {!!warning && <div className="warning"><strong data-l10n-id={this.l10nId('warning')}>{warning}</strong></div>}
-                        {!graduated && <div data-l10n-id={this.l10nId('introduction')}>
-                          {parser(introduction)}
-                        </div>}
-                      </section>}
-                    </div>}
                     {!graduated && <div>
                       <section className="stats-section">
                         <table className="stats"><tbody>
-                          {hasAddon && <tr>
+                          {!experiment.web_url && <tr>
                             <td data-l10n-id="tour">Tour</td>
                             <td><a className="showTour" data-l10n-id="tourLink" onClick={e => this.showTour(e)} href="#">Launch Tour</a></td>
                           </tr>}
@@ -423,14 +417,14 @@ export class ExperimentDetail extends React.Component {
                   {this.renderEolBlock()}
                   {this.renderIncompatibleAddons()}
                   {this.renderLocaleWarning()}
-                  {hasAddon && <div>
+                  <div>
                    {!!introduction && <section className="introduction">
                      {!!warning && <div className="warning"><strong data-l10n-id={this.l10nId('warning')}>{warning}</strong></div>}
                      <div data-l10n-id={this.l10nId('introduction')}>
                        {parser(introduction)}
                      </div>
                    </section>}
-                  </div>}
+                  </div>
                   <div className="details-list">
                     {details.map((detail, idx) => (
                      <div key={idx}>
@@ -652,6 +646,14 @@ export class ExperimentDetail extends React.Component {
     return null;
   }
 
+  renderWebExperimentControls(web_url, title) {
+    return (
+      <a href={web_url} onClick={() => this.handleGoToLink()} target="_blank" rel="noopener noreferrer" className="button default">
+        <span data-l10n-id="experimentGoToLink" data-l10n-args={JSON.stringify({ title })} className="default-text"></span>
+      </a>
+    );
+  }
+
   renderExperimentControls() {
     const { enabled, isDisabling, progressButtonWidth } = this.state;
     const { experiment, installed, isAfterCompletedDate, hasAddon, clientUUID } = this.props;
@@ -660,7 +662,10 @@ export class ExperimentDetail extends React.Component {
     const surveyURL = buildSurveyURL('givefeedback', title, installed, clientUUID, survey_url);
 
     if (!hasAddon || !validVersion) {
-      return null;
+      const useWebLink = (experiment.platforms || []).indexOf('web') !== -1;
+      if (!useWebLink) {
+        return null;
+      }
     }
     if (isAfterCompletedDate(experiment)) {
       if (enabled) {
@@ -696,15 +701,10 @@ export class ExperimentDetail extends React.Component {
 
   renderEnableButton() {
     const { experiment } = this.props;
-    const { title, web_url } = experiment;
-
+    const { title } = experiment;
     const useWebLink = (experiment.platforms || []).indexOf('web') !== -1;
     if (useWebLink) {
-      return (
-        <a href={web_url} onClick={() => this.handleGoToLink()} target="_blank" rel="noopener noreferrer" className="button default">
-          <span data-l10n-id="experimentGoToLink" data-l10n-args={JSON.stringify({ title })} className="default-text"></span>
-        </a>
-      );
+      return this.renderWebExperimentControls(experiment.web_url, title);
     }
 
     const { isEnabling, progressButtonWidth } = this.state;

--- a/frontend/src/styles/modules/_card-list.scss
+++ b/frontend/src/styles/modules/_card-list.scss
@@ -31,7 +31,6 @@
   width: 100%;
 }
 
-
 .card {
   @include flex-container (column, center, center);
 

--- a/frontend/src/styles/modules/_experiment-details.scss
+++ b/frontend/src/styles/modules/_experiment-details.scss
@@ -88,7 +88,8 @@
     }
 
     font-size: $grid-unit * .9;
-    height: $grid-unit * 2;
+    height: $grid-unit * 2.6;
+    line-height: $grid-unit * 2.6;
     padding: 0 $grid-unit * .75;
   }
 
@@ -440,6 +441,12 @@
   color: $transparent-black-5;
   font-size: 1.2 * $font-unit;
   font-weight: normal;
+  margin: 0;
+
+  .platform-copy,
+  .platform-icon {
+    margin-bottom: 0;
+  }
 
   .platform-icon {
     background-position: left center;
@@ -463,14 +470,6 @@
   .platform-icon-mobile {
     background-image: url('../images/experiment-type-mobile.svg');
   }
-}
-
-.experiment-information .experiment-platform {
-  margin: 10px 0 -2px;
-}
-
-.details-overview .experiment-platform {
-  margin: 0 0 8px;
 }
 
 @include respond-to('small') {

--- a/frontend/src/styles/modules/_update-list.scss
+++ b/frontend/src/styles/modules/_update-list.scss
@@ -3,34 +3,26 @@
     margin: 0 0 30px;
   }
 
-  margin: -40px 0 60px;
+  margin: -40px 0 40px;
   width: 100%;
 }
 
 .update-list-heading {
-  @include respond-to('medium') {
-    font-size: $font-unit * 3.5;
-    line-height: $font-unit * 3.5;
-  }
-
-  @include respond-to('small') {
-    font-size: $font-unit * 2.7;
-    line-height: $font-unit * 2.7;
-  }
-
-  font-size: $grid-unit * 2;
-  line-height: $grid-unit * 2.7;
-  margin: 0 0 $grid-unit * 1.5;
+  font-size: $grid-unit * 1.4;
+  line-height: $grid-unit * 1.4;
+  margin: 0 0 $grid-unit * .75;
   text-shadow: 0 2px 0 $transparent-black-3;
 }
 
 .update {
   align-items: center;
   background: $dark-over-darkest-blue;
-  border-radius: 6px;
+  border-radius: 3px;
+  box-shadow: 0 -2px 0 $transparent-black-05 inset;
   cursor: default;
   display: flex;
-  margin: 0 0 12px;
+  margin-bottom: 8px;
+  opacity: .9;
   padding: 5px;
   width: 100%;
 
@@ -39,7 +31,7 @@
 
     header {
       @include flex-container(row, flex-start, center);
-      margin-bottom: 15px;
+      margin-bottom: 10px;
     }
   }
 
@@ -59,10 +51,11 @@
   }
 
   > div {
-    margin: 15px;
+    margin: 10px;
   }
 
   h2 {
+    font-size: $grid-unit * 1.2;
     font-style: italic;
     margin: 0;
   }


### PR DESCRIPTION
This PR does a few small things:
* condenses the newsfeed slightly to move experiments up the page
* changes the layout of the experiment types notice on experiment pages to better match spec
* removes 'install test pilot' banner from web experiments
* gives the user a button to check out a web experiment even if they do not have test pilot installed
* makes it so experiment page layout is the same regardless of whether user has add-on