### PR TITLE
Restore babel-polyfill in place of regenerator-runtime

### DIFF
--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -1,4 +1,4 @@
-import 'regenerator-runtime/runtime';
+import 'babel-polyfill/browser';
 import 'whatwg-fetch';
 import Raven from 'raven-js';
 import moment from 'moment';

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": ">=4.4.0"
   },
   "dependencies": {
+    "babel-polyfill": "6.23.0",
     "classnames": "2.2.5",
     "cldr-core": "31.0.1",
     "clipboard": "1.6.1",
@@ -33,7 +34,6 @@
     "react-redux": "5.0.3",
     "redux": "3.6.0",
     "redux-promise": "0.5.3",
-    "regenerator-runtime": "0.11.0",
     "reselect": "3.0.1",
     "seedrandom": "2.4.2",
     "whatwg-fetch": "^2.0.3"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 const IS_DEV = NODE_ENV === 'development';
 
 const excludeVendorModules = [
-  'regenerator-runtime',
+  'babel-polyfill',
   'fluent',
   'fluent-langneg',
   'fluent-react',
@@ -22,7 +22,7 @@ const excludeVendorModules = [
 ];
 
 const includeVendorModules = [
-  'regenerator-runtime/runtime',
+  'babel-polyfill/browser',
   'fluent/compat',
   'fluent-langneg/compat',
   'fluent-react/compat',


### PR DESCRIPTION
Seems like we need more than just a polyfill for async/await.

Reintroduces some bulk to our JS bundles, but seems like a fix until we
have a more selective polyfill approach.

Issue #2943