### PR TITLE
Allow _l10nsuffix in YAML for parent properties

### DIFF
--- a/frontend/tasks/util.js
+++ b/frontend/tasks/util.js
@@ -49,11 +49,15 @@ function experimentL10nId(experiment, pieces) {
   if (typeof pieces === 'string') {
     pieces = [pieces];
   }
-  const suffix = lookup(experiment, `${pieces.join('.')}_l10nsuffix`);
-  if (suffix) {
-    pieces.push(suffix);
+  const piecesOut = [];
+  for (let i=0; i<pieces.length; i++) {
+    piecesOut.push(pieces[i]);
+    const suffix = lookup(experiment, `${pieces.slice(0, i+1).join('.')}_l10nsuffix`);
+    if (suffix) {
+      piecesOut.push(suffix);
+    }
   }
-  return l10nId([].concat([experiment.slug], pieces));
+  return l10nId([].concat([experiment.slug], piecesOut));
 }
 
 function newsUpdateL10nId(update, fieldName) {

--- a/frontend/test/app/lib/utils-test.js
+++ b/frontend/test/app/lib/utils-test.js
@@ -39,7 +39,12 @@ describe('app/lib/utils', () => {
       }
     ],
     string2: 'h',
-    string2_l10nsuffix: 'i'
+    string2_l10nsuffix: 'i',
+    stringarray: [
+      'item one',
+      'item two'
+    ],
+    stringarray_l10nsuffix: 'bar'
   };
 
   describe('lookup', () => {
@@ -78,6 +83,11 @@ describe('app/lib/utils', () => {
     it('looks up array items', () => {
       expect(experimentL10nId(mockExperiment, ['array', '0', 'x'])).to.equal('fooArray0XZ');
     });
+
+    it('looks up arrays of strings', () => {
+      expect(experimentL10nId(mockExperiment, ['stringarray', '0'])).to.equal('fooStringarrayBar0');
+      expect(experimentL10nId(mockExperiment, ['stringarray', '1'])).to.equal('fooStringarrayBar1');
+    })
 
     it('should return null for a dev-only experiment', () => {
       expect(experimentL10nId({ dev: true, ...mockExperiment }, ['string'])).to.equal(null);


### PR DESCRIPTION
This allows us to apply an L10n ID suffix to lists of strings, where the individual strings do not have named properties. For example:
```yaml
measurements:
  - foo
  - bar
measurements_l10nsuffix: updated
```

This results in L10N IDs like the following:
- measurementsUpdated0
- measurementsUpdated1