### PR TITLE
Fix #2732 Fix localization by using document.querySelector('meta[name=availableLanguages]') instead of config.AVAILABLE_LOCALES

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -113,9 +113,12 @@ class App extends Component {
       return Promise.resolve();
     }
 
+    const availableLanguages = document.querySelector(
+      'meta[name=availableLanguages]').content.split(',');
+
     const negotiated = negotiateLanguages(
       navigator.languages,
-      config.AVAILABLE_LOCALES,
+      availableLanguages,
       { defaultLocale: 'en-US' }
     );
 


### PR DESCRIPTION
Apparently there are two files named config.js, and the one that is
available to the browser does not define AVAILABLE_LOCALES. The one
which does define AVAILABLE_LOCALES is not able to be required by the
browser.

Luckily, the meta tag availableLanguages is usable and always contains
the correct languages.