### PR TITLE
Bump Firefox min version up to 54

### DIFF
--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -1,6 +1,6 @@
 const defaultConfig = {
   isDev: true,
-  minFirefoxVersion: 50,
+  minFirefoxVersion: 54,
   experimentsURL: '/api/experiments.json',
   usageCountsURL:
     'https://analysis-output.telemetry.mozilla.org/testpilot/data/installation-counts/latest.json',


### PR DESCRIPTION
Fixes #2879 

I was too lazy to try to figure out how to dynamically configure release-minus-one. So, I just updated the hardcoded version to 54. If we really want it to self-update, we could figure that out in the future. But, it seems like it could be trouble.