### PR TITLE
Fix #2616 Remove id="show-detail"

### DIFF
--- a/frontend/src/app/components/ExperimentRowCard.js
+++ b/frontend/src/app/components/ExperimentRowCard.js
@@ -45,7 +45,7 @@ export default class ExperimentRowCard extends React.Component {
     const isCompleted = isAfterCompletedDate(experiment);
 
     return (
-      <a id="show-detail" href={`/experiments/${slug}`} onClick={() => this.openDetailPage()}
+      <a href={`/experiments/${slug}`} onClick={() => this.openDetailPage()}
         className={classnames('experiment-summary', {
           enabled,
           'just-launched': this.justLaunched(),


### PR DESCRIPTION
The string "show-detail" doesn't show up anywhere else in the repo, and
it was being applied to multiple elements in the page, so isn't a valid
use of an id anyway.