### PR TITLE
add header links to legal pages

### DIFF
--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -253,6 +253,11 @@ function generateStaticPageFromMarkdown(pageName, pageParam, markdown, params) {
       <h1>
         <a href="/" className="wordmark">Firefox Test Pilot</a>
       </h1>
+
+      <div className="header-links">
+        <a className="news-link" href="/news">News Feed</a>
+        <a className="blog-link" href="https://medium.com/firefox-test-pilot" target="_blank" rel="noopener noreferrer">Blog</a>
+      </div>
     </header>
     <div className="layout-wrapper static-page-content">
       <ReactMarkdown source={ markdown } />


### PR DESCRIPTION
- added news feed and blog links to header of legal pages
- refs #3160
- still doesn't add settings/submenu when logged in on these pages,
not sure if this is necessary.