### PR TITLE
More news update selector fixes and cleanup

### DIFF
--- a/frontend/src/app/containers/App/index.js
+++ b/frontend/src/app/containers/App/index.js
@@ -24,7 +24,11 @@ import newsletterFormActions from '../../actions/newsletter-form';
 import RestartPage from '../../containers/RestartPage';
 import UpgradeWarningPage from '../../containers/UpgradeWarningPage';
 import { isFirefox, isMinFirefoxVersion, isMobile } from '../../lib/utils';
-import { staleNewsUpdatesSelector, freshNewsUpdatesSelector } from '../../selectors/news';
+import {
+  makeStaleNewsUpdatesSelector,
+  makeFreshNewsUpdatesSelector,
+  makeFreshNewsUpdatesSinceLastViewedSelector
+} from '../../selectors/news';
 import config from '../../config';
 
 let clipboard = null;
@@ -215,7 +219,11 @@ const mapStateToProps = state => ({
   addon: state.addon,
   clientUUID: state.addon.clientUUID,
   experiments: experimentSelector(state),
-  freshNewsUpdates: freshNewsUpdatesSelector(state),
+  freshNewsUpdates: makeFreshNewsUpdatesSelector(Date.now())(state),
+  freshNewsUpdatesSinceLastViewed: makeFreshNewsUpdatesSinceLastViewedSelector(
+    cookies.get('updates-last-viewed-date'),
+    Date.now()
+  )(state),
   getExperimentBySlug: slug =>
     getExperimentBySlug(state.experiments, slug),
   hasAddon: state.addon.hasAddon,
@@ -241,7 +249,7 @@ const mapStateToProps = state => ({
   protocol: state.browser.protocol,
   routing: state.routing,
   slug: state.experiments.slug,
-  staleNewsUpdates: staleNewsUpdatesSelector(state),
+  staleNewsUpdates: makeStaleNewsUpdatesSelector(Date.now())(state),
   varianttests: state.varianttests
 });
 

--- a/frontend/src/app/containers/HomePageWithAddon.js
+++ b/frontend/src/app/containers/HomePageWithAddon.js
@@ -22,6 +22,7 @@ type HomePageWithAddonProps = {
   hasAddon: any,
   experiments: Array<Object>,
   freshNewsUpdates: Array<Object>,
+  freshNewsUpdatesSinceLastViewed: Array<Object>,
   staleNewsUpdates: Array<Object>,
   getCookie: Function,
   removeCookie: Function,
@@ -116,8 +117,8 @@ export default class HomePageWithAddon extends React.Component {
   }
 
   render() {
-    const { sendToGA, experiments, isAfterCompletedDate, staleNewsUpdates, freshNewsUpdates }
-      = this.props;
+    const { sendToGA, experiments, isAfterCompletedDate, staleNewsUpdates, freshNewsUpdates,
+      freshNewsUpdatesSinceLastViewed } = this.props;
 
     if (experiments.length === 0) { return null; }
 
@@ -133,8 +134,8 @@ export default class HomePageWithAddon extends React.Component {
 
       {this.renderSplash()}
 
-      {showNewsUpdateDialog && freshNewsUpdates.length ? (
-          <NewsUpdatesDialog {...this.props} newsUpdates={freshNewsUpdates}
+      {showNewsUpdateDialog && freshNewsUpdatesSinceLastViewed.length ? (
+          <NewsUpdatesDialog {...this.props} newsUpdates={freshNewsUpdatesSinceLastViewed}
                              currentExperiments={currentExperiments}
                              onCancel={() => this.setState({ showNewsUpdateDialog: false })}
                              onComplete={() => this.setState({ showNewsUpdateDialog: false })} />) : null}

--- a/frontend/src/app/selectors/news.js
+++ b/frontend/src/app/selectors/news.js
@@ -1,19 +1,21 @@
 import { createSelector } from 'reselect';
-import moment from 'moment';
-import cookies from 'js-cookie';
 import experimentSelector from './experiment';
 
 export function publishedFilter(update) {
-  const hasPublishedField = (typeof update.published !== 'undefined');
-  const isPublished = moment(moment.utc()).isAfter(update.published);
+  const hasPublishedField = typeof update.published !== 'undefined';
+  if (!hasPublishedField) {
+    return false;
+  }
 
-  return (hasPublishedField && isPublished);
+  const now = Date.now();
+  const published = new Date(update.published).getTime();
+  return now > published;
 }
 
 export function experimentUpdateAvailable(update, availableExperiments) {
   // general updates do not include an experimentSlug so we'll just
   // return early in that case
-  const hasExperimentSlug = (typeof update.experimentSlug !== 'undefined');
+  const hasExperimentSlug = typeof update.experimentSlug !== 'undefined';
   if (!hasExperimentSlug) return true;
   return availableExperiments.has(update.experimentSlug);
 }
@@ -23,33 +25,38 @@ export function experimentUpdateAvailable(update, availableExperiments) {
 const newsUpdatesSelector = createSelector(
   store => store.news.updates,
   experimentSelector,
-
   (newsUpdates, experiments) => {
     const availableExperiments = new Set(experiments.map(e => e.slug));
-    return newsUpdates
-
-      // Filter for published updates and updates for available experiments,
-      .filter(update => {
-        return (publishedFilter(update) && experimentUpdateAvailable(update, availableExperiments));
-      })
-
-      // Reverse-chronological sort
-      .sort((a, b) => {
-        if (b.published < a.published) {
-          return -1;
-        } else if (b.published > a.published) {
-          return 1;
-        }
-        return 0;
-      });
+    return (
+      newsUpdates
+        // Filter for published updates and updates for available experiments,
+        .filter(
+          update =>
+            publishedFilter(update) &&
+            experimentUpdateAvailable(update, availableExperiments)
+        )
+        // Reverse-chronological sort
+        .sort((a, b) => {
+          if (b.published < a.published) {
+            return -1;
+          } else if (b.published > a.published) {
+            return 1;
+          }
+          return 0;
+        })
+    );
   }
 );
 
-
 const TWO_WEEKS = 2 * 7 * 24 * 60 * 60 * 1000;
-const twoWeeksAgoSelector = () => Date.now() - TWO_WEEKS;
 
-const makeNewsAgeSelector = includeStale => (newsUpdates, twoWeeksAgo) => {
+const makeNewsAgeSelector = (
+  includeStale,
+  lastViewedDate,
+  now
+) => newsUpdates => {
+  const twoWeeksAgo = now - TWO_WEEKS;
+
   // only include updates published within the past 2 weeks, unless
   // includeStale is passed, in which case we will return the whole
   // amount.
@@ -58,26 +65,31 @@ const makeNewsAgeSelector = includeStale => (newsUpdates, twoWeeksAgo) => {
     return includeStale ? dt < twoWeeksAgo : dt >= twoWeeksAgo;
   });
 
-  if (includeStale) return result;
-  // if includeStale return before filtering out updates which have
-  // been seen.
+  if (!lastViewedDate) {
+    return result;
+  }
+
+  // If lastViewedDate is supplied, further filter result by that cut-off date
   return result.filter(update => {
     const dt = new Date(update.published || update.created).getTime();
-    const lastSeen = new Date(cookies.get('updates-last-viewed-date') || 0);
+    const lastSeen = lastViewedDate || 0;
     return dt > lastSeen;
   });
 };
 
-export const freshNewsUpdatesSelector = createSelector(
-  newsUpdatesSelector,
-  twoWeeksAgoSelector,
-  makeNewsAgeSelector(false)
-);
+export const makeFreshNewsUpdatesSelector = now =>
+  createSelector(newsUpdatesSelector, makeNewsAgeSelector(false, null, now));
 
-export const staleNewsUpdatesSelector = createSelector(
-  newsUpdatesSelector,
-  twoWeeksAgoSelector,
-  makeNewsAgeSelector(true)
-);
+export const makeFreshNewsUpdatesSinceLastViewedSelector = (
+  lastViewedDate,
+  now
+) =>
+  createSelector(
+    newsUpdatesSelector,
+    makeNewsAgeSelector(false, lastViewedDate, now)
+  );
+
+export const makeStaleNewsUpdatesSelector = now =>
+  createSelector(newsUpdatesSelector, makeNewsAgeSelector(true, null, now));
 
 export default newsUpdatesSelector;

--- a/frontend/test/app/containers/HomePageWithAddon-test.js
+++ b/frontend/test/app/containers/HomePageWithAddon-test.js
@@ -19,33 +19,35 @@ describe('app/containers/HomePageWithAddon', () => {
       uninstallAddon: sinon.spy(),
       navigateTo: sinon.spy(),
       newsletterForm: {succeeded: true},
-      freshNewsUpdates: [{experimentSlug: 'min-vid',
-                          slug: 'min-vid-update-1',
-                          title: 'update shouldnt show since its more than 2 weeks old',
-                          link: 'https://medium.com/firefox-test-pilot',
-                          created: new Date(twoWeeksAgo).toISOString(),
-                          published: new Date(twoWeeksAgo).toISOString(),
-                          image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
-                          content: 'update shouldnt show since its more than 2 weeks old'},
-                         {
-                           experimentSlug: 'min-vid',
-                           slug: 'min-vid-update-2',
-                           title: 'update should be 2nd in carousel',
-                           link: 'https://medium.com/firefox-test-pilot',
-                           created: new Date(twoDaysAgo).toISOString(),
-                           published: new Date(twoDaysAgo).toISOString(),
-                           image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
-                           content: 'Min Vid 1.1.0 just shipped with enhanced browser support and a few other improvements as well.'},
-                         {
-                           experimentSlug: 'min-vid',
-                           slug: 'min-vid-update-3',
-                           title: 'Another update, should be shown 1st in the carousel since it is fresher',
-                           link: 'https://medium.com/firefox-test-pilot',
-                           created: new Date(oneDayAgo).toISOString(),
-                           published: new Date(oneDayAgo).toISOString(),
-                           image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
-                           content: 'Min Vid 1.1.0 just shipped with enhanced browser support and a few other improvements as well.'
-                         }],
+      freshNewsUpdatesSinceLastViewed: [
+        {experimentSlug: 'min-vid',
+          slug: 'min-vid-update-1',
+          title: 'update shouldnt show since its more than 2 weeks old',
+          link: 'https://medium.com/firefox-test-pilot',
+          created: new Date(twoWeeksAgo).toISOString(),
+          published: new Date(twoWeeksAgo).toISOString(),
+          image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
+          content: 'update shouldnt show since its more than 2 weeks old'},
+        {
+          experimentSlug: 'min-vid',
+          slug: 'min-vid-update-2',
+          title: 'update should be 2nd in carousel',
+          link: 'https://medium.com/firefox-test-pilot',
+          created: new Date(twoDaysAgo).toISOString(),
+          published: new Date(twoDaysAgo).toISOString(),
+          image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
+          content: 'Min Vid 1.1.0 just shipped with enhanced browser support and a few other improvements as well.'},
+        {
+          experimentSlug: 'min-vid',
+          slug: 'min-vid-update-3',
+          title: 'Another update, should be shown 1st in the carousel since it is fresher',
+          link: 'https://medium.com/firefox-test-pilot',
+          created: new Date(oneDayAgo).toISOString(),
+          published: new Date(oneDayAgo).toISOString(),
+          image: 'http://www.revelinnewyork.com/sites/default/files/RatMay8-21%2C1970_jpg.jpg',
+          content: 'Min Vid 1.1.0 just shipped with enhanced browser support and a few other improvements as well.'
+        }
+      ],
       isExperimentEnabled: sinon.spy(),
       getCookie: sinon.spy(),
       removeCookie: sinon.spy(),
@@ -94,7 +96,9 @@ describe('app/containers/HomePageWithAddon', () => {
     subject = render(<HomePageWithAddon {...props} getExperimentLastSeen={()=>{}}/>);
     expect(subject.find('.news-updates-modal')).to.have.property('length', 1);
 
-    subject = render(<HomePageWithAddon {...props} freshNewsUpdates={[]} getExperimentLastSeen={()=>{}}/>);
+    subject = render(<HomePageWithAddon {...props}
+      freshNewsUpdatesSinceLastViewed={[]}
+      getExperimentLastSeen={()=>{}}/>);
     expect(subject.find('.news-updates-modal')).to.have.property('length', 0);
   });
 });


### PR DESCRIPTION
- Implement distinction between fresh news items within the last 2 weeks
  and news items since last viewed. This allows the items on the home
  page to stay visible, while allowing the news alert dialog to not be
  shown again

- Cookie and date information should be supplied from outside to a
  selector creator, not generated from within the selector.

Issue #3015