### PR TITLE
Break ExperimentPage container into simpler sub-components

### DIFF
--- a/frontend/src/app/components/Warning.js
+++ b/frontend/src/app/components/Warning.js
@@ -6,10 +6,10 @@ type WarningProps = {
   title: string,
   titleL10nId: string,
   titleL10nArgs: string,
-  subtitle: string,
-  subtitleL10nId: string,
-  subtitleL10nArgs: string,
-  children: Array<any>
+  subtitle?: string,
+  subtitleL10nId?: string,
+  subtitleL10nArgs?: string,
+  children?: Array<any>
 }
 
 export default class Warning extends React.Component {

--- a/frontend/src/app/containers/ExperimentPage/DetailsDescription.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsDescription.js
@@ -1,0 +1,158 @@
+// @flow
+
+import React from 'react';
+import parser from 'html-react-parser';
+import { Localized } from 'fluent-react/compat';
+import LocalizedHtml from '../../components/LocalizedHtml';
+
+import Warning from '../../components/Warning';
+import { experimentL10nId, formatDate } from '../../lib/utils';
+
+import GraduatedNotice from '../../components/GraduatedNotice';
+import IncompatibleAddons from './IncompatibleAddons';
+import { MeasurementsSection } from './DetailsOverview';
+
+import type {
+  DetailsDescriptionProps,
+  LocaleWarningType,
+  EolBlockProps
+} from './types';
+
+export default function DetailsDescription({
+  experiment,
+  graduated,
+  locale,
+  hasAddon,
+  installedAddons,
+  highlightMeasurementPanel
+}: DetailsDescriptionProps) {
+  const {
+    introduction,
+    warning,
+    details,
+    measurements,
+    video_url,
+    graduation_url,
+    completed
+  } = experiment;
+
+  const l10nId = pieces => experimentL10nId(experiment, pieces);
+
+  return (
+    <div className="details-description">
+      {completed && !graduated && <EolBlock {...{ experiment, l10nId }} />}
+      <IncompatibleAddons {...{ experiment, installedAddons }} />
+      <LocaleWarning {...{ experiment, locale, hasAddon }} />
+      {graduated && <GraduatedNotice {...{ graduated, graduation_url }} />}
+
+      {video_url &&
+        <iframe
+          width="100%"
+          height="360"
+          src={video_url}
+          frameBorder="0"
+          allowFullScreen
+          className="experiment-video"
+        />}
+      <div>
+        {!!introduction &&
+          <section className="introduction">
+            {!!warning &&
+              <div className="warning">
+                <Localized id={l10nId('warning')}>
+                  <strong>
+                    {warning}
+                  </strong>
+                </Localized>
+              </div>}
+            <LocalizedHtml id={l10nId('introduction')}>
+              <div>
+                {parser(introduction)}
+              </div>
+            </LocalizedHtml>
+          </section>}
+      </div>
+      <div className="details-list">
+        {details.map(({ image, copy, headline }, idx) =>
+          <div key={idx}>
+            <div className="details-image">
+              <img width="680" src={image} />
+              <p className="caption">
+                {headline &&
+                  <Localized id={l10nId(['details', idx, 'headline'])}>
+                    <strong>
+                      {headline}
+                    </strong>
+                  </Localized>}
+                {copy &&
+                  <Localized id={l10nId(['details', idx, 'copy'])}>
+                    <span>
+                      {parser(copy)}
+                    </span>
+                  </Localized>}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+      {hasAddon &&
+        !graduated &&
+        measurements &&
+        <div>
+          <MeasurementsSection
+            {...{ experiment, highlightMeasurementPanel, l10nId }}
+          />
+        </div>}
+    </div>
+  );
+}
+
+export const LocaleWarning = ({
+  experiment,
+  locale,
+  hasAddon
+}: LocaleWarningType) => {
+  const { locales, locale_blocklist } = experiment;
+  if (
+    hasAddon !== null &&
+    locale &&
+    ((locales && !locales.includes(locale)) ||
+      (locale_blocklist && locale_blocklist.includes(locale)))
+  ) {
+    return (
+      <Warning
+        titleL10nId="localeNotTranslatedWarningTitle"
+        titleL10nArgs={JSON.stringify({ locale_code: locale })}
+        title="This experiment has not been translated to your language (en)."
+        subtitleL10nId="localeWarningSubtitle"
+        subtitle="You can still enable it if you like."
+      />
+    );
+  }
+  return null;
+};
+
+export const EolBlock = ({ experiment, l10nId }: EolBlockProps) => {
+  const completedDate = formatDate(experiment.completed);
+  const title = `${experiment.title} is ending on ${completedDate}`;
+
+  return (
+    <Warning
+      titleL10nId="eolIntroMessage"
+      titleL10nArgs={JSON.stringify({ title: experiment.title, completedDate })}
+      title={title}
+    >
+      <Localized id={l10nId('eolWarning')}>
+        <div>
+          {parser(experiment.eol_warning)}
+        </div>
+      </Localized>
+      <div className="small-spacer" />
+      <Localized id="eolNoticeLink">
+        <a href="/about" target="_blank" rel="noopener noreferrer">
+          Learn more
+        </a>
+      </Localized>
+    </Warning>
+  );
+};

--- a/frontend/src/app/containers/ExperimentPage/DetailsHeader.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsHeader.js
@@ -1,0 +1,587 @@
+// @flow
+
+import React from 'react';
+import classnames from 'classnames';
+import { Localized } from 'fluent-react/compat';
+import LayoutWrapper from '../../components/LayoutWrapper';
+import { experimentL10nId } from '../../lib/utils';
+
+import type {
+  DetailsHeaderProps,
+  ExperimentControlsType,
+  WebExperimentControlsType,
+  EnableButtonType,
+  MinimumVersionNoticeType,
+  MaximumVersionNoticeType
+} from './types';
+
+type DetailsHeaderState = {
+  useStickyHeader: boolean,
+  stickyHeaderSiblingHeight: number,
+  changeHeaderOn: number
+};
+
+export const PRIVACY_SCROLL_OFFSET = 15;
+
+export default class DetailsHeader extends React.Component {
+  props: DetailsHeaderProps;
+  state: DetailsHeaderState;
+  didScroll: boolean;
+  scrollListener: Function;
+
+  constructor(props: DetailsHeaderProps) {
+    super(props);
+
+    this.state = {
+      useStickyHeader: false,
+      stickyHeaderSiblingHeight: 0,
+      changeHeaderOn: 125
+    };
+
+    // HACK: Set this as a plain object property, so we don't trigger crazy
+    // state changes on scrolling events.
+    this.didScroll = false;
+  }
+
+  componentDidMount() {
+    this.scrollListener = () => {
+      if (!this.didScroll && this.props.hasAddon) {
+        this.didScroll = true;
+        setTimeout(this.onScroll.bind(this), 1);
+      }
+    };
+    this.props.addScrollListener(this.scrollListener);
+  }
+
+  componentWillUnmount() {
+    this.props.removeScrollListener(this.scrollListener);
+  }
+
+  render() {
+    const { highlightPrivacy, l10nId } = this;
+
+    const {
+      sendToGA,
+      userAgent,
+      hasAddon,
+      progressButtonWidth,
+      isDisabling,
+      isEnabling,
+      enabled,
+      installed,
+      graduated,
+      experiment,
+      surveyURL,
+      installExperiment,
+      doShowEolDialog,
+      doShowPreFeedbackDialog,
+      uninstallExperimentWithSurvey
+    } = this.props;
+
+    const { useStickyHeader, stickyHeaderSiblingHeight } = this.state;
+
+    const { title, subtitle, error, min_release, max_release } = experiment;
+
+    let statusType = null;
+    if (error) {
+      statusType = 'error';
+    } else if (enabled) {
+      statusType = 'enabled';
+    }
+
+    const hasStatus =
+      !!statusType &&
+      !(
+        installed[experiment.addon_id] &&
+        installed[experiment.addon_id].manuallyDisabled
+      );
+
+    return (
+      <div>
+        <div
+          key="details-header-wrapper"
+          className={classnames('details-header-wrapper', {
+            'has-status': hasStatus,
+            stick: useStickyHeader
+          })}
+        >
+          <div className={classnames('status-bar', statusType)}>
+            {statusType === 'enabled' &&
+              <Localized id="isEnabledStatusMessage" $title={title}>
+                <span>
+                  {title} is enabled.
+                </span>
+              </Localized>}
+            {statusType === 'error' &&
+              <Localized id="installErrorMessage" $title={title}>
+                <span>
+                  Uh oh. {title} could not be enabled. Try again later.
+                </span>
+              </Localized>}
+          </div>
+          <LayoutWrapper
+            helperClass="details-header"
+            flexModifier="row-between-breaking"
+          >
+            <header>
+              <h1>
+                {title}
+              </h1>
+              {subtitle &&
+                <Localized id={l10nId('subtitle')}>
+                  <h4 className="subtitle">
+                    {subtitle}
+                  </h4>
+                </Localized>}
+            </header>
+            <ExperimentControls
+              {...{
+                sendToGA,
+                hasAddon,
+                userAgent,
+                experiment,
+                surveyURL,
+                installed,
+                graduated,
+                enabled,
+                progressButtonWidth,
+                installExperiment,
+                isEnabling,
+                isDisabling,
+                highlightPrivacy,
+                doShowEolDialog,
+                doShowPreFeedbackDialog,
+                uninstallExperimentWithSurvey
+              }}
+            />
+            <MinimumVersionNotice
+              {...{ userAgent, title, hasAddon, min_release, sendToGA }}
+            />
+            <MaximumVersionNotice
+              {...{
+                userAgent,
+                title,
+                hasAddon,
+                max_release,
+                graduated,
+                sendToGA
+              }}
+            />
+          </LayoutWrapper>
+        </div>
+        <div
+          key="sticky-header-sibling"
+          className="sticky-header-sibling"
+          style={{ height: `${stickyHeaderSiblingHeight}px` }}
+        />
+      </div>
+    );
+  }
+
+  onScroll() {
+    const { getElementOffsetHeight, getScrollY } = this.props;
+    const sy = getScrollY();
+    const detailsHeaderWrapperHeight = getElementOffsetHeight(
+      '.details-header-wrapper'
+    );
+    const changeHeaderOn = this.setChangeHeaderOn(detailsHeaderWrapperHeight);
+    const useStickyHeader = sy > changeHeaderOn;
+    const stickyHeaderSiblingHeight = this.setStickyHeaderSiblingHeight(
+      detailsHeaderWrapperHeight,
+      useStickyHeader
+    );
+
+    this.setState({
+      changeHeaderOn,
+      useStickyHeader,
+      stickyHeaderSiblingHeight
+    });
+    this.didScroll = false;
+  }
+
+  // if there is no content in the .status-bar
+  // adjust the initial snap position and the header isn't yet sticky, adjust
+  // changeHeaderOn to the top of the .details-header
+  // instead of the bottom of the #main-header
+  setChangeHeaderOn(detailsHeaderWrapperHeight: number) {
+    const { getElementOffsetHeight, experiment } = this.props;
+    const statusBar = experiment.error || this.props.enabled;
+    const detailsHeaderHeight = getElementOffsetHeight('.details-header');
+    let changeHeaderOn = getElementOffsetHeight('#main-header');
+
+    if (!statusBar) {
+      if (this.state.useStickyHeader) {
+        changeHeaderOn = this.state.stickyHeaderSiblingHeight;
+      } else {
+        changeHeaderOn += detailsHeaderWrapperHeight - detailsHeaderHeight;
+      }
+    }
+
+    return changeHeaderOn;
+  }
+
+  // modify the height of the .sticky-header-sibling if useStickyHeader.
+  // Since the height of the details header changes height depending on
+  // whether there is a visible status, always set the state to whatever
+  // is tallest
+  setStickyHeaderSiblingHeight(detailsHeaderWrapperHeight: number, useStickyHeader: boolean) {
+    let stickyHeaderSiblingHeight = 0;
+
+    if (useStickyHeader) {
+      stickyHeaderSiblingHeight = Math.max(
+        detailsHeaderWrapperHeight,
+        this.state.stickyHeaderSiblingHeight
+      );
+    }
+
+    return stickyHeaderSiblingHeight;
+  }
+
+  l10nId = (pieces: string) => experimentL10nId(this.props.experiment, pieces);
+
+  // scrollOffset lets us scroll to the top of the highlight box shadow animation
+  highlightPrivacy = (evt: Event) => {
+    const {
+      getElementOffsetHeight,
+      getElementY,
+      setScrollY,
+      flashMeasurementPanel
+    } = this.props;
+    const detailsHeaderWrapperHeight = getElementOffsetHeight(
+      '.details-header-wrapper'
+    );
+    const changeHeaderOn = this.setChangeHeaderOn(detailsHeaderWrapperHeight);
+    const stickyHeaderSiblingHeight = this.setStickyHeaderSiblingHeight(
+      detailsHeaderWrapperHeight,
+      true
+    );
+    evt.preventDefault();
+    setScrollY(
+      getElementY('.measurements') +
+        (stickyHeaderSiblingHeight - PRIVACY_SCROLL_OFFSET)
+    );
+    this.setState({
+      changeHeaderOn,
+      stickyHeaderSiblingHeight,
+      useStickyHeader: true
+    });
+    flashMeasurementPanel();
+  };
+}
+
+function maxVersionCheck(userAgent: string, max: number) {
+  const version = parseInt(userAgent.split('/').pop(), 10);
+  return typeof max === 'undefined' || version <= max;
+}
+
+function minVersionCheck(userAgent: string, min: number) {
+  const version = parseInt(userAgent.split('/').pop(), 10);
+  return typeof min === 'undefined' || version >= min;
+}
+
+function isValidVersion(userAgent: string, min: number, max: number) {
+  if (!max) max = Infinity;
+  return minVersionCheck(userAgent, min) && maxVersionCheck(userAgent, max);
+}
+
+export const ExperimentControls = ({
+  hasAddon,
+  userAgent,
+  experiment,
+  installed,
+  graduated,
+  surveyURL,
+  enabled,
+  progressButtonWidth,
+  installExperiment,
+  uninstallExperimentWithSurvey,
+  isEnabling,
+  isDisabling,
+  doShowEolDialog,
+  doShowPreFeedbackDialog,
+  sendToGA,
+  highlightPrivacy
+}: ExperimentControlsType) => {
+  const {
+    title,
+    min_release,
+    max_release,
+    platforms,
+    addon_id,
+    pre_feedback_copy
+  } = experiment;
+
+  const validVersion = isValidVersion(userAgent, min_release, max_release);
+
+  const handleFeedback = evt => {
+    if (pre_feedback_copy === null || !pre_feedback_copy) {
+      sendToGA('event', {
+        eventCategory: 'ExperimentDetailsPage Interactions',
+        eventAction: 'Give Feedback',
+        eventLabel: title
+      });
+    } else {
+      doShowPreFeedbackDialog(evt);
+      sendToGA('event', {
+        eventCategory: 'ExperimentDetailsPage Interactions',
+        eventAction: 'Give Feedback',
+        eventLabel: experiment.title
+      });
+    }
+  };
+
+  if (!hasAddon || !validVersion) {
+    const useWebLink = (platforms || []).indexOf('web') !== -1;
+    if (!useWebLink) {
+      return null;
+    }
+  }
+  if (graduated) {
+    if (enabled) {
+      return (
+        <div className="experiment-controls">
+          <button
+            onClick={doShowEolDialog}
+            style={{ minWidth: progressButtonWidth }}
+            id="uninstall-button"
+            className={classnames(['button', 'warning'], {
+              'state-change': isDisabling
+            })}
+          >
+            <span className="state-change-inner" />
+            <Localized id="disableExperimentTransition">
+              <span className="transition-text">Disabling...</span>
+            </Localized>
+            <Localized id="disableExperiment" $title={title}>
+              <span className="default-text">
+                Disable {title}
+              </span>
+            </Localized>
+          </button>
+        </div>
+      );
+    }
+    return null;
+  }
+  if (
+    installed &&
+    installed[addon_id] &&
+    installed[addon_id].manuallyDisabled
+  ) {
+    return (
+      <div className="experiment-controls">
+        <button
+          disabled
+          onClick={e => {
+            e.preventDefault();
+          }}
+          style={{ minWidth: progressButtonWidth }}
+          id="install-button"
+          className={classnames(['button', 'default'])}
+        >
+          <Localized id="experimentManuallyDisabled" $title={title}>
+            <span className="default-text">
+              {title} disabled in Add-ons Manager
+            </span>
+          </Localized>
+        </button>
+      </div>
+    );
+  }
+  if (enabled) {
+    return (
+      <div className="experiment-controls">
+        <Localized id="giveFeedback">
+          <a
+            onClick={handleFeedback}
+            id="feedback-button"
+            className="button default"
+            href={surveyURL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Give Feedback
+          </a>
+        </Localized>
+        <button
+          onClick={uninstallExperimentWithSurvey}
+          style={{ minWidth: progressButtonWidth }}
+          id="uninstall-button"
+          className={classnames(['button', 'secondary'], {
+            'state-change': isDisabling
+          })}
+        >
+          <span className="state-change-inner" />
+          <Localized id="disableExperimentTransition">
+            <span className="transition-text">Disabling...</span>
+          </Localized>
+          <Localized id="disableExperiment" $title={title}>
+            <span className="default-text">
+              Disable {title}
+            </span>
+          </Localized>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="experiment-controls">
+      <Localized id="highlightPrivacy">
+        <a onClick={highlightPrivacy} className="highlight-privacy">
+          Your privacy
+        </a>
+      </Localized>
+      <EnableButton
+        {...{
+          experiment,
+          installExperiment,
+          isEnabling,
+          progressButtonWidth,
+          sendToGA
+        }}
+      />
+    </div>
+  );
+};
+
+export const MinimumVersionNotice = ({
+  userAgent,
+  title,
+  hasAddon,
+  min_release,
+  sendToGA
+}: MinimumVersionNoticeType) => {
+  if (hasAddon && !minVersionCheck(userAgent, min_release)) {
+    return (
+      <div className="upgrade-notice">
+        <Localized
+          id="upgradeNoticeTitle"
+          $title={title}
+          $min_release={min_release}
+        >
+          <div>
+            {title} requires Firefox {min_release} or later.
+          </div>
+        </Localized>
+        <Localized id="upgradeNoticeLink">
+          <a
+            onClick={() =>
+              sendToGA('event', {
+                eventCategory: 'ExperimentDetailsPage Interactions',
+                eventAction: 'Upgrade Notice',
+                eventLabel: title
+              })}
+            href="https://support.mozilla.org/kb/find-what-version-firefox-you-are-using"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            How to update Firefox.
+          </a>
+        </Localized>
+      </div>
+    );
+  }
+  return null;
+};
+
+export const MaximumVersionNotice = ({
+  userAgent,
+  title,
+  hasAddon,
+  max_release,
+  graduated,
+  sendToGA
+}: MaximumVersionNoticeType) => {
+  if (hasAddon && !maxVersionCheck(userAgent, max_release) && !graduated) {
+    return (
+      <div className="upgrade-notice">
+        <Localized id="versionChangeNotice" $experiment_title={title}>
+          <div>
+            {title} is not supported in this version of Firefox.
+          </div>
+        </Localized>
+        <Localized id="versionChangeNoticeLink">
+          <a
+            onClick={() =>
+              sendToGA('event', {
+                eventCategory: 'ExperimentDetailsPage Interactions',
+                eventAction: 'Upgrade Notice',
+                eventLabel: title
+              })}
+            href="https://www.mozilla.org/firefox/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Get the current version of Firefox.
+          </a>
+        </Localized>
+      </div>
+    );
+  }
+  return null;
+};
+
+export const WebExperimentControls = ({
+  web_url,
+  title,
+  sendToGA
+}: WebExperimentControlsType) => {
+  function handleGoToLink() {
+    sendToGA('event', {
+      eventCategory: 'ExperimentDetailsPage Interactions',
+      eventAction: 'Enable Experiment',
+      eventLabel: title
+    });
+  }
+
+  return (
+    <a
+      href={web_url}
+      onClick={handleGoToLink}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="button default"
+    >
+      <Localized id="experimentGoToLink" $title={title}>
+        <span className="default-text">
+          Go to {title}
+        </span>
+      </Localized>
+    </a>
+  );
+};
+
+export const EnableButton = ({
+  experiment: { title, web_url, platforms },
+  installExperiment,
+  isEnabling,
+  progressButtonWidth,
+  sendToGA
+}: EnableButtonType) => {
+  const useWebLink = (platforms || []).indexOf('web') !== -1;
+  if (useWebLink) {
+    return <WebExperimentControls {...{ web_url, title, sendToGA }} />;
+  }
+
+  return (
+    <button
+      onClick={installExperiment}
+      style={{ minWidth: progressButtonWidth }}
+      id="install-button"
+      className={classnames(['button', 'default'], {
+        'state-change': isEnabling
+      })}
+    >
+      <span className="state-change-inner" />
+      <Localized id="enableExperimentTransition">
+        <span className="transition-text">Enabling...</span>
+      </Localized>
+      <Localized id="enableExperiment" $title={title}>
+        <span className="default-text">
+          Enable {title}
+        </span>
+      </Localized>
+    </button>
+  );
+};

--- a/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
@@ -1,0 +1,257 @@
+// @flow
+
+import React from 'react';
+import classnames from 'classnames';
+import { Localized } from 'fluent-react/compat';
+import LocalizedHtml from '../../components/LocalizedHtml';
+import { experimentL10nId, formatDate } from '../../lib/utils';
+
+import type {
+  DetailsOverviewType,
+  LaunchStatusType,
+  StatsSectionType,
+  ContributorsSectionType,
+  MeasurementsSectionType
+} from './types';
+
+export default function DetailsOverview({
+  experiment,
+  graduated,
+  highlightMeasurementPanel,
+  doShowTourDialog
+}: DetailsOverviewType) {
+  const { slug, thumbnail, measurements } = experiment;
+  const l10nId = (pieces: string) => experimentL10nId(experiment, pieces);
+
+  return (
+    <div className="details-overview">
+      <div
+        className={`experiment-icon-wrapper-${slug} experiment-icon-wrapper`}
+      >
+        <img className="experiment-icon" src={thumbnail} />
+      </div>
+      <div className="details-sections">
+        <section className="user-count">
+          <LaunchStatus {...{ experiment, graduated }} />
+        </section>
+        {!graduated && <StatsSection {...{ experiment, doShowTourDialog }} />}
+        <ContributorsSection {...{ experiment, l10nId }} />
+        {!graduated &&
+          measurements &&
+          <MeasurementsSection
+            {...{ experiment, highlightMeasurementPanel, l10nId }}
+          />}
+      </div>
+    </div>
+  );
+}
+
+export const LaunchStatus = ({ experiment, graduated }: LaunchStatusType) => {
+  const { created, completed } = experiment;
+
+  const completedDate = formatDate(completed);
+  if (graduated) {
+    return (
+      <LocalizedHtml id="completedDateLabel" $completedDate={completedDate}>
+        <span>
+          Experiment End Date: <b>{completedDate}</b>
+        </span>
+      </LocalizedHtml>
+    );
+  }
+
+  const startedDate = formatDate(created);
+  return (
+    <LocalizedHtml id="startedDateLabel" $startedDate={startedDate}>
+      <span>
+        Experiment Start Date: <b>{startedDate}</b>
+      </span>
+    </LocalizedHtml>
+  );
+};
+
+export const StatsSection = ({
+  doShowTourDialog,
+  experiment: {
+    title,
+    web_url,
+    changelog_url,
+    contribute_url,
+    bug_report_url,
+    discourse_url
+  }
+}: StatsSectionType) =>
+  <div>
+    <section className="stats-section">
+      {!web_url &&
+        <p>
+          <Localized id="tourLink">
+            <a className="showTour" onClick={doShowTourDialog} href="#">
+              Launch Tour
+            </a>
+          </Localized>
+        </p>}
+      <dl>
+        {changelog_url &&
+          <Localized id="changelog">
+            <dt>Changelog</dt>
+          </Localized>}
+        {changelog_url &&
+          <dd>
+            <a href={changelog_url}>
+              {changelog_url}
+            </a>
+          </dd>}
+        <Localized id="contribute">
+          <dt>Contribute</dt>
+        </Localized>
+        <dd>
+          <a href={contribute_url}>
+            {contribute_url}
+          </a>
+        </dd>
+
+        <Localized id="bugReports">
+          <dt>Bug Reports</dt>
+        </Localized>
+        <dd>
+          <a href={bug_report_url}>
+            {bug_report_url}
+          </a>
+        </dd>
+
+        <Localized id="discussExperiment" $title={title}>
+          <dt>
+            {title}
+          </dt>
+        </Localized>
+        <dd>
+          <a href={discourse_url}>
+            {discourse_url}
+          </a>
+        </dd>
+      </dl>
+    </section>
+  </div>;
+
+export const ContributorsSection = ({
+  experiment: { contributors, contributors_extra, contributors_extra_url },
+  l10nId
+}: ContributorsSectionType) =>
+  <section className="contributors-section">
+    <Localized id="contributorsHeading">
+      <h3>Brought to you by</h3>
+    </Localized>
+    <ul className="contributors">
+      {contributors.map((contributor, idx) =>
+        <li key={idx}>
+          <img
+            className="avatar"
+            width="56"
+            height="56"
+            src={contributor.avatar}
+          />
+          <div className="contributor">
+            <p className="name">
+              {contributor.display_name}
+            </p>
+            {contributor.title &&
+              <Localized id={l10nId(['contributors', idx, 'title'])}>
+                <p className="title">
+                  {contributor.title}
+                </p>
+              </Localized>}
+          </div>
+        </li>
+      )}
+    </ul>
+    {contributors_extra &&
+      <p className="disclaimer">
+        <Localized id={l10nId('contributors_extra')}>
+          <span>
+            {contributors_extra}
+          </span>
+        </Localized>
+        {contributors_extra_url &&
+          <span>
+            &nbsp;
+            <Localized id="contributorsExtraLearnMore">
+              <a
+                href={contributors_extra_url}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Learn more
+              </a>
+            </Localized>
+            .
+          </span>}
+      </p>}
+  </section>;
+
+const EXPERIMENT_MEASUREMENT_URLS = [
+  null,
+  null,
+  null,
+  'https://www.mozilla.org/privacy/websites'
+];
+
+export const MeasurementsSection = ({
+  experiment: { title, privacy_preamble, privacy_notice_url, measurements },
+  highlightMeasurementPanel,
+  l10nId
+}: MeasurementsSectionType) => {
+  const privacy = (
+    <Localized id="experimentMeasurementIntroPrivacyLink">
+      <a target="_blank" rel="noopener noreferrer" href="/privacy" />
+    </Localized>
+  );
+
+  return (
+    <section
+      className={classnames('measurements', {
+        highlight: highlightMeasurementPanel
+      })}
+    >
+      <Localized id="measurements">
+        <h3>Your privacy</h3>
+      </Localized>
+      <div data-hook="measurements-html" className="measurement">
+        {privacy_preamble &&
+          <Localized id={l10nId('privacy_preamble')}>
+            <p>
+              {privacy_preamble}
+            </p>
+          </Localized>}
+        <LocalizedHtml
+          id="experimentMeasurementIntro"
+          $experimentTitle={title}
+          $privacy={privacy}
+        >
+          <p>
+            In addition to the {privacy} collected by all Test Pilot
+            experiments, here are the key things you should know about what is
+            happening when you use {title}:
+          </p>
+        </LocalizedHtml>
+        <ul>
+          {measurements.map((note, idx) =>
+            <LocalizedHtml key={idx} id={l10nId(['measurements', idx])}>
+              <li>
+                {EXPERIMENT_MEASUREMENT_URLS[idx] === null
+                  ? null
+                  : <a href={EXPERIMENT_MEASUREMENT_URLS[idx]} />}
+              </li>
+            </LocalizedHtml>
+          )}
+        </ul>
+      </div>
+      {privacy_notice_url &&
+        <Localized id="experimentPrivacyNotice" $title={title}>
+          <a className="privacy-policy" href={privacy_notice_url}>
+            You can learn more about the data collection for {title} here.
+          </a>
+        </Localized>}
+    </section>
+  );
+};

--- a/frontend/src/app/containers/ExperimentPage/index.js
+++ b/frontend/src/app/containers/ExperimentPage/index.js
@@ -1,20 +1,16 @@
+// @flow
+
 import { Localized } from 'fluent-react/compat';
 import React from 'react';
 import moment from 'moment';
 
-import classnames from 'classnames';
-import parser from 'html-react-parser';
-
-import { buildSurveyURL, experimentL10nId, formatDate } from '../../lib/utils';
+import { buildSurveyURL, experimentL10nId } from '../../lib/utils';
 
 import NotFoundPage from '../NotFoundPage';
 
-import EmailDialog from '../../components/EmailDialog';
-import GraduatedNotice from '../../components/GraduatedNotice';
-import LocalizedHtml from '../../components/LocalizedHtml';
-import ExperimentCardList from '../../components/ExperimentCardList';
 import View from '../../components/View';
-import Warning from '../../components/Warning';
+import EmailDialog from '../../components/EmailDialog';
+import ExperimentCardList from '../../components/ExperimentCardList';
 
 import ExperimentPlatforms from '../../components/ExperimentPlatforms';
 import Banner from '../../components/Banner';
@@ -24,10 +20,20 @@ import ExperimentPreFeedbackDialog from './ExperimentPreFeedbackDialog';
 import ExperimentDisableDialog from './ExperimentDisableDialog';
 import ExperimentEolDialog from './ExperimentEolDialog';
 import ExperimentTourDialog from './ExperimentTourDialog';
-import IncompatibleAddons from './IncompatibleAddons';
 import TestpilotPromo from './TestpilotPromo';
+import DetailsOverview from './DetailsOverview';
+import DetailsDescription from './DetailsDescription';
+import DetailsHeader from './DetailsHeader';
+
+import type {
+  ExperimentPageProps,
+  ExperimentDetailProps,
+  MouseEventWithElementTarget
+} from './types';
 
 export default class ExperimentPage extends React.Component {
+  props: ExperimentPageProps;
+
   render() {
     const { getExperimentBySlug, slug } = this.props;
     const experiment = getExperimentBySlug(slug);
@@ -35,32 +41,33 @@ export default class ExperimentPage extends React.Component {
   }
 }
 
-// TODO Implement FlowTypes for ExperimentPage
-
-// ExperimentPage.propTypes = {
-//   getExperimentBySlug: React.PropTypes.func,
-//   params: React.PropTypes.shape({
-//     slug: React.PropTypes.string
-//   })
-// };
-
-
-const EXPERIMENT_MEASUREMENT_URLS = [
-  null,
-  null,
-  null,
-  'https://www.mozilla.org/privacy/websites'
-];
-
 export class ExperimentDetail extends React.Component {
+  props: ExperimentDetailProps;
 
-  constructor(props) {
+  state: {
+    enabled: boolean,
+    highlightMeasurementPanel: boolean,
+    isEnabling: boolean,
+    isDisabling: boolean,
+    progressButtonWidth: ?number,
+    showEmailDialog: boolean,
+    showDisableDialog: boolean,
+    shouldShowTourDialog: boolean,
+    showTourDialog: boolean,
+    showPreFeedbackDialog: boolean,
+    showEolDialog: boolean
+  };
+
+  constructor(props: ExperimentDetailProps) {
     super(props);
 
-    const { isExperimentEnabled, experiment,
-            getCookie, removeCookie, hasAddon } = this.props;
-
-    this.installExperiment = this.installExperiment.bind(this);
+    const {
+      isExperimentEnabled,
+      experiment,
+      getCookie,
+      removeCookie,
+      hasAddon
+    } = this.props;
 
     let showEmailDialog = false;
     if (getCookie('first-run')) {
@@ -73,7 +80,6 @@ export class ExperimentDetail extends React.Component {
     // TODO: Clean this up per #1367
     this.state = {
       enabled: isExperimentEnabled(experiment),
-      useStickyHeader: false,
       highlightMeasurementPanel: false,
       isEnabling: false,
       isDisabling: false,
@@ -83,22 +89,11 @@ export class ExperimentDetail extends React.Component {
       shouldShowTourDialog: false,
       showTourDialog: false,
       showPreFeedbackDialog: false,
-      changeHeaderOn: 125,
-      stickyHeaderSiblingHeight: 0,
-      privacyScrollOffset: 15,
       showEolDialog: false
     };
-
-    // HACK: Set this as a plain object property, so we don't trigger crazy
-    // state changes on scrolling events.
-    this.didScroll = false;
   }
 
-  l10nId(pieces) {
-    return experimentL10nId(this.props.experiment, pieces);
-  }
-
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: ExperimentDetailProps) {
     const { shouldShowTourDialog, enabled: prevEnabled } = this.state;
 
     const prevExperiment = this.props.experiment;
@@ -106,7 +101,8 @@ export class ExperimentDetail extends React.Component {
 
     const nextExperiment = nextProps.experiment;
     const nextInProgress = nextExperiment && nextExperiment.inProgress;
-    const nextEnabled = nextExperiment && nextProps.isExperimentEnabled(nextExperiment);
+    const nextEnabled =
+      nextExperiment && nextProps.isExperimentEnabled(nextExperiment);
 
     if (!nextInProgress && prevInProgress !== nextInProgress) {
       this.setState({
@@ -129,118 +125,122 @@ export class ExperimentDetail extends React.Component {
     }
   }
 
-  renderLocaleWarning() {
-    const { experiment, locale, hasAddon } = this.props;
-    if (hasAddon !== null && locale && ((experiment.locales && !experiment.locales.includes(locale)) || (experiment.locale_blocklist && experiment.locale_blocklist.includes(locale)))) {
-      return (
-        <Warning titleL10nId="localeNotTranslatedWarningTitle"
-                 titleL10nArgs={ JSON.stringify({ locale_code: locale }) }
-                 title="This experiment has not been translated to your language (en)."
-                 subtitleL10nId="localeWarningSubtitle"
-                 subtitle="You can still enable it if you like." />
-      );
-    }
-    return null;
-  }
-
-  renderEolBlock() {
-    const { experiment, isAfterCompletedDate } = this.props;
-    if (!experiment.completed || isAfterCompletedDate(experiment)) { return null; }
-
-    const completedDate = formatDate(experiment.completed);
-    const title = `${experiment.title} is ending on ${completedDate}`;
-
-    return (
-      <Warning titleL10nId="eolIntroMessage"
-               titleL10nArgs={ JSON.stringify({ title: experiment.title, completedDate }) }
-               title={ title }>
-        <Localized id={this.l10nId('eolWarning')}>
-          <div>
-            {parser(experiment.eol_warning)}
-          </div>
-        </Localized>
-        <div className="small-spacer" />
-        <Localized id="eolNoticeLink">
-          <a href="/about" target="_blank" rel="noopener noreferrer">
-            Learn more
-          </a>
-        </Localized>
-      </Warning>
-    );
-  }
-
   render() {
-    const { experiment, experiments, installed, isAfterCompletedDate, isDev,
-            hasAddon, setExperimentLastSeen, clientUUID, installedAddons,
-            setPageTitleL10N } = this.props;
+    const {
+      installExperiment,
+      uninstallExperiment,
+      l10nId,
+      uninstallExperimentWithSurvey,
+      flashMeasurementPanel,
+      doShowEolDialog,
+      doShowTourDialog,
+      doShowPreFeedbackDialog
+    } = this;
+
+    const {
+      userAgent,
+      experiment,
+      experiments,
+      installed,
+      isAfterCompletedDate,
+      isDev,
+      hasAddon,
+      setExperimentLastSeen,
+      clientUUID,
+      installedAddons,
+      setPageTitleL10N,
+      locale,
+      getElementOffsetHeight,
+      getElementY,
+      setScrollY,
+      getScrollY,
+      sendToGA,
+      addScrollListener,
+      removeScrollListener
+    } = this.props;
+
+    const {
+      enabled,
+      progressButtonWidth,
+      highlightMeasurementPanel,
+      showEmailDialog,
+      showDisableDialog,
+      showTourDialog,
+      showPreFeedbackDialog,
+      showEolDialog,
+      isEnabling,
+      isDisabling
+    } = this.state;
 
     // Loading handled in static with react router; don't return anything if no experiments
-    if (experiments.length === 0) { return null; }
+    if (experiments.length === 0) {
+      return null;
+    }
 
     // Show a 404 page if an experiment for this slug wasn't found.
-    if (!experiment) { return <NotFoundPage {...this.props} />; }
+    if (!experiment) {
+      return <NotFoundPage {...this.props} />;
+    }
+
+    const { title, survey_url } = experiment;
 
     setPageTitleL10N('pageTitleExperiment', experiment);
 
     // Show a 404 page if an experiment is not ready for launch yet
     const utcNow = moment.utc();
-    if (moment(utcNow).isBefore(experiment.launch_date)
-        && typeof experiment.launch_date !== 'undefined'
-        && !isDev) {
+    if (
+      moment(utcNow).isBefore(experiment.launch_date) &&
+      typeof experiment.launch_date !== 'undefined' &&
+      !isDev
+    ) {
       return <NotFoundPage />;
     }
-
-    const { enabled, useStickyHeader, highlightMeasurementPanel,
-            showEmailDialog, showDisableDialog, showTourDialog,
-            showPreFeedbackDialog, showEolDialog,
-            stickyHeaderSiblingHeight } = this.state;
-
-    const { title, contribute_url, bug_report_url, discourse_url, privacy_preamble,
-            warning, introduction, measurements, privacy_notice_url, changelog_url,
-            thumbnail, subtitle, survey_url, contributors, contributors_extra, contributors_extra_url, details,
-            min_release, max_release, graduation_url } = experiment;
 
     // Set the timestamp for when this experiment was last seen (for
     // ExperimentRowCard updated/launched banner logic)
     setExperimentLastSeen(experiment);
 
-    const surveyURL = buildSurveyURL('givefeedback', title, installed, clientUUID, survey_url);
+    const surveyURL = buildSurveyURL(
+      'givefeedback',
+      title,
+      installed,
+      clientUUID,
+      survey_url
+    );
     const graduated = isAfterCompletedDate(experiment);
-    const currentExperiments = experiments.filter(x => !isAfterCompletedDate(x));
-
-    let statusType = null;
-    if (experiment.error) {
-      statusType = 'error';
-    } else if (enabled) {
-      statusType = 'enabled';
-    }
-
-    const privacy = (<Localized id="experimentMeasurementIntroPrivacyLink">
-                       <a target="_blank" rel="noopener noreferrer" href="/privacy"/>
-                     </Localized>);
+    const currentExperiments = experiments.filter(
+      x => !isAfterCompletedDate(x)
+    );
 
     return (
       <section id="experiment-page">
-
         {showEmailDialog &&
-          <EmailDialog {...this.props}
-            onDismiss={() => this.setState({ showEmailDialog: false })} />}
+          <EmailDialog
+            {...this.props}
+            onDismiss={() => this.setState({ showEmailDialog: false })}
+          />}
 
         {showDisableDialog &&
-          <ExperimentDisableDialog {...this.props}
+          <ExperimentDisableDialog
+            {...this.props}
             installed={installed}
             onCancel={() => this.setState({ showDisableDialog: false })}
-            onSubmit={() => this.setState({ showDisableDialog: false })} />}
+            onSubmit={() => this.setState({ showDisableDialog: false })}
+          />}
 
         {showTourDialog &&
-          <ExperimentTourDialog {...this.props}
+          <ExperimentTourDialog
+            {...this.props}
             onCancel={() => this.setState({ showTourDialog: false })}
-            onComplete={() => this.setState({ showTourDialog: false })} />}
+            onComplete={() => this.setState({ showTourDialog: false })}
+          />}
 
         {showPreFeedbackDialog &&
-          <ExperimentPreFeedbackDialog {...this.props}
+          <ExperimentPreFeedbackDialog
+            {...this.props}
             surveyURL={surveyURL}
-            onCancel={() => this.setState({ showPreFeedbackDialog: false })} />}
+            onCancel={() => this.setState({ showPreFeedbackDialog: false })}
+          />}
 
         {showEolDialog &&
           <ExperimentEolDialog
@@ -249,243 +249,92 @@ export class ExperimentDetail extends React.Component {
             onSubmit={e => {
               this.setState({ showEolDialog: false });
               this.uninstallExperiment(e);
-            }} />}
+            }}
+          />}
 
         <View {...this.props}>
-
-          <TestpilotPromo {...{
-            ...this.props,
-            graduated,
-            experiment,
-            installCallback: this.installExperiment
-          }} />
-
-        <div className="default-background">
-          <div className={classnames(
-              'details-header-wrapper',
-            {
-              'has-status': !!statusType && !(installed[experiment.addon_id] && installed[experiment.addon_id].manuallyDisabled),
-              stick: useStickyHeader
-            })
-            }>
-            <div className={classnames('status-bar', statusType)}>
-              {(statusType === 'enabled') && <Localized id="isEnabledStatusMessage" $title={ title }>
-                <span>{title} is enabled.</span>
-              </Localized>}
-              {(statusType === 'error') && <Localized id="installErrorMessage" $title={ title }>
-                <span>Uh oh. {title} could not be enabled. Try again later.</span>
-              </Localized>}
-            </div>
-            <LayoutWrapper helperClass="details-header" flexModifier="row-between-breaking">
-              <header>
-                <h1>{title}</h1>
-                {subtitle && <Localized id={this.l10nId('subtitle')}>
-                  <h4 className="subtitle">{subtitle}</h4>
-                </Localized>}
-              </header>
-              { this.renderExperimentControls() }
-              { this.renderMinimumVersionNotice(title, hasAddon, min_release) }
-              { this.renderMaximumVersionNotice(title, hasAddon, max_release, graduated) }
-            </LayoutWrapper>
-          </div>
-          <div className="sticky-header-sibling" style={{ height: `${stickyHeaderSiblingHeight}px` }} ></div>
-
-          <div id="details">
+          <TestpilotPromo
+            {...{
+              ...this.props,
+              graduated,
+              experiment,
+              installCallback: installExperiment
+            }}
+          />
+          <div className="default-background">
+            <DetailsHeader
+              {...{
+                hasAddon,
+                userAgent,
+                experiment,
+                enabled,
+                installed,
+                graduated,
+                surveyURL,
+                progressButtonWidth,
+                flashMeasurementPanel,
+                installExperiment,
+                uninstallExperiment,
+                isEnabling,
+                isDisabling,
+                uninstallExperimentWithSurvey,
+                getElementOffsetHeight,
+                getElementY,
+                setScrollY,
+                getScrollY,
+                l10nId,
+                sendToGA,
+                doShowEolDialog,
+                doShowPreFeedbackDialog,
+                addScrollListener,
+                removeScrollListener
+              }}
+            />
+            <div id="details">
               <LayoutWrapper>
-                {experiment.platforms && <ExperimentPlatforms experiment={experiment} />}
+                {experiment.platforms &&
+                  <ExperimentPlatforms experiment={experiment} />}
               </LayoutWrapper>
-              <LayoutWrapper helperClass="details-content" flexModifier="details-content">
-                  <div className="details-overview">
-                  <div className={`experiment-icon-wrapper-${experiment.slug} experiment-icon-wrapper`}>
-                    <img className="experiment-icon" src={thumbnail}></img>
-                  </div>
-                  <div className="details-sections">
-                    <section className="user-count">
-                      { this.renderLaunchStatus() }
-                    </section>
-                    <div>
-                    {!graduated &&
-                      <section className="stats-section">
-                        {!experiment.web_url &&
-                        <p>
-                          <Localized id="tourLink">
-                            <a className="showTour" onClick={e => this.showTour(e)} href="#">Launch Tour</a>
-                          </Localized>
-                        </p>}
-                        <dl>
-                          {changelog_url &&
-                          <Localized id="changelog">
-                            <dt>Changelog</dt>
-                          </Localized>}
-                          {changelog_url &&
-                          <dd><a href={changelog_url}>{changelog_url}</a></dd>}
-                          <Localized id="contribute">
-                            <dt>Contribute</dt>
-                          </Localized>
-                          <dd><a href={contribute_url}>{contribute_url}</a></dd>
-
-                          <Localized id="bugReports">
-                            <dt>Bug Reports</dt>
-                          </Localized>
-                          <dd><a href={bug_report_url}>{bug_report_url}</a></dd>
-
-                          <Localized id="discussExperiment" $title={title}>
-                            <dt>{title}</dt>
-                          </Localized>
-                          <dd><a href={discourse_url}>{discourse_url}</a></dd>
-                        </dl>
-                      </section>}
-                    </div>
-                    <section className="contributors-section">
-                      <Localized id="contributorsHeading">
-                        <h3>Brought to you by</h3>
-                      </Localized>
-                      <ul className="contributors">
-                        {contributors.map((contributor, idx) => (
-                          <li key={idx}>
-                            <img className="avatar" width="56" height="56" src={contributor.avatar} />
-                            <div className="contributor">
-                              <p className="name">{contributor.display_name}</p>
-                              {contributor.title && <Localized id={this.l10nId(['contributors', idx, 'title'])}>
-                                <p className="title">{contributor.title}</p>
-                              </Localized>}
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    {contributors_extra && <p className="disclaimer">
-                        <Localized id={this.l10nId('contributors_extra')}>
-                          <span>{contributors_extra}</span>
-                        </Localized>
-                        {contributors_extra_url && <span>&nbsp;
-                          <Localized id="contributorsExtraLearnMore">
-                            <a href={contributors_extra_url} target="_blank" rel="noopener noreferrer">Learn more</a>
-                          </Localized>
-                          .
-                        </span>}
-                      </p>
-                    }
-                    </section>
-                    {!graduated && <div>
-                      <div>
-                        {measurements && <section
-                              className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
-                          <Localized id="measurements">
-                            <h3>Your privacy</h3>
-                          </Localized>
-                          <div data-hook="measurements-html" className="measurement">
-                            {privacy_preamble && <Localized id={this.l10nId('privacy_preamble')}>
-                              <p>{privacy_preamble}</p>
-                            </Localized>}
-                            <LocalizedHtml id="experimentMeasurementIntro"
-                              $experimentTitle={experiment.title} $privacy={privacy}>
-                              <p>
-                                In addition to the {privacy} collected by all Test Pilot experiments, here are the key things you should know about what is happening when you use {experiment.title}:
-                              </p>
-                            </LocalizedHtml>
-                            <ul>
-                              {measurements.map((note, idx) => <LocalizedHtml key={idx} id={this.l10nId(['measurements', idx])}>
-                                <li>{
-                                  EXPERIMENT_MEASUREMENT_URLS[idx] === null ? null : <a href={EXPERIMENT_MEASUREMENT_URLS[idx]}></a>
-                                }</li>
-                              </LocalizedHtml>)}
-                            </ul>
-                          </div>
-                          {privacy_notice_url && <Localized id="experimentPrivacyNotice" $title={title}>
-                            <a className="privacy-policy" href={privacy_notice_url}>You can learn more about the data collection for {title} here.</a>
-                          </Localized>}
-                        </section>}
-                      </div>
-                    </div>}
-                  </div>
-                </div>
-                <div className="details-description">
-                  {this.renderEolBlock()}
-                  <IncompatibleAddons {...{ experiment, installedAddons }} />
-                  {this.renderLocaleWarning()}
-                  {graduated && <GraduatedNotice graduated={graduated} graduation_url={graduation_url} />}
-
-                  {experiment.video_url &&
-                    <iframe width="100%" height="360" src={experiment.video_url} frameBorder="0" allowFullScreen className="experiment-video"></iframe>
-                  }
-                  <div>
-                   {!!introduction && <section className="introduction">
-                     {!!warning && <div className="warning">
-                       <Localized id={this.l10nId('warning')}>
-                         <strong>{warning}</strong>
-                       </Localized>
-                     </div>}
-                     <LocalizedHtml id={this.l10nId('introduction')}>
-                       <div>
-                         {parser(introduction)}
-                       </div>
-                     </LocalizedHtml>
-                   </section>}
-                  </div>
-                  <div className="details-list">
-                    {details.map((detail, idx) => (
-                     <div key={idx}>
-                       <div className="details-image">
-                         <img width="680" src={detail.image} />
-                         <p className="caption">
-                           {detail.headline && <Localized id={this.l10nId(['details', idx, 'headline'])}>
-                             <strong>{detail.headline}</strong>
-                           </Localized>}
-                           {detail.copy && <Localized id={this.l10nId(['details', idx, 'copy'])}>
-                             <span>
-                               {parser(detail.copy)}
-                             </span>
-                           </Localized>}
-                         </p>
-                       </div>
-                     </div>
-                    ))}
-                  </div>
-                  {hasAddon && !graduated && <div>
-                    {measurements && <section
-                          className={classnames('measurements', { highlight: highlightMeasurementPanel })}>
-                      <Localized id="measurements">
-                        <h3>Your privacy</h3>
-                      </Localized>
-                      <div data-hook="measurements-html" className="measurement">
-                        {privacy_preamble && <Localized id={this.l10nId('privacy_preamble')}>
-                          <p>{privacy_preamble}</p>
-                        </Localized>}
-                        <LocalizedHtml id="experimentMeasurementIntro" $experimentTitle={experiment.title} $privacy={privacy}>
-                          <p>
-                            In addition to the
-                            {privacy}
-                            collected by all Test Pilot experiments, here are the key things you should know about what is happening when you use {experiment.title}:
-                          </p>
-                        </LocalizedHtml>
-                        <ul>
-                          {measurements.map((note, idx) => (
-                            <LocalizedHtml key={idx} id={this.l10nId(['measurements', idx])}>
-                              <li>{
-                                EXPERIMENT_MEASUREMENT_URLS[idx] === null ? null : <a href={EXPERIMENT_MEASUREMENT_URLS[idx]}></a>
-                              }</li>
-                            </LocalizedHtml>
-                          ))}
-                        </ul>
-                      </div>
-                      {privacy_notice_url && <Localized id="experimentPrivacyNotice" $title={title}>
-                        <a className="privacy-policy" href={privacy_notice_url}><span data-hook="title"></span></a>
-                      </Localized>}
-                    </section>}
-                  </div>}
-                </div>
+              <LayoutWrapper
+                helperClass="details-content"
+                flexModifier="details-content"
+              >
+                <DetailsOverview
+                  {...{
+                    experiment,
+                    graduated,
+                    highlightMeasurementPanel,
+                    doShowTourDialog,
+                    l10nId
+                  }}
+                />
+                <DetailsDescription
+                  {...{
+                    experiment,
+                    graduated,
+                    locale,
+                    hasAddon,
+                    installedAddons,
+                    highlightMeasurementPanel,
+                    l10nId
+                  }}
+                />
               </LayoutWrapper>
             </div>
           </div>
           <Banner>
             <Localized id="otherExperiments">
-              <h2 className="banner__subtitle centered">Try out these experiments as well</h2>
+              <h2 className="banner__subtitle centered">
+                Try out these experiments as well
+              </h2>
             </Localized>
             <LayoutWrapper flexModifier="card-list">
-              <ExperimentCardList {...this.props}
-                                  experiments={currentExperiments}
-                                  except={experiment.slug}
-                                  eventCategory="ExperimentsDetailPage Interactions" />
+              <ExperimentCardList
+                {...this.props}
+                experiments={currentExperiments}
+                except={experiment.slug}
+                eventCategory="ExperimentsDetailPage Interactions"
+              />
             </LayoutWrapper>
           </Banner>
         </View>
@@ -493,315 +342,18 @@ export class ExperimentDetail extends React.Component {
     );
   }
 
-  componentDidMount() {
-    this.scrollListener = () => {
-      if (!this.didScroll && this.props.hasAddon) {
-        this.didScroll = true;
-        setTimeout(this.onScroll.bind(this), 1);
-      }
-    };
-    this.props.addScrollListener(this.scrollListener);
-  }
+  l10nId = (pieces: string) => experimentL10nId(this.props.experiment, pieces);
 
-  componentWillUnmount() {
-    this.props.removeScrollListener(this.scrollListener);
-  }
-
-  onScroll() {
-    const { getElementOffsetHeight, getScrollY } = this.props;
-    const sy = getScrollY();
-    const detailsHeaderWrapperHeight = getElementOffsetHeight('.details-header-wrapper');
-    const changeHeaderOn = this.setChangeHeaderOn(detailsHeaderWrapperHeight);
-    const useStickyHeader = sy > changeHeaderOn;
-    const stickyHeaderSiblingHeight = this.setStickyHeaderSiblingHeight(detailsHeaderWrapperHeight, useStickyHeader);
-
-    this.setState({
-      changeHeaderOn,
-      useStickyHeader,
-      stickyHeaderSiblingHeight });
-    this.didScroll = false;
-  }
-
-  // if there is no content in the .status-bar
-  // adjust the initial snap position and the header isn't yet sticky, adjust
-  // changeHeaderOn to the top of the .details-header
-  // instead of the bottom of the #main-header
-  setChangeHeaderOn(detailsHeaderWrapperHeight) {
-    const { getElementOffsetHeight, experiment } = this.props;
-    const statusBar = experiment.error || this.state.enabled;
-    const detailsHeaderHeight = getElementOffsetHeight('.details-header');
-    let changeHeaderOn = getElementOffsetHeight('#main-header');
-
-    if (!statusBar) {
-      if (this.state.useStickyHeader) {
-        changeHeaderOn = this.state.stickyHeaderSiblingHeight;
-      } else {
-        changeHeaderOn += (detailsHeaderWrapperHeight - detailsHeaderHeight);
-      }
-    }
-
-    return changeHeaderOn;
-  }
-
-  // modify the height of the .sticky-header-sibling if useStickyHeader.
-  // Since the height of the details header changes height depending on
-  // whether there is a visible status, always set the state to whatever
-  // is tallest
-  setStickyHeaderSiblingHeight(detailsHeaderWrapperHeight, useStickyHeader) {
-    let stickyHeaderSiblingHeight = 0;
-
-    if (useStickyHeader) {
-      stickyHeaderSiblingHeight = Math.max(
-        detailsHeaderWrapperHeight, this.state.stickyHeaderSiblingHeight);
-    }
-
-    return stickyHeaderSiblingHeight;
-  }
-
-  renderLaunchStatus() {
-    const { experiment, isAfterCompletedDate } = this.props;
-    const { created, completed } = experiment;
-
-    if (isAfterCompletedDate(experiment)) {
-      const completedDate = <b>
-        {formatDate(completed)}
-      </b>;
-      return <LocalizedHtml id="completedDateLabel" $completedDate={completedDate}>
-        <span>Experiment End Date: {completedDate}</span>
-      </LocalizedHtml>;
-    }
-    // Don't show installation counts any more
-    const startedDate = <b>
-      {formatDate(created)}
-    </b>;
-    return <LocalizedHtml id="startedDateLabel" $startedDate={startedDate}>
-      <span>Experiment Start Date: {startedDate}</span>
-    </LocalizedHtml>;
-  }
-
-  maxVersionCheck(max) {
-    const version = parseInt(this.props.userAgent.split('/').pop(), 10);
-    return typeof max === 'undefined' || version <= max;
-  }
-
-  minVersionCheck(min) {
-    const version = parseInt(this.props.userAgent.split('/').pop(), 10);
-    return typeof min === 'undefined' || version >= min;
-  }
-
-  isValidVersion(min, max) {
-    if (!max) max = Infinity;
-    return this.minVersionCheck(min) && this.maxVersionCheck(max);
-  }
-
-  renderMinimumVersionNotice(title, hasAddon, min_release) {
-    if (hasAddon && !this.minVersionCheck(min_release)) {
-      return (
-        <div className="upgrade-notice">
-          <Localized id="upgradeNoticeTitle" $title={title} $min_release={min_release}>
-            <div>{title} requires Firefox {min_release} or later.</div>
-          </Localized>
-          <Localized id="upgradeNoticeLink">
-            <a onClick={e => this.clickUpgradeNotice(e)} href="https://support.mozilla.org/kb/find-what-version-firefox-you-are-using" target="_blank" rel="noopener noreferrer">How to update Firefox.</a>
-          </Localized>
-        </div>
-      );
-    }
-    return null;
-  }
-
-  renderMaximumVersionNotice(title, hasAddon, max_release, graduated) {
-    if (hasAddon && !this.maxVersionCheck(max_release) && !graduated) {
-      return (
-        <div className="upgrade-notice">
-          <Localized id="versionChangeNotice" $experiment_title={title}>
-            <div>{title} is not supported in this version of Firefox.</div>
-          </Localized>
-          <Localized id="versionChangeNoticeLink">
-            <a onClick={e => this.clickUpgradeNotice(e)} href="https://www.mozilla.org/firefox/" target="_blank" rel="noopener noreferrer">Get the current version of Firefox.</a>
-          </Localized>
-        </div>
-      );
-    }
-    return null;
-  }
-
-  renderWebExperimentControls(web_url, title) {
-    return (
-      <a href={web_url} onClick={() => this.handleGoToLink()} target="_blank" rel="noopener noreferrer" className="button default">
-        <Localized id="experimentGoToLink" $title={ title }>
-          <span className="default-text">Go to { title }</span>
-        </Localized>
-      </a>
-    );
-  }
-
-  renderExperimentControls() {
-    const { enabled, isDisabling, progressButtonWidth } = this.state;
-    const { experiment, installed, isAfterCompletedDate, hasAddon, clientUUID } = this.props;
-    const { title, min_release, max_release, survey_url } = experiment;
-    const validVersion = this.isValidVersion(min_release, max_release);
-    const surveyURL = buildSurveyURL('givefeedback', title, installed, clientUUID, survey_url);
-
-    if (!hasAddon || !validVersion) {
-      const useWebLink = (experiment.platforms || []).indexOf('web') !== -1;
-      if (!useWebLink) {
-        return null;
-      }
-    }
-    if (isAfterCompletedDate(experiment)) {
-      if (enabled) {
-        return (
-          <div className="experiment-controls">
-            <button onClick={e => { e.preventDefault(); this.setState({ showEolDialog: true }); }} style={{ minWidth: progressButtonWidth }} id="uninstall-button" className={classnames(['button', 'warning'], { 'state-change': isDisabling })}>
-              <span className="state-change-inner"></span>
-              <Localized id="disableExperimentTransition">
-                <span className="transition-text">Disabling...</span>
-              </Localized>
-              <Localized id="disableExperiment" $title={title}>
-                <span className="default-text">Disable {title}</span>
-              </Localized>
-            </button>
-          </div>
-        );
-      }
-      return null;
-    }
-    if (installed && installed[experiment.addon_id] && installed[experiment.addon_id].manuallyDisabled) {
-      return <div className="experiment-controls">
-        <button disabled onClick={e => { e.preventDefault(); }} style={{ minWidth: progressButtonWidth }} id="install-button"  className={classnames(['button', 'default'])}>
-          <Localized id="experimentManuallyDisabled" $title={title}>
-            <span className="default-text">{title} disabled in Add-ons Manager</span>
-          </Localized>
-        </button>
-      </div>;
-    }
-    if (enabled) {
-      return <div className="experiment-controls">
-        <Localized id="giveFeedback">
-          <a onClick={e => this.handleFeedback(e)} id="feedback-button" className="button default" href={surveyURL} target="_blank" rel="noopener noreferrer">Give Feedback</a>
-        </Localized>
-        <button onClick={e => this.renderUninstallSurvey(e)} style={{ minWidth: progressButtonWidth }} id="uninstall-button" className={classnames(['button', 'secondary'], { 'state-change': isDisabling })}><span className="state-change-inner"></span>
-          <Localized id="disableExperimentTransition">
-            <span className="transition-text">Disabling...</span>
-          </Localized>
-          <Localized id="disableExperiment" $title={title}>
-            <span className="default-text">Disable {title}</span>
-          </Localized>
-        </button>
-      </div>;
-    }
-
-    return (
-      <div className="experiment-controls">
-        <Localized id="highlightPrivacy">
-          <a onClick={e => this.highlightPrivacy(e)} className="highlight-privacy">Your privacy</a>
-        </Localized>
-        {this.renderEnableButton()}
-      </div>
-    );
-  }
-
-  renderEnableButton() {
-    const { experiment } = this.props;
-    const { title } = experiment;
-    const useWebLink = (experiment.platforms || []).indexOf('web') !== -1;
-    if (useWebLink) {
-      return this.renderWebExperimentControls(experiment.web_url, title);
-    }
-
-    const { isEnabling, progressButtonWidth } = this.state;
-    return (
-      <button onClick={e => this.installExperiment(e)} style={{ minWidth: progressButtonWidth }} id="install-button"  className={classnames(['button', 'default'], { 'state-change': isEnabling })}>
-        <span className="state-change-inner"></span>
-        <Localized id="enableExperimentTransition">
-          <span className="transition-text">Enabling...</span>
-        </Localized>
-        <Localized id="enableExperiment" $title={ title }>
-          <span className="default-text">Enable { title }</span>
-        </Localized>
-      </button>
-    );
-  }
-
-  handleGoToLink() {
-    this.props.sendToGA('event', {
-      eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'Enable Experiment',
-      eventLabel: this.props.experiment.title
-    });
-  }
-
-  // scrollOffset lets us scroll to the top of the highlight box shadow animation
-  highlightPrivacy(evt) {
-    const { getElementOffsetHeight, getElementY, setScrollY } = this.props;
-    const { privacyScrollOffset } = this.state;
-    const detailsHeaderWrapperHeight = getElementOffsetHeight('.details-header-wrapper');
-    const changeHeaderOn = this.setChangeHeaderOn(detailsHeaderWrapperHeight);
-    const stickyHeaderSiblingHeight = this.setStickyHeaderSiblingHeight(detailsHeaderWrapperHeight, true);
-    evt.preventDefault();
-    setScrollY(getElementY('.measurements') + (stickyHeaderSiblingHeight - privacyScrollOffset));
-    this.setState({
-      changeHeaderOn,
-      stickyHeaderSiblingHeight,
-      useStickyHeader: true,
-      highlightMeasurementPanel: true
-    });
-    setTimeout(() => {
-      this.setState({ highlightMeasurementPanel: false });
-    }, 5000);
-  }
-
-  clickUpgradeNotice() {
-    const { experiment } = this.props;
-    // If a user goes to the upgrade SUMO
-    this.props.sendToGA('event', {
-      eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'Upgrade Notice',
-      eventLabel: experiment.title
-    });
-  }
-
-  feedback() {
-    const { experiment } = this.props;
-    this.props.sendToGA('event', {
-      eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'Give Feedback',
-      eventLabel: experiment.title
-    });
-  }
-
-  showPreFeedbackDialog() {
-    const { experiment } = this.props;
-    this.setState({
-      showPreFeedbackDialog: true
-    });
-
-    this.props.sendToGA('event', {
-      eventCategory: 'ExperimentDetailsPage Interactions',
-      eventAction: 'Give Feedback',
-      eventLabel: experiment.title
-    });
-  }
-
-  handleFeedback(evt) {
-    const { pre_feedback_copy } = this.props.experiment;
-    if (pre_feedback_copy === null || !pre_feedback_copy) {
-      this.feedback();
-    } else {
-      evt.preventDefault();
-      this.showPreFeedbackDialog();
-    }
-  }
-
-  installExperiment(evt) {
+  installExperiment = (evt: MouseEventWithElementTarget) => {
     const { experiment, enableExperiment, sendToGA } = this.props;
     const { isEnabling } = this.state;
 
     evt.preventDefault();
 
     // Ignore subsequent clicks if already in progress
-    if (isEnabling) { return; }
+    if (isEnabling) {
+      return;
+    }
 
     let installAddonPromise = null;
     if (!this.props.hasAddon) {
@@ -812,7 +364,8 @@ export class ExperimentDetail extends React.Component {
         requireRestart,
         sendToGA,
         eventCategory,
-        eventLabel);
+        eventLabel
+      );
     }
     let progressButtonWidth;
     if (this.props.hasAddon) {
@@ -841,31 +394,35 @@ export class ExperimentDetail extends React.Component {
       return;
     }
 
-    installAddonPromise.then(() => {
-      return new Promise((resolve, reject) => {
-        let i = 0;
-        const interval = setInterval(() => {
-          i++;
-          if (this.props.hasAddon) {
-            clearInterval(interval);
-            resolve();
-          } else if (i > 2000) {
-            clearInterval(interval);
-            reject(new Error('hasAddon still false after 200 seconds'));
-          }
-        }, 100);
-      });
-    }).then(finishEnabling);
-  }
+    installAddonPromise
+      .then(() => {
+        return new Promise((resolve, reject) => {
+          let i = 0;
+          const interval = setInterval(() => {
+            i++;
+            if (this.props.hasAddon) {
+              clearInterval(interval);
+              resolve();
+            } else if (i > 2000) {
+              clearInterval(interval);
+              reject(new Error('hasAddon still false after 200 seconds'));
+            }
+          }, 100);
+        });
+      })
+      .then(finishEnabling);
+  };
 
-  uninstallExperiment(evt) {
+  uninstallExperiment = (evt: MouseEventWithElementTarget) => {
     const { experiment, disableExperiment } = this.props;
     const { isDisabling } = this.state;
 
     evt.preventDefault();
 
     // Ignore subsequen clicks if already in progress
-    if (isDisabling) { return; }
+    if (isDisabling) {
+      return;
+    }
 
     this.props.sendToGA('event', {
       eventCategory: 'ExperimentDetailsPage Interactions',
@@ -880,46 +437,33 @@ export class ExperimentDetail extends React.Component {
     });
 
     disableExperiment(experiment);
-  }
+  };
 
-  renderUninstallSurvey(evt) {
+  doShowTourDialog = (evt: MouseEvent) => {
     evt.preventDefault();
-
-    this.uninstallExperiment(evt);
-
-    this.setState({ showDisableDialog: true });
-  }
-
-  showTour(e) {
-    e.preventDefault();
     this.setState({ showTourDialog: true });
-  }
+  };
+
+  doShowEolDialog = (evt: MouseEvent) => {
+    evt.preventDefault();
+    this.setState({ showEolDialog: true });
+  };
+
+  doShowPreFeedbackDialog = (evt: MouseEvent) => {
+    evt.preventDefault();
+    this.setState({ showPreFeedbackDialog: true });
+  };
+
+  uninstallExperimentWithSurvey = (evt: MouseEvent) => {
+    evt.preventDefault();
+    this.uninstallExperiment(evt);
+    this.setState({ showDisableDialog: true });
+  };
+
+  flashMeasurementPanel = () => {
+    this.setState({ highlightMeasurementPanel: true });
+    setTimeout(() => {
+      this.setState({ highlightMeasurementPanel: false });
+    }, 5000);
+  };
 }
-
-// TODO Implement FlowTypes for ExperimentDetail
-
-// ExperimentDetail.propTypes = {
-//   userAgent: React.PropTypes.string,
-//   clientUUID: React.PropTypes.string,
-//   isDev: React.PropTypes.bool,
-//   hasAddon: React.PropTypes.any,
-//   experiments: React.PropTypes.array,
-//   installed: React.PropTypes.object,
-//   installedAddons: React.PropTypes.array,
-//   navigateTo: React.PropTypes.func,
-//   isAfterCompletedDate: React.PropTypes.func,
-//   isExperimentEnabled: React.PropTypes.func,
-//   requireRestart: React.PropTypes.func,
-//   sendToGA: React.PropTypes.func,
-//   openWindow: React.PropTypes.func,
-//   uninstallAddon: React.PropTypes.func,
-//   enableExperiment: React.PropTypes.func,
-//   disableExperiment: React.PropTypes.func,
-//   addScrollListener: React.PropTypes.func,
-//   removeScrollListener: React.PropTypes.func,
-//   getScrollY: React.PropTypes.func,
-//   setScrollY: React.PropTypes.func,
-//   getElementY: React.PropTypes.func,
-//   getElementOffsetHeight: React.PropTypes.func,
-//   setExperimentLastSeen: React.PropTypes.func
-// };

--- a/frontend/src/app/containers/ExperimentPage/stories.js
+++ b/frontend/src/app/containers/ExperimentPage/stories.js
@@ -3,8 +3,12 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import LayoutWrapper from '../../components/LayoutWrapper';
 
+import { experimentL10nId } from '../../lib/utils';
+
 import IncompatibleAddons from './IncompatibleAddons';
 import TestpilotPromo from './TestpilotPromo';
+import DetailsOverview from './DetailsOverview';
+import DetailsDescription, { EolBlock } from './DetailsDescription';
 
 const layoutDecorator = story =>
   <div className="blue" style={{ padding: 10 }} onClick={action('click')}>
@@ -14,17 +18,100 @@ const layoutDecorator = story =>
     </LayoutWrapper>
   </div>;
 
+const detailsLayoutDecorator = story =>
+  <div className="blue" style={{ padding: 10 }} onClick={action('click')}>
+    <div className="stars" />
+    <LayoutWrapper>
+      <div className="default-background" style={{ padding: '40px' }}>
+        <div id="details">
+          <LayoutWrapper
+            helperClass="details-content"
+            flexModifier="details-content"
+          >
+            {story()}
+          </LayoutWrapper>
+        </div>
+      </div>
+    </LayoutWrapper>
+  </div>;
+
 const experiment = {
+  slug: 'snooze-tabs',
   title: 'Sample experiment',
   description: 'This is an example experiment',
   subtitle: '',
-  slug: 'snooze-tabs',
   survey_url: 'https://example.com',
   created: '2010-06-21T12:12:12Z',
   modified: '2010-06-21T12:12:12Z',
   incompatible: {
     'foo@bar.com': 'Foo from BarCorp'
-  }
+  },
+  completed: null,
+  thumbnail: '/static/images/check.png',
+  changelog_url:
+    'https://github.com/meandavejustice/min-vid/blob/master/CHANGELOG.md',
+  contribute_url: 'https://github.com/meandavejustice/min-vid',
+  bug_report_url: 'https://github.com/meandavejustice/min-vid/issues',
+  discourse_url: 'https://discourse.mozilla-community.org/c/test-pilot/min-vid',
+  privacy_notice_url:
+    'https://github.com/meandavejustice/min-vid/blob/master/docs/metrics.md',
+  details: [
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimentdetail/detail1.jpg',
+      copy: 'Access Min Vid from YouTube and Vimeo video players.\n'
+    },
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimentdetail/detail2.jpg',
+      copy:
+        'Watch video in the foreground while you do other things on the Web.\n'
+    },
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimentdetail/detail3.jpg',
+      copy:
+        'Right click on links to video to find Min Vid in the in-context controls.\n'
+    }
+  ],
+  tour_steps: [
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimenttourstep/tour1.jpg',
+      copy: 'The first step (is the hardest)'
+    },
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimenttourstep/tour2.jpg',
+      copy: 'The second step'
+    },
+    {
+      image:
+        '/static/images/experiments/min-vid/experiments_experimenttourstep/tour3.jpg',
+      copy: 'The third step'
+    },
+    {
+      image: '/static/images/experiments/shared/tour-final.jpg',
+      copy: 'The final step'
+    }
+  ],
+  contributors: [
+    {
+      display_name: 'Dave Justice',
+      title: 'Engineer',
+      avatar: '/static/images/experiments/min-vid/avatars/dave-justice.jpg'
+    },
+    {
+      display_name: 'Jared Hirsch',
+      title: 'Staff Engineer',
+      avatar: '/static/images/experiments/min-vid/avatars/jared-hirsch.jpg'
+    },
+    {
+      display_name: 'Jen Kagan',
+      title: 'Engineering Intern',
+      avatar: '/static/images/experiments/min-vid/avatars/jen-kagan.jpg'
+    }
+  ]
 };
 
 const installedAddons = ['foo@bar.com'];
@@ -68,4 +155,105 @@ storiesOf('ExperimentPage/TestpilotPromo', module)
   )
   .add('has add-on', () =>
     <TestpilotPromo {...{ ...testpilotPromoBaseProps, hasAddon: true }} />
+  );
+
+storiesOf('ExperimentPage/EolBlock', module)
+  .addDecorator(layoutDecorator)
+  .add('base state', () =>
+    <EolBlock
+      l10nId={pieces => experimentL10nId(experiment, pieces)}
+      experiment={{
+        ...experiment,
+        completed: '2027-10-24T12:12:12Z',
+        eol_warning:
+          'This experiment is ending, but it will live on in our metrics.'
+      }}
+    />
+  );
+
+storiesOf('ExperimentPage/DetailsOverview', module)
+  .addDecorator(detailsLayoutDecorator)
+  .add('base state', () =>
+    <DetailsOverview
+      {...{
+        experiment,
+        graduated: false,
+        highlightMeasurementPanel: false,
+        showTour: action('showTour')
+      }}
+    />
+  )
+  .add('graduated', () =>
+    <DetailsOverview
+      {...{
+        experiment: {
+          ...experiment,
+          completed: '2017-09-09T12:00:00Z'
+        },
+        graduated: true,
+        highlightMeasurementPanel: false,
+        showTour: action('showTour')
+      }}
+    />
+  );
+
+storiesOf('ExperimentPage/DetailsDescription', module)
+  .addDecorator(detailsLayoutDecorator)
+  .add('base state', () =>
+    <DetailsDescription
+      {...{
+        experiment,
+        graduated: false,
+        locale: 'en-US',
+        hasAddon: false,
+        highlightMeasurementPanel: false,
+        l10nId: id => id
+      }}
+    />
+  )
+  .add('locale warning', () =>
+    <DetailsDescription
+      {...{
+        experiment: { ...experiment, locales: ['ar'] },
+        graduated: false,
+        locale: 'en-US',
+        hasAddon: true,
+        highlightMeasurementPanel: false,
+        l10nId: id => id
+      }}
+    />
+  )
+  .add('graduate soon', () =>
+    <DetailsDescription
+      {...{
+        experiment: {
+          ...experiment,
+          eol_warning:
+            'This experiment is ending, but it will live on in our hearts.',
+          graduation_url: 'https://mozilla.org/',
+          completed: '2017-09-09T12:00:00Z'
+        },
+        graduated: false,
+        locale: 'en-US',
+        hasAddon: false,
+        highlightMeasurementPanel: false,
+        l10nId: id => id
+      }}
+    />
+  )
+  .add('graduated', () =>
+    <DetailsDescription
+      {...{
+        experiment: {
+          ...experiment,
+          graduation_url: 'https://mozilla.org/',
+          completed: '2017-09-09T12:00:00Z'
+        },
+        graduated: true,
+        locale: 'en-US',
+        hasAddon: false,
+        highlightMeasurementPanel: false,
+        l10nId: id => id
+      }}
+    />
   );

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -17,6 +17,8 @@ import ExperimentDisableDialog from './ExperimentDisableDialog';
 import ExperimentEolDialog from './ExperimentEolDialog';
 import ExperimentTourDialog from './ExperimentTourDialog';
 
+import { PRIVACY_SCROLL_OFFSET } from './DetailsHeader';
+
 describe('app/containers/ExperimentPage', () => {
   const mockExperiment = {
     slug: 'testing',
@@ -119,7 +121,7 @@ describe('app/containers/ExperimentPage:ExperimentDetail', () => {
       setPageTitleL10N: sinon.spy()
     };
 
-    subject = shallow(<ExperimentDetail {...props} />);
+    subject = mount(<ExperimentDetail {...props} />);
   });
 
   const setExperiment = experiment => {
@@ -386,7 +388,6 @@ describe('app/containers/ExperimentPage:ExperimentDetail', () => {
         const mountedSubject = mount(<ExperimentDetail {...mountedProps} />);
 
         expect(props.addScrollListener.called).to.be.true;
-        expect(mountedSubject.state('useStickyHeader')).to.be.false;
         expect(mountedSubject.find('.details-header-wrapper').hasClass('stick')).to.be.false;
 
         const scrollListener = props.addScrollListener.lastCall.args[0];
@@ -395,14 +396,12 @@ describe('app/containers/ExperimentPage:ExperimentDetail', () => {
 
         // HACK: scrollListner() has a setTimeout(..., 1) so let's wait longer.
         setTimeout(() => {
-          expect(mountedSubject.state('useStickyHeader')).to.be.true;
           expect(mountedSubject.find('.details-header-wrapper').hasClass('stick')).to.be.true;
 
           // Now, scroll back.
           scrollY = 10;
           scrollListener();
           setTimeout(() => {
-            expect(mountedSubject.state('useStickyHeader')).to.be.false;
             expect(mountedSubject.find('.details-header-wrapper').hasClass('stick')).to.be.false;
             expect(mountedSubject.find('.details-header-wrapper.stick'))
               .to.have.property('length', 0);
@@ -424,8 +423,7 @@ describe('app/containers/ExperimentPage:ExperimentDetail', () => {
 
         subject.find('.highlight-privacy').simulate('click', mockClickEvent);
         expect(props.setScrollY.lastCall.args[0]).to.equal(
-          elementY + (genericElementHeight - subject.state('privacyScrollOffset')));
-        expect(subject.state('useStickyHeader')).to.be.true;
+          elementY + (genericElementHeight - PRIVACY_SCROLL_OFFSET));
         expect(subject.state('highlightMeasurementPanel')).to.be.true;
 
         // TODO: 5 second delay is too much. Skip until/unless we mock setTimeout.

--- a/frontend/src/app/containers/ExperimentPage/types.js
+++ b/frontend/src/app/containers/ExperimentPage/types.js
@@ -4,6 +4,49 @@ import type {
   SendToGAProps
 } from '../../containers/types';
 
+export type ExperimentPropsFromApp = {
+  isExperimentEnabled: Function,
+  getCookie: Function,
+  removeCookie: Function,
+  hasAddon: boolean,
+  userAgent: string,
+  experiments: Array<Object>,
+  installed: Object,
+  isAfterCompletedDate: Function,
+  isDev: boolean,
+  setExperimentLastSeen: Function,
+  clientUUID: string,
+  installedAddons: Object,
+  setPageTitleL10N: Function,
+  locale: string,
+  getElementOffsetHeight: Function,
+  getElementY: Function,
+  setScrollY: Function,
+  getScrollY: Function,
+  sendToGA: Function,
+  addScrollListener: Function,
+  removeScrollListener: Function,
+  disableExperiment: Function
+};
+
+export type ExperimentPageProps = ExperimentPropsFromApp & {
+  getExperimentBySlug: Function,
+  slug: string
+};
+
+export type ExperimentDetailProps = ExperimentPropsFromApp & {
+  experiment: Object
+};
+
+// HACK: Not sure why, but MouseEvent target is missing offsetWidth
+// https://github.com/facebook/flow/blob/v0.57.3/lib/dom.js#L154
+export type MouseEventWithElementTarget = {
+  preventDefault: Function,
+  target: {
+    offsetWidth: number
+  }
+};
+
 export type IncompatibleAddonsProps = {
   experiment: Object,
   installedAddons: Array<string>
@@ -15,3 +58,125 @@ export type TestpilotPromoProps = {
   experiment: Object,
   installCallback: Function
 } & MiscAppProps & SendToGAProps & BrowserEnvProps;
+
+export type DetailsHeaderProps = {
+  hasAddon: any,
+  userAgent: string,
+  experiment: Object,
+  installed: Object,
+  enabled: boolean,
+  progressButtonWidth: string,
+  isDisabling: boolean,
+  isEnabling: boolean,
+  surveyURL: string,
+  installExperiment: Function,
+  uninstallExperimentWithSurvey: Function,
+  getElementOffsetHeight: Function,
+  getElementY: Function,
+  setScrollY: Function,
+  getScrollY: Function,
+  l10nId: Function,
+  addScrollListener: Function,
+  removeScrollListener: Function,
+  flashMeasurementPanel: Function,
+  sendToGA: Function,
+  doShowEolDialog: Function
+};
+
+export type ExperimentControlsType = {
+  hasAddon: any,
+  userAgent: string,
+  experiment: Object,
+  installed: Object,
+  graduated: boolean,
+  surveyURL: string,
+  enabled: boolean,
+  progressButtonWidth: number,
+  installExperiment: Function,
+  uninstallExperimentWithSurvey: Function,
+  isEnabling: boolean,
+  isDisabling: boolean,
+  doShowEolDialog: Function,
+  doShowPreFeedbackDialog: Function,
+  sendToGA: Function,
+  highlightPrivacy: Function
+};
+
+export type WebExperimentControlsType = {
+  web_url: string,
+  title: string,
+  sendToGA: Function
+};
+
+export type EnableButtonType = {
+  experiment: Object,
+  installExperiment: Function,
+  isEnabling: boolean,
+  progressButtonWidth: number,
+  sendToGA: Function
+};
+
+export type MinimumVersionNoticeType = {
+  userAgent: string,
+  title: string,
+  hasAddon: any,
+  min_release: string,
+  sendToGA: Function
+};
+
+export type MaximumVersionNoticeType = {
+  userAgent: string,
+  title: string,
+  hasAddon: any,
+  max_release: string,
+  graduated: boolean,
+  sendToGA: Function
+};
+
+export type DetailsDescriptionProps = {
+  experiment: Object,
+  graduated: boolean,
+  locale: string,
+  hasAddon: any,
+  installedAddons: Object,
+  highlightMeasurementPanel: Function
+};
+
+export type LocaleWarningType = {
+  experiment: Object,
+  locale: string,
+  hasAddon: any
+};
+
+export type EolBlockProps = {
+  experiment: Object,
+  l10nId: Function
+};
+
+export type DetailsOverviewType = {
+  experiment: Object,
+  graduated: boolean,
+  highlightMeasurementPanel: boolean,
+  doShowTourDialog: Function
+};
+
+export type LaunchStatusType = {
+  experiment: Object,
+  graduated: boolean
+};
+
+export type StatsSectionType = {
+  experiment: Object,
+  doShowTourDialog: Function
+};
+
+export type ContributorsSectionType = {
+  experiment: Object,
+  l10nId: Function
+};
+
+export type MeasurementsSectionType = {
+  experiment: Object,
+  highlightMeasurementPanel: boolean,
+  l10nId: Function
+};


### PR DESCRIPTION
- Extract DetailHeader, DetailOverview, and DetailDescription from
  ExperimentDetail component

- De-dupe measurements section into single component, repeated for
  responsive layout

- Add flow type annotations to ExperimentPage and new sub-components

- Subtitle related properties optional in Warning component

- Reformatted components with `prettier --single-quote`

- Move privacyScrollOffset from state and into a constant since it never changes

- Switch ExperimentPage tests from shallow() to mount() to test sub-components

- Stop testing component state since it moved into subcomponents and
  markup should be enough to reflect functionality

Issue #2807