### PR TITLE
Update to fluent 0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7742,9 +7742,9 @@
       }
     },
     "fluent": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.4.2.tgz",
-      "integrity": "sha512-P2w5DeSRYkq80J2VsuFC4SRZaG/jglAgVbHkUgLAaRoQtdDw6vdJjr36/ZH2zKk7bBwubGdIBuavNAhOVeuQxw=="
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/fluent/-/fluent-0.4.3.tgz",
+      "integrity": "sha512-yyqQmC83pOc0yyVGMynzHVAkJp61KJu9Be1aGhkO0PirkgsqfjyAn/0271eA/exwwQvYgQuDhBVYXA0zGxwKaA=="
     },
     "fluent-langneg": {
       "version": "0.1.0",
@@ -7756,7 +7756,7 @@
       "resolved": "https://registry.npmjs.org/fluent-react/-/fluent-react-0.4.1.tgz",
       "integrity": "sha512-5cPA0xyuqQ9JTGmrSyknnXLABBgKdK4L1WFyUUCWa9NBhu97V/fa1jp46qx5s0Bi7wSwZySRvWi/yJRES97rwQ==",
       "requires": {
-        "fluent": "0.4.2",
+        "fluent": "0.4.3",
         "prop-types": "15.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "domready": "1.0.8",
     "es-symbol": "1.1.2",
     "es6-promise": "4.2.2",
-    "fluent": "0.4.2",
+    "fluent": "0.4.3",
     "fluent-langneg": "0.1.0",
     "fluent-react": "0.4.1",
     "html-react-parser": "0.4.1",


### PR DESCRIPTION
Please update the `fluent` dependency to 0.4.3.  It has important fixes to the FTL parser.

While the main development of `fluent` continues with the recent 0.6.x versions, I also published 0.4.3 which is API-compatible with other 0.4.x versions. The upgrade should be painless.

`fluent` 0.4.3 supports the recent changes to the Fluent Syntax. It also supports the syntax Test Pilot and Pontoon use right now. We expect Pontoon to upgrade their Fluent dependencies early next week, at which point all translations saved back to GitHub will be serialized using the new syntax. This PR will minimize the risk of regressions from that update (which is already low because the changes to the syntax are small).

Some of the syntax changes will require an update to the en-US reference file in this repo, too. We'll open a new PR for that once Pontoon is capable of reading it.

cc @flodolo and @zbraniecki who will be around next week to assist in case of questions.