### PR TITLE
Added a few install tests and enable tests

### DIFF
--- a/frontend/test/ui/conftest.py
+++ b/frontend/test/ui/conftest.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 import requests
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 @pytest.fixture
@@ -17,10 +20,17 @@ def firefox_options(firefox_options):
         'extensions.install.requireBuiltInCerts', False)
     firefox_options.set_preference('xpinstall.signatures.required', False)
     firefox_options.set_preference('extensions.webapi.testing', True)
+    firefox_options.set_preference('extensions.legacy.enabled', True)
     firefox_options.set_preference('testpilot.env', 'local')
     firefox_options.add_argument('-foreground')
     firefox_options.log.level = 'trace'
     return firefox_options
+
+
+@pytest.fixture
+def install_testpilot(selenium):
+    addon = os.path.abspath('addon/addon.xpi')
+    selenium.install_addon(addon, temporary=True)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/frontend/test/ui/conftest.py
+++ b/frontend/test/ui/conftest.py
@@ -4,7 +4,6 @@ import pytest
 import requests
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
-from selenium.webdriver.support.wait import WebDriverWait
 
 
 @pytest.fixture

--- a/frontend/test/ui/pages/desktop/detail.py
+++ b/frontend/test/ui/pages/desktop/detail.py
@@ -9,6 +9,8 @@ class Detail(Base):
     _root_locator = (By.CLASS_NAME, 'default-background')
     _name_locator = (By.CSS_SELECTOR, '.details-header > header > h1')
     _enable_locator = (By.ID, 'install-button')
+    _install_and_enable_locator = (By.CLASS_NAME, 'main-install__button')
+    _uninstall_button_locator = (By.ID, 'uninstall-button')
 
     def wait_for_page_to_load(self):
         self.wait.until(
@@ -26,13 +28,26 @@ class Detail(Base):
 
     def enable(self):
         self.wait_for_page_to_load()
+        self.wait.until(lambda _: self.enable_button.is_displayed())
+        self.enable_button.click()
+
+    @property
+    def enable_button(self):
+        return self.find_element(*self._enable_locator)
+
+    def install_and_enable(self):
+        self.wait_for_page_to_load()
         self.wait.until(lambda _: self.find_element(
-            *self._enable_locator).is_displayed())
-        self.find_element(*self._enable_locator).click()
+            *self._install_and_enable_locator).is_displayed())
+        self.find_element(*self._install_and_enable_locator).click()
+
+    def disable(self):
+        self.find_element(*self._uninstall_button_locator).click()
 
     class EnabledPopup(Region):
         _root_locator = (By.CSS_SELECTOR, '.tour-modal')
         _popup_header_locator = (By.CSS_SELECTOR, '.modal-header-wrapper')
+        _close_button_locator = (By.CLASS_NAME, 'modal-cancel')
 
         def wait_for_region_to_load(self):
             self.wait.until(
@@ -41,6 +56,9 @@ class Detail(Base):
         def is_popup_displayed(self):
             el = self.find_element(*self._popup_header_locator).is_displayed()
             return el
+
+        def close(self):
+            self.find_element(*self._close_button_locator).click()
 
     class Footer(Region):
         _root_locator = (By.CSS_SELECTOR, '#main-footer')

--- a/frontend/test/ui/pages/desktop/home.py
+++ b/frontend/test/ui/pages/desktop/home.py
@@ -22,6 +22,12 @@ class Home(Base):
     def signup_footer(self):
         return self.SignUpFooter(self)
 
+    def bottom_install_button(self):
+        els = self.find_elements(By.CLASS_NAME, 'main-install__button')
+        els[-1].click()
+        from .experiments import Experiments
+        return Experiments(self.selenium, self.base_url)
+
     class Header(Region):
         """Represents the Header portion of the page"""
         _root_locator = (By.CLASS_NAME, 'banner')
@@ -36,7 +42,11 @@ class Home(Base):
         @property
         def is_install_button_displayed(self):
             """Return if the testplot addon install button is displayed."""
-            return self.find_element(*self._install_locator).is_displayed()
+            try:
+                self.find_element(*self._install_locator).is_displayed()
+            except Exception:
+                return False
+            return True
 
         def click_install_button(self):
             """Clicks the button to install the testpilot addon.

--- a/frontend/test/ui/test_homepage.py
+++ b/frontend/test/ui/test_homepage.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import os
 
 import pytest
 import requests
@@ -88,3 +89,13 @@ def test_incomplete_email(base_url, selenium):
     assert page.signup_footer.is_stay_informed_displayed
     page.signup_footer.sign_up('test')
     assert page.signup_footer.is_stay_informed_displayed
+
+
+@pytest.mark.skipif(os.environ.get('SKIP_INSTALL_TEST') is not None,
+                    reason='Skip install on Release and Beta Firefox.')
+@pytest.mark.nondestructive
+def test_install_button_not_shown_when_ext_is_installed(
+        base_url, selenium, install_testpilot):
+    page = Home(selenium, base_url).open()
+    page.wait_for_page_to_load()
+    assert page.header.is_install_button_displayed is False

--- a/frontend/test/ui/test_install.py
+++ b/frontend/test/ui/test_install.py
@@ -2,6 +2,7 @@ import os
 import datetime
 
 import pytest
+from pages.desktop.experiments import Experiments
 from pages.desktop.home import Home
 from pages.desktop.detail import Detail
 
@@ -27,10 +28,39 @@ def test_install_of_test_pilot_addon(
         assert experiments.welcome_popup.is_title_displayed()
 
 
+@pytest.mark.skipif(os.environ.get('SKIP_INSTALL_TEST') is not None,
+                    reason='Skip install on Release and Beta Firefox.')
+@pytest.mark.nondestructive
+def test_bottom_install_button(base_url, selenium, firefox, notifications):
+    page = Home(selenium, base_url).open()
+    experiments = page.bottom_install_button()
+    firefox.browser.wait_for_notification(
+        notifications.AddOnInstallComplete).close()
+    assert experiments.welcome_popup.is_title_displayed()
+
+
+@pytest.mark.skipif(os.environ.get('SKIP_INSTALL_TEST') is not None,
+                    reason='Skip install on Release and Beta Firefox.')
+@pytest.mark.nondestructive
+def test_install_and_enable(base_url, selenium, firefox, notifications):
+    Home(selenium, base_url).open()
+    experiments = Experiments(selenium, base_url)
+    experiment = experiments.find_experiment(experiment='Dev Example')
+    experiment.install_and_enable()
+    firefox.browser.wait_for_notification(
+        notifications.AddOnInstallComplete).close()
+    firefox.browser.wait_for_notification(
+        notifications.AddOnInstallConfirmation).install()
+    firefox.browser.wait_for_notification(
+        notifications.AddOnInstallComplete).close()
+    assert Detail(selenium, base_url).enabled_popup.is_popup_displayed()
+
+
 @pytest.mark.nondestructive
 @pytest.mark.skipif(os.environ.get('SKIP_INSTALL_TEST') is not None,
                     reason='Skip install on Release and Beta Firefox.')
-def test_enable_experiment(base_url, selenium, firefox, notifications):
+def test_enable_and_disable_experiment(
+        base_url, selenium, firefox, notifications):
     """Test enabling of an experiment."""
     page = Home(selenium, base_url).open()
     selenium.add_cookie({'name': 'updates-last-viewed-date',
@@ -53,4 +83,8 @@ def test_enable_experiment(base_url, selenium, firefox, notifications):
         notifications.AddOnInstallConfirmation).install()
     firefox.browser.wait_for_notification(
         notifications.AddOnInstallComplete).close()
-    assert Detail(selenium, base_url).enabled_popup.is_popup_displayed()
+    exp_detail = Detail(selenium, base_url)
+    assert exp_detail.enabled_popup.is_popup_displayed()
+    exp_detail.enabled_popup.close()
+    experiment.disable()
+    assert experiment.enable_button.is_displayed()

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ whitelist_externals =
     bash
 commands =
     bash bin/circleci/start-server.sh
-    pytest -v --verify-base-url --driver=Firefox --self-contained-html frontend/test/ui {posargs}
+    pytest -n=4 -v --verify-base-url --driver=Firefox --self-contained-html frontend/test/ui {posargs}
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Fixes #3088

New tests:
1: Disable experiment
2: Install the TestPilot experiment and enable an experiment from the experiment page
3: Install TestPilot extension from the bottom install button
4: Check the install button is not shown when the TestPilot extension is installed
