### PR TITLE
Ensures that Firefox iOS is excluded from UA checks for Firefox (closes #2642).

### DIFF
--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -40,7 +40,8 @@ export function buildSurveyURL(ref, title, installed, clientUUID, survey_url) {
 }
 
 export function isFirefox(ua) {
-  return ua.indexOf("firefox") > -1 || ua.indexOf("fxios") > -1;
+  const userAgent = ua.toLowerCase();
+  return userAgent.indexOf("firefox") > -1 && userAgent.indexOf("fxios") === -1;
 }
 
 export function isMinFirefoxVersion(ua, minVersion) {

--- a/frontend/test/app/lib/utils-test.js
+++ b/frontend/test/app/lib/utils-test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { l10nIdFormat, l10nId, experimentL10nId, newsUpdateL10nId, lookup } from "../../../src/app/lib/utils";
+import { isFirefox, l10nIdFormat, l10nId, experimentL10nId, newsUpdateL10nId, lookup } from "../../../src/app/lib/utils";
 
 describe("app/lib/utils", () => {
 
@@ -121,6 +121,35 @@ describe("app/lib/utils", () => {
         title: "bazquux"
       }, "title");
       expect(result).to.equal("testpilotNewsupdatesXyzzyTitle");
+    });
+
+  });
+
+  describe("isFirefox", () => {
+
+    it("should recognize Firefox 58's UA string as Firefox", () => {
+      const UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:58.0) Gecko/20100101 Firefox/58.0';
+      expect(isFirefox(UA)).to.equal(true);
+    });
+
+    it("should not recognize Chrome's UA string as Firefox", () => {
+      const UA = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36';
+      expect(isFirefox(UA)).to.equal(false);
+    });
+
+    it("should not recognize Firefox for iOS/iPod's UA string as Firefox", () => {
+      const UA = 'Mozilla/5.0 (iPod touch; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4';
+      expect(isFirefox(UA)).to.equal(false);
+    });
+
+    it("should not recognize Firefox for iOS/iPhone's UA string as Firefox", () => {
+      const UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4';
+      expect(isFirefox(UA)).to.equal(false);
+    });
+
+    it("should not recognize Firefox for iOS/iPad's UA string as Firefox", () => {
+      const UA = 'Mozilla/5.0 (iPad; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4';
+      expect(isFirefox(UA)).to.equal(false);
     });
 
   });


### PR DESCRIPTION
This is a very small fix, but testing it is…arduous. To get the right code paths you need to access it off an example.com host, so you need to do local testing on a host where you have access to `/etc/hosts`, and then you need to run Firefox for iOS in the simulator from there. Since it’s a simulator and not an emulator (i.e. ARM vs x86), there’s no access to the App Store, so you need to build https://github.com/mozilla-mobile/firefox-ios from scratch to do that.

To save you all that work, I instead recommend that you use these screenshots and the new unit tests as verification of it working locally, then test in dev once it's merged.

### Before

<img width="598" alt="screen shot 2018-01-17 at 17 43 06" src="https://user-images.githubusercontent.com/23885/35075513-affa5006-fbb0-11e7-8ec1-23b793089032.png">

### After

<img width="598" alt="screen shot 2018-01-17 at 17 43 22" src="https://user-images.githubusercontent.com/23885/35075511-abd85aea-fbb0-11e7-86cc-889636613d87.png">