### PR TITLE
Update API used to find hostname for WebExtension BroadcastChannels

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -2,7 +2,7 @@
   "title": "Test Pilot",
   "name": "testpilot-addon",
   "id": "@testpilot-addon",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "description": "Test Pilot is a privacy-sensitive user research program focused on getting new features into Firefox faster.",
   "repository": "mozilla/testpilot",

--- a/addon/src/lib/channels.js
+++ b/addon/src/lib/channels.js
@@ -28,6 +28,9 @@ export async function startupChannels() {
   registerWebExtensionAPI('openChannel', ({ addonId, topic }) =>
     openChannel(addonId, topic)
   );
+  registerWebExtensionAPI('closeChannel', ({ addonId, topic }) =>
+    closeChannel(addonId, topic)
+  );
 }
 
 export async function shutdownChannels() {


### PR DESCRIPTION
Also skip creating channels for experiments that aren't installed,
because the new API won't yield a hostname (not sure how this was even
working before)

Fixes #2968