### PR TITLE
Adds missing events from GA documentation (#3301).

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
@@ -17,7 +17,8 @@ export default function DetailsOverview({
   experiment,
   graduated,
   highlightMeasurementPanel,
-  doShowTourDialog
+  doShowTourDialog,
+  sendToGA
 }: DetailsOverviewType) {
   const { slug, thumbnail, measurements } = experiment;
   const l10nId = (pieces: string) => experimentL10nId(experiment, pieces);
@@ -33,7 +34,7 @@ export default function DetailsOverview({
         <section className="user-count">
           <LaunchStatus {...{ experiment, graduated }} />
         </section>
-        {!graduated && <StatsSection {...{ experiment, doShowTourDialog }} />}
+        {!graduated && <StatsSection {...{ experiment, doShowTourDialog, sendToGA }} />}
         <ContributorsSection {...{ experiment, l10nId }} />
         {!graduated &&
           measurements &&
@@ -78,14 +79,22 @@ export const StatsSection = ({
     contribute_url,
     bug_report_url,
     discourse_url
-  }
+  },
+  sendToGA
 }: StatsSectionType) =>
   <div>
     <section className="stats-section">
       {!web_url &&
         <p>
           <Localized id="tourLink">
-            <a className="showTour" onClick={doShowTourDialog} href="#">
+            <a className="showTour" onClick={evt => {
+              sendToGA("event", {
+                eventCategory: "ExperimentDetailsPage Interactions",
+                eventAction: "button click",
+                eventLabel: "take tour"
+              });
+              doShowTourDialog(evt);
+            }} href="#">
               Launch Tour
             </a>
           </Localized>

--- a/frontend/src/app/containers/ExperimentPage/index.js
+++ b/frontend/src/app/containers/ExperimentPage/index.js
@@ -302,7 +302,8 @@ export class ExperimentDetail extends React.Component {
                     graduated,
                     highlightMeasurementPanel,
                     doShowTourDialog,
-                    l10nId
+                    l10nId,
+                    sendToGA
                   }}
                 />
                 <DetailsDescription

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -18,6 +18,7 @@ import ExperimentEolDialog from "./ExperimentEolDialog";
 
 import { PRIVACY_SCROLL_OFFSET } from "./DetailsHeader";
 import DetailsDescription, { LocaleWarning } from "./DetailsDescription";
+import { StatsSection } from "./DetailsOverview";
 
 describe("app/containers/ExperimentPage", () => {
   const mockExperiment = {
@@ -820,5 +821,35 @@ describe("app/containers/ExperimentPage/ExperimentPreFeedbackDialog", () => {
       eventLabel: "foobar",
       outboundURL: surveyURL
     }]);
+  });
+});
+
+describe("app/containers/ExperimentPage/DetailsOverview:StatsSection", () => {
+
+  let doShowTourDialog, mockClickEvent, props, sendToGA, subject;
+  beforeEach(() => {
+    mockClickEvent = {};
+    doShowTourDialog = sinon.spy();
+    sendToGA = sinon.spy();
+    props = {
+      experiment: {},
+      doShowTourDialog,
+      sendToGA
+    };
+    subject = shallow(<StatsSection {...props} />);
+  });
+
+  it("should send GA event when 'Take Tour' is clicked", () => {
+    subject.find(".showTour").simulate("click", mockClickEvent);
+    expect(sendToGA.lastCall.args).to.deep.equal(["event", {
+      eventCategory: "ExperimentDetailsPage Interactions",
+      eventAction: "button click",
+      eventLabel: "take tour"
+    }]);
+  });
+
+  it("launch tour when 'Take Tour' is clicked", () => {
+    subject.find(".showTour").simulate("click", mockClickEvent);
+    expect(doShowTourDialog.callCount).to.equal(1);
   });
 });

--- a/frontend/src/app/containers/ExperimentPage/types.js
+++ b/frontend/src/app/containers/ExperimentPage/types.js
@@ -156,7 +156,8 @@ export type DetailsOverviewType = {
   experiment: Object,
   graduated: boolean,
   highlightMeasurementPanel: boolean,
-  doShowTourDialog: Function
+  doShowTourDialog: Function,
+  sendToGA: Function
 };
 
 export type LaunchStatusType = {
@@ -166,7 +167,8 @@ export type LaunchStatusType = {
 
 export type StatsSectionType = {
   experiment: Object,
-  doShowTourDialog: Function
+  doShowTourDialog: Function,
+  sendToGA: Function
 };
 
 export type ContributorsSectionType = {


### PR DESCRIPTION
There was only one missing event in #3237, the others were just misdocumented. #3300 fixes the documentation, and this adds the missing event.