### PR TITLE
Remove server-generated page container before rendering client-side

### DIFF
--- a/frontend/src/app/components/UpdateList/index.js
+++ b/frontend/src/app/components/UpdateList/index.js
@@ -157,9 +157,9 @@ export default class UpdateList extends React.Component {
            <h1 className="update-list-heading">Latest Updates</h1>
          </Localized>}
         <LayoutWrapper flexModifier="column-center">
-          {shownNewsUpdates.map((update, index) =>
+          {shownNewsUpdates.map(update =>
             <Update
-              key={index}
+              key={update.slug}
               sendToGA={sendToGA}
               update={update}
               experiment={experimentsBySlug[update.experimentSlug]}

--- a/frontend/src/app/lib/inject.js
+++ b/frontend/src/app/lib/inject.js
@@ -19,11 +19,14 @@ export default function inject(name, component, callback) {
     setupAddonConnection(s);
     if (document.body !== null) {
       let node = document.getElementById('page-container');
-      if (node === null) {
-        node = document.createElement('div');
-        node.id = 'page-container';
-        document.body.appendChild(node);
+      if (node !== null) {
+        node.remove();
       }
+
+      node = document.createElement('div');
+      node.id = 'page-container';
+      document.body.appendChild(node);
+
       ReactDOM.render(provider, node);
     }
   }


### PR DESCRIPTION
- [React 16 Performs Less Strict Client-Side Checking][ssr]. That means
  when client-side rendering differs from what the server offers, React
  can do unexpected things.

  The fix in this PR, albeit drastic, is to remove the server rendering
  from the DOM before applying client-side

- Use more unique key props for news items, based on slugs - which didn't
  fix the original issue as expected, but is a good idea anyway.

[ssr]: https://hackernoon.com/whats-new-with-server-side-rendering-in-react-16-9b0d78585d67?token=nVWMJUyuYkp0s6eL

Fixes #3172