### PR TITLE
Show tour dialog if experiment enabled, regardless of previous error

### DIFF
--- a/frontend/src/app/containers/ExperimentPage.js
+++ b/frontend/src/app/containers/ExperimentPage.js
@@ -118,10 +118,7 @@ export class ExperimentDetail extends React.Component {
 
     // On enable state change, stop installation indicators & show tour dialog if needed.
     if (prevEnabled !== nextEnabled) {
-      // TODO: Tweak experiment install count?
-      const showTourDialog = shouldShowTourDialog &&
-                             nextExperiment &&
-                             !nextExperiment.error;
+      const showTourDialog = shouldShowTourDialog && nextEnabled;
       this.setState({
         shouldShowTourDialog: false,
         showTourDialog


### PR DESCRIPTION
Fixes #1866 

Not sure why this was checking for error state - we don't get the experiment enabled state if there's an error, so that seems good enough to decide whether to show the tour.

When checking for error, there was a weird state sequence where the error goes away, the shouldShowTourDialog flag is cleared, and then enabled becomes true.