### PR TITLE
Wait for Cloudfront invalidation to complete after upload to S3 bucket in dev deployment

### DIFF
--- a/bin/circleci/invalidate-cloudfront-cache.sh
+++ b/bin/circleci/invalidate-cloudfront-cache.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+DISTRIBUTION_ID=$1
+
+aws configure set preview.cloudfront true
+
+INVALIDATION_ID=$(aws cloudfront create-invalidation \
+  --distribution-id $DISTRIBUTION_ID \
+  --paths '/*' | jq -r '.Invalidation.Id');
+
+aws cloudfront wait invalidation-completed \
+  --distribution-id $DISTRIBUTION_ID \
+  --id $INVALIDATION_ID

--- a/circle.yml
+++ b/circle.yml
@@ -52,16 +52,14 @@ deployment:
       - master
     commands:
       - TESTPILOT_BUCKET=testpilot.dev.mozaws.net ./bin/circleci/do-exclusively.sh --branch master ./bin/deploy.sh dev
-      - aws configure set preview.cloudfront true
-      - aws cloudfront create-invalidation --distribution-id E2ERG47PHCWD0Z --paths '/*'
+      - ./bin/circleci/invalidate-cloudfront-distribution.sh E2ERG47PHCWD0Z
   static_l10n:
     owner: mozilla
     branch:
       - l10n
     commands:
       - TESTPILOT_BUCKET=testpilot-l10n.dev.mozaws.net ./bin/deploy.sh dev
-      - aws configure set preview.cloudfront true
-      - aws cloudfront create-invalidation --distribution-id ELL21V1NJAJJ8 --paths '/*'
+      - ./bin/circleci/invalidate-cloudfront-distribution.sh ELL21V1NJAJJ8
 
 # Only notify of builds on master branch.
 experimental:


### PR DESCRIPTION
Still seeing back-to-back dev deployments end up breaking the site on dev. 

This is even with [the `do-exclusively.sh` wrapper](https://github.com/mozilla/testpilot/commit/5bb405f97f8b2f505fb64235f301484b31f1202f) to serialize deployments to S3. That makes me think we need to bite the bullet and also wait for the CloudFront invalidation to complete before attempting the next deployment. This PR should do that.