### PR TITLE
Add whatwg-fetch polyfill for older browsers like IE11

### DIFF
--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -1,4 +1,5 @@
 import 'regenerator-runtime/runtime';
+import 'whatwg-fetch';
 import Raven from 'raven-js';
 import moment from 'moment';
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "redux-promise": "0.5.3",
     "regenerator-runtime": "0.11.0",
     "reselect": "3.0.1",
-    "seedrandom": "2.4.2"
+    "seedrandom": "2.4.2",
+    "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
     "@storybook/addon-actions": "3.2.0",


### PR DESCRIPTION
Not super happy with this, since it looks like the vendor bundle is starting to grow again. But, it fixes an error in IE11 (and I assume other older browsers). Issue #2943