### PR TITLE
Fix HTTP headers in deployment for JSON resources

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -43,7 +43,7 @@ CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https
 HSTS="\"strict-transport-security\": \"max-age=${ONE_YEAR}; includeSubDomains; preload\""
 TYPE="\"x-content-type-options\": \"nosniff\""
 XSS="\"x-xss-protection\": \"1; mode=block\""
-ACAO="\"Access-Control-Allow-Origin\": \"\*\""
+ACAO="\"Access-Control-Allow-Origin\": \"*\""
 
 # Our dev server has a couple different rules to allow easier debugging and
 # enable localization.  Also expires more often.


### PR DESCRIPTION
Should fix this error with overzealous JSON escaping I just noticed happening [in deployment in CircleCI](https://circleci.com/gh/mozilla/testpilot/5245):

```
Error parsing parameter '--metadata': Invalid JSON: Invalid \escape:
line 1 column 34 (char 33) JSON received:
{"Access-Control-Allow-Origin": "\*", "Public-Key-Pins":
"max-age=300;pin-sha256=\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\";pin-sha256=\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\";pin-sha256=\"YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=\";pin-sha256=\"sRHdihwgkaib1P1gxX8HFszlD+7/gTfNvuAybgLPNis=\";",
"strict-transport-security": "max-age=31536000; includeSubDomains;
preload", "x-content-type-options": "nosniff"}
```