### PR TITLE
Implement `npm run package` in root dir for addon build

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "coverage": "cross-env NODE_ENV=test nyc mocha --recursive --require frontend/test-setup.js frontend/test",
     "flow-coverage": "cd frontend && flow-coverage-report --threshold 60 -i 'src/**/*.js' -t html -o coverage/flow",
     "addon:locales": "gulp addon-copy-locales",
+    "package": "cd addon && npm install && npm run package && cp addon.xpi ..",
     "content": "gulp content-build",
     "storybook": "start-storybook -s ./frontend/build -p 6006",
     "build-storybook": "build-storybook -o ./frontend/build/storybook"


### PR DESCRIPTION
For Issue #2627 

In the docs updated in #2615 about Mozilla Extension signing:

> Jenkins will run `npm install` followed by `npm run package`

This is a bit ugly - because `npm install` will install all the *website* dependencies before we get to `npm run package`. That, then, will get around to installing the *addon* dependencies. But, in the end, it should end up with `addon.xpi` in the root directory of the repo.