### PR TITLE
Handle key events in modals.

### DIFF
--- a/frontend/src/app/components/EmailDialog.js
+++ b/frontend/src/app/components/EmailDialog.js
@@ -22,6 +22,8 @@ export default class EmailDialog extends React.Component {
   props: EmailDialogProps
   state: EmailDialogState
 
+  modalContainer: Object
+
   constructor(props: EmailDialogProps) {
     super(props);
     this.state = {
@@ -32,11 +34,17 @@ export default class EmailDialog extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.modalContainer.focus();
+  }
+
   render() {
     const { isSuccess, isError } = this.state;
 
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         {!isSuccess && !isError && this.renderForm()}
         {isSuccess && this.renderSuccess()}
         {isError && this.renderError()}
@@ -187,6 +195,23 @@ export default class EmailDialog extends React.Component {
 
   close() {
     if (this.props.onDismiss) { this.props.onDismiss(); }
+  }
+
+  handleKeyDown(e: Object) {
+    const { isSuccess, isError } = this.state;
+    switch (e.key) {
+      case 'Escape':
+        if (!isSuccess && !isError) {
+          this.skip(e);
+        } else if (isSuccess) {
+          this.continue(e);
+        } else if (isError) {
+          this.continue(e);
+        }
+        break;
+      default:
+        break;
+    }
   }
 
 }

--- a/frontend/src/app/components/EmailDialog.js
+++ b/frontend/src/app/components/EmailDialog.js
@@ -209,6 +209,15 @@ export default class EmailDialog extends React.Component {
           this.continue(e);
         }
         break;
+      case 'Enter':
+        if (!isSuccess && !isError) {
+          this.handleSubscribe(this.state.email);
+        } else if (isSuccess) {
+          this.continue(e);
+        } else if (isError) {
+          this.reset(e);
+        }
+        break;
       default:
         break;
     }

--- a/frontend/src/app/components/RetireConfirmationDialog.js
+++ b/frontend/src/app/components/RetireConfirmationDialog.js
@@ -14,9 +14,17 @@ type RetireConfirmationDialogProps = {
 export default class RetireConfirmationDialog extends React.Component {
   props: RetireConfirmationDialogProps
 
+  modalContainer: Object
+
+  componentDidMount() {
+    this.modalContainer.focus();
+  }
+
   render() {
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         <div id="retire-dialog-modal" className="modal feedback-modal modal-bounce-in">
           <header className="modal-header-wrapper warning-modal">
             <Localized id="retireDialogTitle">
@@ -62,5 +70,15 @@ export default class RetireConfirmationDialog extends React.Component {
   cancel(e: Object) {
     e.preventDefault();
     this.props.onDismiss();
+  }
+
+  handleKeyDown(e: Object) {
+    switch (e.key) {
+      case 'Escape':
+        this.cancel(e);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/frontend/src/app/components/RetireConfirmationDialog.js
+++ b/frontend/src/app/components/RetireConfirmationDialog.js
@@ -77,6 +77,9 @@ export default class RetireConfirmationDialog extends React.Component {
       case 'Escape':
         this.cancel(e);
         break;
+      case 'Enter':
+        this.proceed(e);
+        break;
       default:
         break;
     }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentDisableDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentDisableDialog.js
@@ -17,6 +17,12 @@ type ExperimentDisableDialogProps = {
 export default class ExperimentDisableDialog extends React.Component {
   props: ExperimentDisableDialogProps
 
+  modalContainer: Object
+
+  componentDidMount() {
+    this.modalContainer.focus();
+  }
+
   render() {
     const { experiment, installed, clientUUID } = this.props;
     const { title, survey_url } = experiment;
@@ -24,7 +30,9 @@ export default class ExperimentDisableDialog extends React.Component {
     const surveyURL = buildSurveyURL('disable', title, installed, clientUUID, survey_url);
 
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         <div id="disabled-feedback-modal" className="modal feedback-modal modal-bounce-in">
           <header className="modal-header-wrapper">
             <Localized id="feedbackUninstallTitle" $title={ experiment.title }>
@@ -68,5 +76,15 @@ export default class ExperimentDisableDialog extends React.Component {
   cancel(e: Object) {
     e.preventDefault();
     this.props.onCancel(e);
+  }
+
+  handleKeyDown(e: Object) {
+    switch (e.key) {
+      case 'Escape':
+        this.cancel(e);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentDisableDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentDisableDialog.js
@@ -83,6 +83,18 @@ export default class ExperimentDisableDialog extends React.Component {
       case 'Escape':
         this.cancel(e);
         break;
+      case 'Enter': {
+        this.submit(e);
+
+        const { experiment, installed, clientUUID } = this.props;
+        const { title, survey_url } = experiment;
+        const surveyURL = buildSurveyURL('disable', title, installed, clientUUID, survey_url);
+
+        const newWindow = window.open();
+        newWindow.opener = null;
+        newWindow.location = surveyURL;
+        break;
+      }
       default:
         break;
     }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
@@ -12,10 +12,19 @@ type ExperimentEolDialogProps = {
 export default class ExperimentEolDialog extends React.Component {
   props: ExperimentEolDialogProps
 
+  modalContainer: Object
+
+  componentDidMount() {
+    this.modalContainer.focus();
+    console.log(typeof this.modalContainer);
+  }
+
   render() {
     const { title } = this.props;
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         <div id="retire-dialog-modal" className="modal feedback-modal modal-bounce-in">
           <header className="modal-header-wrapper warning-modal">
             <Localized id="disableHeader">
@@ -52,5 +61,15 @@ export default class ExperimentEolDialog extends React.Component {
   cancel(e: Object) {
     e.preventDefault();
     this.props.onCancel();
+  }
+
+  handleKeyDown(e: Object) {
+    switch (e.key) {
+      case 'Escape':
+        this.cancel(e);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
@@ -16,7 +16,6 @@ export default class ExperimentEolDialog extends React.Component {
 
   componentDidMount() {
     this.modalContainer.focus();
-    console.log(typeof this.modalContainer);
   }
 
   render() {

--- a/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentEolDialog.js
@@ -68,6 +68,9 @@ export default class ExperimentEolDialog extends React.Component {
       case 'Escape':
         this.cancel(e);
         break;
+      case 'Enter':
+        this.proceed(e);
+        break;
       default:
         break;
     }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
@@ -45,7 +45,7 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
               </div>
               <div className="tour-text">
                 <Localized id="experimentPreFeedbackLinkCopy" $title={experiment.title}>
-                  <a onClick={e => this.feedback(e)}
+                  <a onClick={e => this.feedback(e, e.target.getAttribute('href'))}
                      href={surveyURL}>Give feedback about the {experiment.title} experiment</a>
                 </Localized>
               </div>
@@ -55,14 +55,14 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
     );
   }
 
-  feedback(e: Object) {
+  feedback(e: Object, url: String) {
     e.preventDefault();
 
     this.props.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
       eventAction: 'PreFeedback Confirm',
       eventLabel: this.props.experiment.title,
-      outboundURL: e.target.getAttribute('href')
+      outboundURL: url
     });
   }
 
@@ -81,6 +81,15 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
       case 'Escape':
         this.cancel(e);
         break;
+      case 'Enter': {
+        const { surveyURL } = this.props;
+        this.feedback(e, surveyURL);
+
+        const newWindow = window.open();
+        newWindow.opener = null;
+        newWindow.location = surveyURL;
+        break;
+      }
       default:
         break;
     }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
@@ -15,11 +15,19 @@ type ExperimentPreFeedbackDialogProps = {
 export default class ExperimentPreFeedbackDialog extends React.Component {
   props: ExperimentPreFeedbackDialogProps
 
+  modalContainer: Object
+
+  componentDidMount() {
+    this.modalContainer.focus();
+  }
+
   render() {
     const { experiment, surveyURL } = this.props;
 
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         <div className={classnames('modal', 'tour-modal')}>
           <header className="modal-header-wrapper">
             <Localized id="experimentPreFeedbackTitle" $title={experiment.title}>
@@ -66,5 +74,15 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
       eventLabel: 'cancel feedback'
     });
     this.props.onCancel(e);
+  }
+
+  handleKeyDown(e: Object) {
+    switch (e.key) {
+      case 'Escape':
+        this.cancel(e);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
@@ -55,7 +55,7 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
     );
   }
 
-  feedback(e: Object, url: String) {
+  feedback(e: Object, url: string) {
     e.preventDefault();
 
     this.props.sendToGA('event', {

--- a/frontend/src/app/containers/ExperimentPage/ExperimentTourDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentTourDialog.js
@@ -22,6 +22,8 @@ export default class ExperimentTourDialog extends React.Component {
   props: ExperimentTourDialogProps
   state: ExperimentTourDialogState
 
+  modalContainer: Object
+
   constructor(props: ExperimentTourDialogProps) {
     super(props);
     this.state = { currentStep: 0 };
@@ -29,6 +31,10 @@ export default class ExperimentTourDialog extends React.Component {
 
   l10nId(pieces: string | Array<string | number>) {
     return experimentL10nId(this.props.experiment, pieces);
+  }
+
+  componentDidMount() {
+    this.modalContainer.focus();
   }
 
   render() {
@@ -47,7 +53,9 @@ export default class ExperimentTourDialog extends React.Component {
       </Localized>) : (<h3 className="modal-header">{experiment.title}</h3>);
 
     return (
-      <div className="modal-container">
+      <div className="modal-container" tabIndex="0"
+           ref={modalContainer => { this.modalContainer = modalContainer; }}
+           onKeyDown={e => this.handleKeyDown(e)}>
         <div className={classnames('modal', 'tour-modal')}>
           <header className="modal-header-wrapper">
             {headerTitle}
@@ -152,5 +160,15 @@ export default class ExperimentTourDialog extends React.Component {
       eventAction: 'button click',
       eventLabel: `forward to step ${newStep}`
     });
+  }
+
+  handleKeyDown(e: Object) {
+    switch (e.key) {
+      case 'Escape':
+        this.cancel(e);
+        break;
+      default:
+        break;
+    }
   }
 }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentTourDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentTourDialog.js
@@ -163,10 +163,27 @@ export default class ExperimentTourDialog extends React.Component {
   }
 
   handleKeyDown(e: Object) {
+    e.preventDefault();
     switch (e.key) {
       case 'Escape':
         this.cancel(e);
         break;
+      case 'ArrowRight':
+        this.tourNext();
+        break;
+      case 'ArrowLeft':
+        this.tourBack();
+        break;
+      case 'Enter': {
+        const { experiment } = this.props;
+        const { currentStep } = this.state;
+        const tourSteps = experiment.tour_steps || [];
+        const atEnd = (currentStep === tourSteps.length - 1);
+        if (atEnd) {
+          this.complete(e);
+        }
+        break;
+      }
       default:
         break;
     }

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -620,13 +620,18 @@ describe('app/containers/ExperimentPage/ExperimentDisableDialog', () => {
   const installed = { ex1: true, ex2: true };
   const clientUUID = '38c51b84-9586-499f-ac52-94626e2b29cf';
 
-  let onSubmit, onCancel, sendToGA, preventDefault, mockClickEvent, subject;
+  let onSubmit, onCancel, sendToGA, preventDefault,
+    mockClickEvent, mockEscapeKeyDownEvent, subject;
   beforeEach(() => {
     onSubmit = sinon.spy();
     onCancel = sinon.spy();
     sendToGA = sinon.spy();
     preventDefault = sinon.spy();
     mockClickEvent = { preventDefault };
+    mockEscapeKeyDownEvent = {
+      preventDefault,
+      key: 'Escape'
+    };
     subject = shallow(
       <ExperimentDisableDialog
         experiment={experiment} installed={installed}
@@ -643,6 +648,12 @@ describe('app/containers/ExperimentPage/ExperimentDisableDialog', () => {
 
   it('should call onCancel when cancel button clicked', () => {
     subject.find('.modal-cancel').simulate('click', mockClickEvent);
+    expect(onCancel.called).to.be.true;
+    expect(preventDefault.called).to.be.true;
+  });
+
+  it('should call onCancel when the <Escape> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
     expect(onCancel.called).to.be.true;
     expect(preventDefault.called).to.be.true;
   });
@@ -665,7 +676,7 @@ describe('app/containers/ExperimentPage/ExperimentDisableDialog', () => {
 });
 
 describe('app/containers/ExperimentPage/ExperimentEolDialog', () => {
-  let props, mockClickEvent, subject;
+  let props, mockClickEvent, mockEscapeKeyDownEvent, subject;
   beforeEach(() => {
     props = {
       onSubmit: sinon.spy(),
@@ -673,6 +684,10 @@ describe('app/containers/ExperimentPage/ExperimentEolDialog', () => {
     };
     mockClickEvent = {
       preventDefault: sinon.spy()
+    };
+    mockEscapeKeyDownEvent = {
+      preventDefault: sinon.spy(),
+      key: 'Escape'
     };
     subject = shallow(<ExperimentEolDialog {...props} />);
   });
@@ -683,6 +698,11 @@ describe('app/containers/ExperimentPage/ExperimentEolDialog', () => {
 
   it('calls onCancel when the cancel button is clicked', () => {
     subject.find('.modal-cancel').simulate('click', mockClickEvent);
+    expect(props.onCancel.called).to.be.true;
+  });
+
+  it('should call onCancel when the <Escape> button is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
     expect(props.onCancel.called).to.be.true;
   });
 
@@ -702,13 +722,18 @@ describe('app/containers/ExperimentPage/ExperimentPreFeedbackDialog', () => {
   };
   const surveyURL = experiment.survey_url;
 
-  let sendToGA, onCancel, preventDefault, getAttribute, mockClickEvent, subject;
+  let sendToGA, onCancel, preventDefault, getAttribute,
+    mockClickEvent, mockEscapeKeyDownEvent, subject;
   beforeEach(() => {
     sendToGA = sinon.spy();
     onCancel = sinon.spy();
     preventDefault = sinon.spy();
     getAttribute = sinon.spy(() => surveyURL);
     mockClickEvent = { preventDefault, target: { getAttribute } };
+    mockEscapeKeyDownEvent = {
+      preventDefault,
+      key: 'Escape'
+    };
     subject = shallow(
       <ExperimentPreFeedbackDialog experiment={experiment} surveyURL={surveyURL}
                                    onCancel={onCancel} sendToGA={sendToGA} />
@@ -738,6 +763,16 @@ describe('app/containers/ExperimentPage/ExperimentPreFeedbackDialog', () => {
     }]);
   });
 
+  it('should call onCancel when the <Escape> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
+    expect(onCancel.called).to.be.true;
+    expect(sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'cancel feedback'
+    }]);
+  });
+
   it('should launch feedback on feedback button click', () => {
     subject.find('.tour-text a').simulate('click', mockClickEvent);
     expect(onCancel.called).to.be.false;
@@ -752,9 +787,13 @@ describe('app/containers/ExperimentPage/ExperimentPreFeedbackDialog', () => {
 });
 
 describe('app/containers/ExperimentPage/ExperimentTourDialog', () => {
-  let props, mockClickEvent, subject;
+  let props, mockClickEvent, mockEscapeKeyDownEvent, subject;
   beforeEach(() => {
     mockClickEvent = { preventDefault: sinon.spy() };
+    mockEscapeKeyDownEvent = {
+      preventDefault: sinon.spy(),
+      key: 'Escape'
+    };
 
     props = {
       experiment: {
@@ -866,6 +905,18 @@ describe('app/containers/ExperimentPage/ExperimentTourDialog', () => {
 
   it('should ping GA and call onCancel when cancel button clicked', () => {
     subject.find('.modal-cancel').simulate('click', mockClickEvent);
+
+    expect(props.onCancel.called).to.be.true;
+
+    expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'cancel tour'
+    }]);
+  });
+
+  it('should ping GA and call onCancel when the <Escape> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
 
     expect(props.onCancel.called).to.be.true;
 

--- a/frontend/test/app/components/EmailDialog-test.js
+++ b/frontend/test/app/components/EmailDialog-test.js
@@ -22,6 +22,11 @@ describe('app/components/EmailDialog', () => {
     stopPropagation() {},
     key: 'Escape'
   };
+  const mockEnterKeyDownEvent = {
+    preventDefault() {},
+    stopPropagation() {},
+    key: 'Enter'
+  };
 
   let onDismiss, sendToGA, getWindowLocation, subject;
   beforeEach(() => {
@@ -100,6 +105,43 @@ describe('app/components/EmailDialog', () => {
     }, 1);
   });
 
+  it('should subscribe to basket on valid email when <Enter> key is pressed', done => {
+    const expectedEmail = 'me@a.b.com';
+    subject.setState({ email: expectedEmail });
+
+    fetchMock.post(basketUrl, 200);
+    subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);
+
+    expect(sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'Sign me up'
+    }]);
+
+    // HACK: Yield for fetch-mock promises to complete, because we don't have
+    // direct control over that here.
+    setTimeout(() => {
+      const [url, request] = fetchMock.lastCall(basketUrl);
+
+      expect(url).to.equal(basketUrl);
+      expect(request).to.deep.equal({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'newsletters=test-pilot&email=me%40a.b.com&source_url=https%3A%2F%2Fexample.com'
+      });
+
+      expect(subject.state('isSuccess')).to.be.true;
+      expect(findLocalizedById(subject, 'newsletterFooterSuccessBody')).to.have.length(1);
+
+      expect(sendToGA.lastCall.args).to.deep.equal(['event', {
+        eventCategory: 'HomePage Interactions',
+        eventAction: 'button click',
+        eventLabel: 'email submitted to basket'
+      }]);
+      done();
+    }, 1);
+  });
+
   it('should show an error page on error', done => {
     const expectedEmail = 'me@a.b.com';
     subject.setState({ email: expectedEmail });
@@ -119,6 +161,23 @@ describe('app/components/EmailDialog', () => {
       done();
     }, 1);
   });
+
+  it('should reset the email dialog when the <Enter> key is pressed ' +
+    'on the error page', () => {
+    subject.setState({ isSuccess: false, isError: true });
+
+    const footer = findLocalizedById(subject, 'newsletterFooterError');
+    expect(footer).to.have.length(1);
+
+    const button = subject.findWhere(el => 'email-success-continue' === el.props()['id']);
+    expect(button).to.have.length(1);
+
+    subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);
+
+    expect(subject.state('isSuccess')).to.be.false;
+    expect(subject.state('isError')).to.be.false;
+  });
+
 
   it('should dismiss when continue button is clicked after subscribe', () => {
     subject.setState({ isSuccess: true, isError: false });

--- a/frontend/test/app/components/EmailDialog-test.js
+++ b/frontend/test/app/components/EmailDialog-test.js
@@ -17,6 +17,12 @@ describe('app/components/EmailDialog', () => {
     stopPropagation() {}
   };
 
+  const mockEscapeKeyDownEvent = {
+    preventDefault() {},
+    stopPropagation() {},
+    key: 'Escape'
+  };
+
   let onDismiss, sendToGA, getWindowLocation, subject;
   beforeEach(() => {
     fetchMock.restore();
@@ -32,6 +38,17 @@ describe('app/components/EmailDialog', () => {
 
   it('should dismiss when skip is clicked', () => {
     subject.find('.modal-cancel').simulate('click', mockClickEvent);
+
+    expect(onDismiss.called).to.be.true;
+    expect(sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'Skip email'
+    }]);
+  });
+
+  it('should dismiss when <Escape> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
 
     expect(onDismiss.called).to.be.true;
     expect(sendToGA.lastCall.args).to.deep.equal(['event', {
@@ -112,6 +129,23 @@ describe('app/components/EmailDialog', () => {
     expect(button).to.have.length(1);
 
     button.simulate('click', mockClickEvent);
+    expect(onDismiss.called).to.be.true;
+    expect(sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'On to the experiments'
+    }]);
+  });
+
+  it('should dismiss when <Escape> key is pressed, after subscribe', () => {
+    subject.setState({ isSuccess: true, isError: false });
+
+    expect(findLocalizedById(subject, 'newsletterFooterSuccessBody')).to.have.length(1);
+
+    const button = subject.findWhere(el => 'email-success-continue' === el.props()['id']);
+    expect(button).to.have.length(1);
+
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
     expect(onDismiss.called).to.be.true;
     expect(sendToGA.lastCall.args).to.deep.equal(['event', {
       eventCategory: 'HomePage Interactions',

--- a/frontend/test/app/components/RetireConfirmationDialog-test.js
+++ b/frontend/test/app/components/RetireConfirmationDialog-test.js
@@ -7,7 +7,7 @@ import { findLocalizedById } from '../util';
 import RetireConfirmationDialog from '../../../src/app/components/RetireConfirmationDialog';
 
 describe('app/components/RetireConfirmationDialog', () => {
-  let props, mockClickEvent, subject;
+  let props, mockClickEvent, mockEscapeKeyDownEvent, subject;
   beforeEach(function() {
     props = {
       uninstallAddon: sinon.spy(),
@@ -18,6 +18,10 @@ describe('app/components/RetireConfirmationDialog', () => {
     mockClickEvent = {
       preventDefault: sinon.spy()
     };
+    mockEscapeKeyDownEvent = {
+      preventDefault: sinon.spy(),
+      key: 'Escape'
+    };
     subject = shallow(<RetireConfirmationDialog {...props} />);
   });
 
@@ -27,6 +31,11 @@ describe('app/components/RetireConfirmationDialog', () => {
 
   it('should call onDismiss when the cancel button is clicked', () => {
     subject.find('.modal-cancel').simulate('click', mockClickEvent);
+    expect(props.onDismiss.called).to.be.true;
+  });
+
+  it('should call onDismiss when the <Escape> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEscapeKeyDownEvent);
     expect(props.onDismiss.called).to.be.true;
   });
 

--- a/frontend/test/app/components/RetireConfirmationDialog-test.js
+++ b/frontend/test/app/components/RetireConfirmationDialog-test.js
@@ -7,7 +7,8 @@ import { findLocalizedById } from '../util';
 import RetireConfirmationDialog from '../../../src/app/components/RetireConfirmationDialog';
 
 describe('app/components/RetireConfirmationDialog', () => {
-  let props, mockClickEvent, mockEscapeKeyDownEvent, subject;
+  let props, mockClickEvent, subject,
+    mockEscapeKeyDownEvent, mockEnterKeyDownEvent;
   beforeEach(function() {
     props = {
       uninstallAddon: sinon.spy(),
@@ -21,6 +22,10 @@ describe('app/components/RetireConfirmationDialog', () => {
     mockEscapeKeyDownEvent = {
       preventDefault: sinon.spy(),
       key: 'Escape'
+    };
+    mockEnterKeyDownEvent = {
+      preventDefault: sinon.spy(),
+      key: 'Enter'
     };
     subject = shallow(<RetireConfirmationDialog {...props} />);
   });
@@ -41,6 +46,18 @@ describe('app/components/RetireConfirmationDialog', () => {
 
   it('should uninstall the addon and ping GA when the proceed button is clicked', () => {
     findLocalizedById(subject, 'retireSubmitButton').find('button').simulate('click', mockClickEvent);
+    expect(props.uninstallAddon.called).to.be.true;
+    expect(props.navigateTo.called).to.be.true;
+    expect(props.navigateTo.lastCall.args[0]).to.equal('/retire');
+    expect(props.sendToGA.lastCall.args).to.deep.equal(['event', {
+      eventCategory: 'HomePage Interactions',
+      eventAction: 'button click',
+      eventLabel: 'Retire'
+    }]);
+  });
+
+  it('should uninstall the addon and ping GA when the <Enter> key is pressed', () => {
+    subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);
     expect(props.uninstallAddon.called).to.be.true;
     expect(props.navigateTo.called).to.be.true;
     expect(props.navigateTo.lastCall.args[0]).to.equal('/retire');


### PR DESCRIPTION
The scope of this PR is to enable modals to handle the following key events:
- `<Escape>` to dismiss modals (#2888)
- `<Enter>` for submit/done/continue actions
- `<ArrowLeft>` and `<ArrowRight>` for going through the steps in Experiment Tour modals

For the modals to listen on key events they first have to gain **focus**. This was accomplished by following React's documentation on managing focus with [Refs and the DOM](https://reactjs.org/docs/refs-and-the-dom.html). Also, since the modal elements are `<div>` elements, `tabIndex="0"` was used on them for them to be focusable.

| Dialog Name | Escape | Enter | ArrowLeft | ArrowRight |
| --- | --- | --- | --- | --- |
| Experiment Disable * | Dismiss | Open survey URL | - | - |
| Experiment EOL | Dismiss | Disable Experiment | - | - |
| Experiment PreFeedback * | Dismiss | Open survey URL | - | - |
| Experiment Tour | Dismiss | Complete Tour (if on final step) | Previous step | Next step  |
| Email ** | Dismiss | Sign Up \| Try Again \| Proceed | - | - |
| Retire Confirmation | Dismiss | Uninstall Testpilot | - | - |

*: The `Enter` key in these modals attempts to programmatically launch the survey in a new tab (i.e. the expected behavior when the button is clicked.) There are a couple of issues with that. For one, the new tab is prevented by the pop-up blocker. Another tricky part is trying to honor the `rel="noopener noreferrer"` attributes on the anchor element. 
For `noopener`, the following does the trick ([Source](https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/)): 
```
const newWindow = window.open();
newWindow.opener = null;
```
However, I couldn't come up with a clean solution for applying `noreferrer` programmatically. 
Also note that even when the anchors are clicked, the `noreferrer` attribute has no effect: `document.referrer` in the survey page shows the referrer URL. Maybe it's worth opening a new issue for this.

**: There seems to be an issue with focusing the Email Dialog. Right after Testpilot is installed the focus goes from the modal container to `<body>`. Ideally, for this modal the focus should automatically go in the email input field for the user to be able to type straightaway rather having to click on it first.

Regarding the event metrics, right now most of the modal related actions send the following: `eventAction: 'button click'`. Is it worth changing this to something like `eventAction: 'button key'` for key events?