### PR TITLE
Revert "Turn the featured experiment ui off for one more release until the privacy string is localized."

### DIFF
--- a/content-src/experiments/notes.yaml
+++ b/content-src/experiments/notes.yaml
@@ -1,7 +1,7 @@
 id: 15
 title: 'Notes'
 slug: notes
-is_featured: false
+is_featured: true
 platforms: ['addon']
 min_release: 54
 thumbnail: /static/images/experiments/notes/experiments_experiment/thumbnail.png

--- a/frontend/test/ui/test_homepage.py
+++ b/frontend/test/ui/test_homepage.py
@@ -27,8 +27,6 @@ def test_install_button_loads(base_url, selenium):
         assert True
 
 
-@pytest.mark.skipif(
-  True, reason='Skip featured experiment tests.')
 @pytest.mark.nondestructive
 def test_featured_experiment_actions(base_url, selenium):
     """Test if featured experiment action buttons exists"""
@@ -39,8 +37,6 @@ def test_featured_experiment_actions(base_url, selenium):
         assert True
 
 
-@pytest.mark.skipif(
-  True, reason='Skip featured experiment tests.')
 @pytest.mark.nondestructive
 def test_featured_experiment(base_url, selenium):
     """Test if featured experiment video exists"""


### PR DESCRIPTION
Reverts mozilla/testpilot#3288