### PR TITLE
Don't use sudo when building frontend & addon on dev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,9 +22,9 @@ jobs:
       - run:
           name: Build addon and frontend
           command: |
-            sudo ./bin/circleci/build-addon.sh
-            sudo ./bin/circleci/build-version-json.sh
-            sudo ./bin/circleci/build-frontend.sh
+            ./bin/circleci/build-addon.sh
+            ./bin/circleci/build-version-json.sh
+            ./bin/circleci/build-frontend.sh
       - store_artifacts:
           path: ~/testpilot/addon/update.rdf
       - store_artifacts:


### PR DESCRIPTION
Fixes #3262 

Turns out that the root user doesn't inherit the CircleCI env vars expected by the build scripts. I'm also guessing this could cause some issues in the frontend & addon builds if we're using env vars to control those too (e.g. NODE_ENV and friends)

Guessing this was just a copypasta artifact, since most of the rest of the shell commands using sudo are installing dependencies.