### PR TITLE
Skip flake8 on Pontoon commit

### DIFF
--- a/bin/circleci/flake8.sh
+++ b/bin/circleci/flake8.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -ex
+
+# Skip builds for Pontoon commits
+IS_PONTOON=$(git show -s --format=%s | grep -q 'Pontoon:' && echo 'true' || echo '')
+if [[ $IS_PONTOON ]]; then
+  echo "Skipping Integration Tests on Pontoon commit.";
+  exit 0;
+fi
+
+tox -e flake8

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ test:
   override:
     - ./bin/circleci/test-addon.sh
     - ./bin/circleci/test-frontend.sh
-    - tox -e flake8
+    - ./bin/circleci/flake8.sh
     - mkdir integration-test-results
     - ./bin/circleci/test-firefox-release.sh
     - ./bin/circleci/test-firefox-dev.sh


### PR DESCRIPTION
This should skip flake8 on pontoon commits and hopefully solve the issue when tox isn't cached.