### PR TITLE
Bump Node version from 8.9.0 to 8.9.4

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
   hosts:
     example.com: 127.0.0.1
   node:
-    version: 8.9.0
+    version: 8.9.4
   post:
     - pyenv global 2.7.12 3.6.1
 

--- a/docs/development/quickstart.md
+++ b/docs/development/quickstart.md
@@ -2,7 +2,7 @@
 
 # Development Quickstart
 
-Test Pilot uses Node.js [v8.9.0](https://nodejs.org/dist/latest-v8.x/) for
+Test Pilot uses Node.js [v8.9.4](https://nodejs.org/dist/latest-v8.x/) for
 development. You may be able to get by using
 [the most current release](https://nodejs.org/en/download/current/), but
 earlier versions will definitely result in error messages and problems. [Node

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/mozilla/testpilot/issues"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=8.9.4"
   },
   "dependencies": {
     "babel-polyfill": "6.26.0",


### PR DESCRIPTION
Small version bump to latest [so we match ops' deployment config](https://github.com/mozilla-services/cloudops-deployment/pull/1461)