### PR TITLE
Make .editorconfig more general for indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,18 +6,10 @@ indent_style = space
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
+indent_size = 2
 
 [*.py]
 indent_size = 4
 
-[*.js]
-indent_size = 2
-
-[*.scss]
-indent_size = 2
-
 [*.md]
 trim_trailing_whitespace = false
-
-[*.{yml,yaml,config,config-dist}]
-indent_size = 2


### PR DESCRIPTION
Started playing with rename .js -> .jsx on a branch, and noticed that .editorconfig didn't cover those files