### PR TITLE
Fix 404s for images on local dev server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -143,7 +143,9 @@ module.exports = {
             options: {
               hash: 'sha512',
               digest: 'hex',
-              name: '/static/app/images/[name]-[hash].[ext]'
+              publicPath: '/',
+              outputPath: 'static/app/images/',
+              name: '[name]-[hash].[ext]'
             }
           },
           {


### PR DESCRIPTION
I think this should fix the issue with missing images.

Not sure why it needs both publicPath and outputPath, but that combo seemed the only thing to fix it.

You can test this in two ways:
1. `npm start` - for the usual local server with file watching
1. `npm run static && npm run server` - for a static rendering of the site like we do on testpilot.dev.mozaws.net