### PR TITLE
Ensure proper add-on path is used while installing via mozAddonManager

### DIFF
--- a/frontend/src/app/lib/moz.js
+++ b/frontend/src/app/lib/moz.js
@@ -1,4 +1,5 @@
 import cookies from 'js-cookie';
+import config from '../config';
 import addonActions from '../actions/addon';
 import { hasAddonSelector } from '../selectors/addon';
 import { updateExperiment } from '../actions/experiments';
@@ -32,7 +33,7 @@ export function installAddon(
   eventLabel
 ) {
   const { protocol, hostname, port } = window.location;
-  const path = '/static/addon/addon.xpi';
+  const path = config.addonPath;
   const downloadUrl = `${protocol}//${hostname}${port ? ':' + port : ''}${path}`;
 
   const gaEvent = {


### PR DESCRIPTION
Quick fix to hardcoded path to old add-on.