### PR TITLE
Fix #3119 Use the mozilla-central eslint configuration.

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -51,7 +51,7 @@
     "watch": "cross-env NODE_ENV=development webpack --watch",
     "package": "cross-env NODE_ENV=production webpack",
     "package:dev": "cross-env NODE_ENV=development webpack",
-    "lint": "eslint -c ../.eslintrc src || echo \"not erroring on lint until lint is in sync with mozilla-central config\"",
+    "lint": "eslint -c ../.eslintrc src",
     "test": "mocha --require babel-register --require ./test/test-setup.js --recursive",
     "test:watch": "npm test -- --watch"
   }

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -17,14 +17,8 @@ We also use the following eslint plugin recommended rules:
  - eslint-plugin-flowtype
  - eslint-plugin-react
 
-We are currently migrating away from our old lint configuration, so
-lint errors are treated as warnings until this process is complete.
-You can track the progress of our migration in [the bug][bug].
-
 To lint the frontend, run `npm run lint` in the testpilot directory.
 To lint the addon, run `npm run lint` in the addon directory.
-The migration process should be fairly straightforward, since it mostly
-entails replacing ' with ".
 
 To lint only one file in the frontend, run eslint inside the testpilot directory:
 
@@ -35,7 +29,6 @@ To lint only one file in the addon, run eslint inside the addon directory:
     ./node_modules/.bin/eslint -c ../.eslintrc [path/to/file.js]
 
 [source]: https://dxr.mozilla.org/mozilla-central/source/tools/lint/eslint/eslint-plugin-mozilla
-[bug]: https://github.com/mozilla/testpilot/issues/3119
 
 
 ## All tests

--- a/frontend/src/app/components/View/index.js
+++ b/frontend/src/app/components/View/index.js
@@ -34,7 +34,7 @@ export default class View extends React.Component {
      * { '$$typeof': Symbol(react.element), type: 'div' }
      */
     return (
-      React.Component.isPrototypeOf.call(React.Component, element) || (
+      React.Component.isPrototypeOf(element) || (
         element.$$typeof === Symbol.for("react.element") &&
         DOMFactories.indexOf(element.type) === -1
       )

--- a/frontend/src/app/containers/App/index.js
+++ b/frontend/src/app/containers/App/index.js
@@ -157,7 +157,7 @@ class App extends Component {
       this.props.setLocalizations(langs);
       const staticNode = document.getElementById("static-root");
       if (staticNode) {
-        staticNode.parentNode.removeChild(staticNode);
+        staticNode.remove();
       }
     });
   }

--- a/frontend/src/app/lib/inject.js
+++ b/frontend/src/app/lib/inject.js
@@ -23,8 +23,8 @@ export default function inject(name, component, callback) {
         node.remove();
       }
 
-      node = document.createElement('div');
-      node.id = 'page-container';
+      node = document.createElement("div");
+      node.id = "page-container";
       document.body.appendChild(node);
 
       ReactDOM.render(provider, node);

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "docs": "doctoc README.md && doctoc addon/README.md",
     "lint": "npm-run-all lint:*",
     "lint:styles": "gulp styles-lint",
-    "lint:js": "eslint ./gulpfile.babel.js ./webpack.config.js ./frontend/{src,tests}/**/*.{js,jsx} || echo \"not erroring on lint until lint is in sync with mozilla-central config\"",
+    "lint:js": "eslint ./gulpfile.babel.js ./webpack.config.js ./frontend/{src,tests}/**/*.{js,jsx}",
     "test": "cd frontend && mocha --require babel-register --require test-setup.js --recursive 'test' 'src/**/tests.js'",
     "flow": "flow frontend",
     "l10n:extract": "gulp content-extract-strings",


### PR DESCRIPTION
We're all done now! This PR just makes lint errors into build errors
again, and removes the parts of the documentation that say we're
migrating the lint format.