### PR TITLE
3041 fix email dialog enter key interaction when privacy checkbox is unchecked

### DIFF
--- a/frontend/src/app/components/EmailDialog.js
+++ b/frontend/src/app/components/EmailDialog.js
@@ -211,7 +211,17 @@ export default class EmailDialog extends React.Component {
         break;
       case 'Enter':
         if (!isSuccess && !isError) {
-          this.handleSubscribe(this.state.email);
+          // If event is bubbled up from the input form,
+          // do nothing and let the HTML form handle it.
+          if (e.target !== e.currentTarget) {
+            return;
+          }
+          // Submit only if privacy checkbox is checked.
+          if (this.state.privacy) {
+            this.handleSubscribe(this.state.email);
+          }
+          // TODO: Else, show notification that the checkbox
+          // needs to be checked to proceed (#3042)
         } else if (isSuccess) {
           this.continue(e);
         } else if (isError) {

--- a/frontend/src/app/components/EmailDialog.js
+++ b/frontend/src/app/components/EmailDialog.js
@@ -221,7 +221,7 @@ export default class EmailDialog extends React.Component {
             this.handleSubscribe(this.state.email);
           }
           // TODO: Else, show notification that the checkbox
-          // needs to be checked to proceed (#3042)
+          // needs to be checked to proceed.
         } else if (isSuccess) {
           this.continue(e);
         } else if (isError) {

--- a/frontend/test/app/components/EmailDialog-test.js
+++ b/frontend/test/app/components/EmailDialog-test.js
@@ -105,9 +105,17 @@ describe('app/components/EmailDialog', () => {
     }, 1);
   });
 
+  it('should not submit the email when privacy checkbox is unchecked and <Enter> key is pressed', () => {
+    const expectedEmail = 'me@a.b.com';
+    subject.setState({ email: expectedEmail, privacy: false });
+    subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);
+    expect(sendToGA.notCalled).to.be.true;
+    expect(subject.state('isSuccess')).to.be.false;
+  });
+
   it('should subscribe to basket on valid email when <Enter> key is pressed', done => {
     const expectedEmail = 'me@a.b.com';
-    subject.setState({ email: expectedEmail });
+    subject.setState({ email: expectedEmail, privacy: true });
 
     fetchMock.post(basketUrl, 200);
     subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);


### PR DESCRIPTION
This fixes #3041. 

One caveat when: 
1. Checkbox is unchecked
2. Focus is on modal-container (not on its child component, [NewsletterForm](testpilot/frontend/src/app/components/NewsletterForm/index.js)) 
3. \<Enter\> key is pressed

The modal will not proceed, but the notification prompting to check the checkbox will not show up. However, if the focus is on the input form, the event will be handled by the form and the notification will show up as expected.

That's because the state for the notification on the checkbox is handled internally by [NewsletterForm](testpilot/frontend/src/app/components/NewsletterForm/index.js) which is a child component of Email Dialog. This can be addressed by _slightly_ modifying [NewsletterForm](testpilot/frontend/src/app/components/NewsletterForm/index.js), but since it's a component used in several other places, I judged it's better to leave it as is, unless deemed necessary to handle the caveat mentioned above.