### PR TITLE
Update fluent-langneg to 0.1.0

### DIFF
--- a/frontend/src/app/containers/App.js
+++ b/frontend/src/app/containers/App.js
@@ -1,6 +1,6 @@
 /* global ga */
 import { MessageContext } from 'fluent/compat';
-import negotiateLanguages from 'fluent-langneg/compat';
+import { negotiateLanguages } from 'fluent-langneg/compat';
 import { LocalizationProvider } from 'fluent-react/compat';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "es-symbol": "1.1.2",
     "es6-promise": "4.1.0",
     "fluent": "0.4.1",
-    "fluent-langneg": "0.0.2",
+    "fluent-langneg": "0.1.0",
     "fluent-react": "0.4.1",
     "html-react-parser": "0.3.5",
     "isomorphic-fetch": "2.2.1",


### PR DESCRIPTION
The exported API changed in 0.1.0. Updating now will help avoid headaches later on :)