### PR TITLE
3059 Email Dialog "Enter" key validation

### DIFF
--- a/frontend/src/app/components/EmailDialog/index.js
+++ b/frontend/src/app/components/EmailDialog/index.js
@@ -25,6 +25,7 @@ export default class EmailDialog extends React.Component {
   state: EmailDialogState
 
   modalContainer: Object
+  submitButton: Object
 
   constructor(props: EmailDialogProps) {
     super(props);
@@ -37,9 +38,7 @@ export default class EmailDialog extends React.Component {
   }
 
   componentDidMount() {
-    if (this.modalContainer !== undefined) {
-      this.modalContainer.focus();
-    }
+    this.focusModalContainer();
   }
 
   render() {
@@ -75,7 +74,8 @@ export default class EmailDialog extends React.Component {
                           isModal={true}
                           setEmail={newEmail => this.setState({ email: newEmail })}
                           setPrivacy={newPrivacy => this.setState({ privacy: newPrivacy })}
-                          subscribe={this.handleSubscribe.bind(this)} />
+                          subscribe={this.handleSubscribe.bind(this)}
+                          buttonRef={button => this.submitButton = button} />
         </div>
       </div>
     );
@@ -129,6 +129,13 @@ export default class EmailDialog extends React.Component {
         </div>
       </div>
     );
+  }
+
+  focusModalContainer() {
+    if (!this.modalContainer) {
+      return;
+    }
+    this.modalContainer.focus();
   }
 
   handleEmailChange(e: Object) {
@@ -203,6 +210,7 @@ export default class EmailDialog extends React.Component {
 
   handleKeyDown(e: Object) {
     const { isSuccess, isError } = this.state;
+
     switch (e.key) {
       case 'Escape':
         if (!isSuccess && !isError) {
@@ -215,17 +223,12 @@ export default class EmailDialog extends React.Component {
         break;
       case 'Enter':
         if (!isSuccess && !isError) {
-          // If event is bubbled up from the input form,
-          // do nothing and let the HTML form handle it.
-          if (e.target !== e.currentTarget) {
-            return;
-          }
-          // Submit only if privacy checkbox is checked.
-          if (this.state.privacy) {
-            this.handleSubscribe(this.state.email);
-          }
-          // TODO: Else, show notification that the checkbox
-          // needs to be checked to proceed.
+          e.preventDefault();
+          e.stopPropagation();
+          // Keeps the modal-container focused
+          // after success/error state renders
+          this.focusModalContainer();
+          this.submitButton.click();
         } else if (isSuccess) {
           this.continue(e);
         } else if (isError) {

--- a/frontend/src/app/components/EmailDialog/tests.js
+++ b/frontend/src/app/components/EmailDialog/tests.js
@@ -68,14 +68,6 @@ describe('app/components/EmailDialog', () => {
     expect(form).to.have.length(1);
   });
 
-  it('should not submit the email when privacy checkbox is unchecked and <Enter> key is pressed', () => {
-    const expectedEmail = 'me@a.b.com';
-    subject.setState({ email: expectedEmail, privacy: false });
-    subject.find('.modal-container').simulate('keyDown', mockEnterKeyDownEvent);
-    expect(sendToGA.notCalled).to.be.true;
-    expect(subject.state('isSuccess')).to.be.false;
-  });
-
   it('should reset the email dialog when the <Enter> key is pressed ' +
     'on the error page', () => {
     subject.setState({ isSuccess: false, isError: true });

--- a/frontend/src/app/components/NewsletterForm/index.js
+++ b/frontend/src/app/components/NewsletterForm/index.js
@@ -16,7 +16,8 @@ type NewsletterFormProps = {
   isModal?: boolean,
   subscribe?: Function,
   setEmail?: Function,
-  setPrivacy?: Function
+  setPrivacy?: Function,
+  buttonRef?: Function
 }
 
 type NewsletterFormState = {
@@ -109,7 +110,8 @@ export default class NewsletterForm extends React.Component {
       );
     }
     return <Localized id='newsletterFormSubmitButton'>
-      <button className={classnames('button', 'large', this.props.isModal ? 'default' : 'outline')}>Sign Up Now</button>
+      <button className={classnames('button', 'large', this.props.isModal ? 'default' : 'outline')}
+              ref={this.props.buttonRef}>Sign Up Now</button>
     </Localized>;
   }
 


### PR DESCRIPTION
The "Enter" key now fires a click event on the submit button, instead of directly calling `handleSubscribe(...)`. This approach initially struck me as "hacky", but it follows the [WHATWG spec](https://html.spec.whatwg.org/#implicit-submission): 
> If the user agent supports letting the user submit a form implicitly (for example, on some platforms hitting the "enter" key [...], must cause the user agent to fire a click event at that default button.

Removed 2 of the tests that I previously wrote due to issues with Enzyme and ref callbacks.