### PR TITLE
If children is null, don't have an error.

### DIFF
--- a/frontend/src/app/components/LocalizedHtml.js
+++ b/frontend/src/app/components/LocalizedHtml.js
@@ -73,14 +73,19 @@ export default class LocalizedHtml extends Localized {
         html <span>///</span> and storing the original
         template elements in `templates`.
       */
-      joined = React.Children.map(result.props.children, child => {
+      const mapped = React.Children.map(result.props.children, child => {
         if (typeof child === 'string') {
           return child;
         }
         templates.insertIndex++;
         templates[templates.insertIndex] = child;
         return '<span>///</span>';
-      }).join('');
+      });
+      if (mapped === null) {
+        joined = '';
+      } else {
+        joined = mapped.join('');
+      }
     }
 
     /*


### PR DESCRIPTION
It seems sometimes children can be null. I'm not exactly sure why,
perhaps when the LocalizedHtml placeholder does not have any children.
This may fix the 'e is null' errors we have been seeing on production.