### PR TITLE
Update path for Test Pilot logo and halve its size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Test Pilot Logo](frontend/src/images/copter.png)
+<img src="frontend/src/app/components/Copter/img/copter.png" alt="Test Pilot Logo" width="328" height="265">  
 
 # Test Pilot
 


### PR DESCRIPTION
With the componentization of [Copter](https://github.com/mozilla/testpilot/tree/master/frontend/src/app/components/Copter), the Test Pilot logo has moved. 
It also doubled in size: 328x265 -> 656x530.  

Since 656x530 looks too big for the README, I tried to halve the displayed size. I'd prefer a pure markdown way to adjust the copter's size but couldn't find one. Maybe it's worth to restore and keep an extra copy of the 328x265 copter.