### PR TITLE
Added new dependency's for pytest update

### DIFF
--- a/frontend/test/ui/requirements/requirements.txt
+++ b/frontend/test/ui/requirements/requirements.txt
@@ -1,3 +1,5 @@
+attrs==17.3.0
+pluggy==0.6.0
 PyPOM==1.2.0
 pytest==3.2.5
 pytest-selenium==1.11.2


### PR DESCRIPTION
Pytest 3.3.0  requires 2 new plugins, those being attrs https://pypi.org/project/attrs/, and pluggy https://pypi.python.org/pypi/pluggy. 

This patch will add both of those before we add pytest 3.3.0.