### PR TITLE
Possibly fix #3105 Remove opacity: 0 because the fade-in animations aren't working on dev

### DIFF
--- a/frontend/src/app/components/Modal/index.scss
+++ b/frontend/src/app/components/Modal/index.scss
@@ -55,7 +55,6 @@
   background: $white;
   box-shadow: 0 4px $grid-unit $transparent-black-5;
   color: $black;
-  opacity: 0;
   position: relative;
   width: $grid-unit * 25;
 

--- a/frontend/src/app/components/NewsletterForm/index.scss
+++ b/frontend/src/app/components/NewsletterForm/index.scss
@@ -99,6 +99,4 @@
     transparent
   );
   background-size: 50px 50px;
-  opacity: 0;
-  transition: opacity .1s ease;
 }


### PR DESCRIPTION
Even though they are working fine locally. We had this problem before
and I think it was fixed by removing opacity fade in transitions, but
the photon-modals branch re-introduced it, I think.