### PR TITLE
Correctly handle middle/cmd/ctrl clicks with GA navigation events.

### DIFF
--- a/frontend/src/app/components/ExperimentRowCard/index.js
+++ b/frontend/src/app/components/ExperimentRowCard/index.js
@@ -171,16 +171,15 @@ export default class ExperimentRowCard extends React.Component {
     return "";
   }
 
-  openDetailPage(evt: Function) {
+  openDetailPage(evt: Object) {
     const { eventCategory, experiment, sendToGA } = this.props;
     const { title } = experiment;
-    evt.preventDefault();
     sendToGA("event", {
       eventCategory,
       eventAction: "Open detail page",
       eventLabel: title,
       outboundURL: evt.target.href || evt.target.offsetParent.href
-    });
+    }, evt);
   }
 
 }

--- a/frontend/src/app/components/ExperimentRowCard/tests.js
+++ b/frontend/src/app/components/ExperimentRowCard/tests.js
@@ -195,7 +195,7 @@ describe("app/components/ExperimentRowCard", () => {
       eventAction: "Open detail page",
       eventLabel: mockExperiment.title,
       outboundURL: mockClickEvent.target.href
-    }]);
+    }, mockClickEvent]);
   });
 
   it("should have an anchor component with the right properties", () => {

--- a/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
+++ b/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
@@ -79,13 +79,12 @@ export default class FeaturedButton extends React.Component {
 
   handleManage = (evt: Function) => {
     const { experiment, eventCategory } = this.props;
-    evt.preventDefault();
     this.props.sendToGA("event", {
       eventCategory,
       eventAction: "Open detail page",
       eventLabel: experiment.title,
       outboundURL: evt.target.href
-    });
+    }, evt);
   };
 
   handleFeedback = () => {

--- a/frontend/src/app/components/FeaturedExperiment/tests.js
+++ b/frontend/src/app/components/FeaturedExperiment/tests.js
@@ -246,7 +246,7 @@ describe("app/components/FeaturedButton", () => {
     });
     subject.find(".manage-button").simulate("click", mockClickEvent);
 
-    expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
+    expect(props.sendToGA.lastCall.args.slice(0, 2)).to.deep.equal(["event", {
       eventCategory: props.eventCategory,
       eventAction: "Open detail page",
       eventLabel: mockExperiment.title,

--- a/frontend/src/app/components/Footer/index.js
+++ b/frontend/src/app/components/Footer/index.js
@@ -52,14 +52,13 @@ export default class Footer extends React.Component {
   }
 
   eventToGA(e: Object) {
-    e.preventDefault();
     const label = e.target.getAttribute("title");
     this.props.sendToGA("event", {
       eventCategory: "FooterView Interactions",
       eventAction: "social link clicked",
       eventLabel: label,
       outboundURL: e.target.href
-    });
+    }, e);
   }
 
 }

--- a/frontend/src/app/components/Footer/tests.js
+++ b/frontend/src/app/components/Footer/tests.js
@@ -47,7 +47,7 @@ describe("app/components/Footer", () => {
         eventAction: "social link clicked",
         eventLabel: label,
         outboundURL: mockClickEvent.target.href
-      }]);
+      }, mockClickEvent]);
     });
   });
 });

--- a/frontend/src/app/components/Header/index.js
+++ b/frontend/src/app/components/Header/index.js
@@ -95,33 +95,30 @@ export default class Header extends React.Component {
   }
 
   blogLinkClick(evt: Object) {
-    evt.preventDefault();
     this.props.sendToGA("event", {
       eventCategory: "Menu Interactions",
       eventAction: "click",
       eventLabel: "open blog",
       outboundURL: evt.target.href
-    });
+    }, evt);
   }
 
   newsLinkClick(evt: Object) {
-    evt.preventDefault();
     this.props.sendToGA("event", {
       eventCategory: "Menu Interactions",
       eventAction: "click",
       eventLabel: "open newsfeed",
       outboundURL: evt.target.href
-    });
+    }, evt);
   }
 
   homepageClick(evt: Function) {
-    evt.preventDefault();
     this.props.sendToGA("event", {
       eventCategory: "Menu Interactions",
       eventAction: "click",
       eventLabel: "Firefox logo",
       outboundURL: evt.target.href
-    });
+    }, evt);
   }
 
   render() {

--- a/frontend/src/app/components/Header/tests.js
+++ b/frontend/src/app/components/Header/tests.js
@@ -43,7 +43,7 @@ describe("Header", () => {
     });
     it("should ping GA when wordmark is clicked", () => {
       subject.find(".wordmark").simulate("click", mockClickEvent);
-      expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
+      expect(props.sendToGA.lastCall.args.slice(0, 2)).to.deep.equal(["event", {
         eventCategory: "Menu Interactions",
         eventAction: "click",
         eventLabel: "Firefox logo",
@@ -67,7 +67,7 @@ describe("Header", () => {
 
     it("should ping GA on blog link clicked", () => {
       subject.find(".blog-link").simulate("click", mockClickEvent);
-      expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
+      expect(props.sendToGA.lastCall.args.slice(0, 2)).to.deep.equal(["event", {
         eventCategory: "Menu Interactions",
         eventAction: "click",
         eventLabel: "open blog",
@@ -77,7 +77,7 @@ describe("Header", () => {
 
     it("should ping GA on newsfeed link clicked", () => {
       subject.find(".news-link").simulate("click", mockClickEvent);
-      expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
+      expect(props.sendToGA.lastCall.args.slice(0, 2)).to.deep.equal(["event", {
         eventCategory: "Menu Interactions",
         eventAction: "click",
         eventLabel: "open newsfeed",

--- a/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentPreFeedbackDialog.js
@@ -58,14 +58,12 @@ export default class ExperimentPreFeedbackDialog extends React.Component {
   }
 
   feedback(e: Object, url: string) {
-    e.preventDefault();
-
     this.props.sendToGA("event", {
       eventCategory: "ExperimentDetailsPage Interactions",
       eventAction: "PreFeedback Confirm",
       eventLabel: this.props.experiment.title,
       outboundURL: url
-    });
+    }, e);
   }
 
   cancel(e: Object) {

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -808,7 +808,7 @@ describe("app/containers/ExperimentPage/ExperimentPreFeedbackDialog", () => {
       eventAction: "PreFeedback Confirm",
       eventLabel: "foobar",
       outboundURL: surveyURL
-    }]);
+    }, mockClickEvent]);
   });
 
   it("should launch feedback on <Enter> key pressed", () => {
@@ -820,7 +820,7 @@ describe("app/containers/ExperimentPage/ExperimentPreFeedbackDialog", () => {
       eventAction: "PreFeedback Confirm",
       eventLabel: "foobar",
       outboundURL: surveyURL
-    }]);
+    }, mockClickEvent]);
   });
 });
 

--- a/frontend/src/app/lib/tests.js
+++ b/frontend/src/app/lib/tests.js
@@ -1,0 +1,50 @@
+/* global describe, beforeEach, it */
+import { expect } from "chai";
+
+import { shouldOpenInNewTab } from "./utils";
+
+describe("app/lib/utils:shouldOpenInNewTab", () => {
+  let mockClickEvent;
+  beforeEach(() => {
+    mockClickEvent = {
+      ctrlKey: false,
+      metaKey: false,
+      type: "click",
+      which: 1
+    };
+  });
+
+  it("should default to false", () => {
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.false;
+  });
+
+  it("should return true when ctrl-clicked", () => {
+    mockClickEvent.ctrlKey = true;
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.true;
+  });
+
+  it("should return true when cmd-clicked", () => {
+    mockClickEvent.metaKey = true;
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.true;
+  });
+
+  it("should return false for non-click events", () => {
+    mockClickEvent.type = "keypress";
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.false;
+  });
+
+  it("should return true for middle clicks", () => {
+    mockClickEvent.which = 2;
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.true;
+  });
+
+  it("should return false for right clicks", () => {
+    mockClickEvent.which = 3;
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.false;
+  });
+
+  it("should return true for side clicks", () => {
+    mockClickEvent.which = 4;
+    expect(shouldOpenInNewTab(mockClickEvent)).to.be.true;
+  });
+});

--- a/frontend/src/app/lib/utils.js
+++ b/frontend/src/app/lib/utils.js
@@ -52,7 +52,6 @@ export function isMobile(ua) {
   return ua.indexOf("mobi") > -1 || ua.indexOf("tablet") > -1;
 }
 
-
 // Passed a string, returns a verison of that string sanitized by stripping all
 // non-alphanumeric characters, lowercasing the entire string, then capitalizing
 // the first character.
@@ -93,3 +92,17 @@ export { experimentL10nId };
 export { lookup };
 
 export { newsUpdateL10nId };
+
+// Returns true if the passed event is a click event that ocurred while the user
+// was ctrl/cmd-clicking or middle-clicking, indicating that that they performed
+// the action expecting the link to open in a new tab.
+export const shouldOpenInNewTab = (e: Object) => {
+  if (
+    !e ||
+    e.type !== "click" ||
+    (!("which" in e) && !("ctrlKey" in e) && !("metaKey" in e))
+  ) {
+    return false;
+  }
+  return e.which === 2 || e.which === 4 || e.ctrlKey || e.metaKey;
+};


### PR DESCRIPTION
NB: the `.slice(0, 2)` added to tests is because because you can't do deep equality checks of Sinon spy events, so `props.sendToGA.lastCall.args[2] === mockClickEvent` would evaluate to false.

(Closes #3309)