### PR TITLE
Switch en-US FTL file to new syntax

### DIFF
--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -1,14 +1,12 @@
 siteName = Firefox Test Pilot
 
-// Page titles, put in the <title> HTML tag.
-[[pageTitle]]
+## Page titles, put in the <title> HTML tag.
 pageTitleDefault = Firefox Test Pilot
 pageTitleLandingPage = Firefox Test Pilot
 pageTitleExperimentListPage = Firefox Test Pilot - Experiments
 pageTitleExperiment = Firefox Test Pilot - {$title}
 
-// Links in the footer.
-[[footerLink]]
+## Links in the footer.
 footerLinkCookies = Cookies
 footerLinkPrivacy = Privacy
 footerLinkTerms = Terms
@@ -16,8 +14,7 @@ footerLinkLegal = Legal
 footerLinkFeedback = Give Feedback
 footerLinkAbout = About Test Pilot
 
-// Items in the menu.
-[[menu]]
+## Items in the menu.
 home = Home
 menuTitle = Settings
 menuWiki = Test Pilot Wiki
@@ -26,27 +23,23 @@ menuFileIssue = File an Issue
 menuRetire = Uninstall Test Pilot
 headerLinkBlog = Blog
 
-// The splash on the homepage.
-[[landing]]
+## The splash on the homepage.
 landingIntroOne = Test new features.
 landingIntroTwo = Give your feedback.
 landingIntroThree = Help build Firefox.
 landingLegalNotice = By proceeding, you agree to the <a>Terms of Use</a> and <a>Privacy Notice</a> of Test Pilot.
 landingMoreExperimentsButton = More Experiments
 
-// Related to the installation of the Test Pilot add-on.
-[[landingInstall]]
+## Related to the installation of the Test Pilot add-on.
 landingInstallButton = Install the Test Pilot Add-on
 landingInstallingButton = Installing…
 landingEnablingButton = Enabling…
 
-// Related to a one click to install test pilot and an experiment.
-[[oneClickInstall]]
+## Related to a one click to install test pilot and an experiment.
 oneClickInstallMinorCta = Install Test Pilot &amp;
 oneClickInstallMajorCta = Enable {$title}
 
-// Homepage messaging for users not on Firefox or with an old version of Firefox.
-[[landingFirefox]]
+## Homepage messaging for users not on Firefox or with an old version of Firefox.
 landingRequiresDesktop = Test Pilot requires Firefox for Desktop on Windows, Mac or Linux
 landingDownloadFirefoxDesc = (Test Pilot is available for Firefox on Windows, OS X and Linux)
 landingUpgradeDesc = Test Pilot requires Firefox 49 or higher.
@@ -55,41 +48,35 @@ landingDownloadFirefoxTitle = Firefox
 landingUpgradeFirefoxTitle = Upgrade Firefox
 landingDownloadFirefoxSubTitle = Free Download
 
-// A section of the homepage explaining how Test Pilot works.
-[[landingCard]]
+## A section of the homepage explaining how Test Pilot works.
 landingCardListTitle = Get started in 3, 2, 1
 landingCardOne = Get the Test Pilot add-on
 landingCardTwo = Enable experimental features
 landingCardThree = Tell us what you think
 
-// Shown after the user installs the Test Pilot add-on.
-[[onboarding]]
+## Shown after the user installs the Test Pilot add-on.
 onboardingMessage = We put an icon in your toolbar so you can always find Test Pilot.
 
-// Error message pages.
-[[error]]
+## Error message pages.
 errorHeading = Whoops!
 errorMessage = Looks like we broke something. <br> Maybe try again later.
 notFoundHeader = Four Oh Four!
 
-// A modal prompt to sign up for the Test Pilot newsletter.
-[[emailOptIn]]
+## A modal prompt to sign up for the Test Pilot newsletter.
 emailOptInDialogTitle = Welcome to Test Pilot!
 emailOptInMessage = Find out about new experiments and see test results for experiments you've tried.
 emailOptInConfirmationTitle = Email Sent
 emailOptInConfirmationClose = On to the experiments...
 emailOptInDialogErrorTitle = Oh no!
 
-// news feed updates.
-[[updateList]]
+## News feed updates.
 latestUpdatesTitle = Latest updates
 showMoreNewsTitle = Show Past News
 
-[[featuredExperiment]]
+## Featured experiment.
 moreDetail = View details
 
-// A listing of all Test Pilot experiments.
-[[experimentsList]]
+## A listing of all Test Pilot experiments.
 experimentListEnabledTab = Enabled
 experimentListJustLaunchedTab = Just Launched
 experimentListJustUpdatedTab = Just Updated
@@ -99,17 +86,15 @@ experimentCondensedHeader = Welcome to Test Pilot!
 experimentListHeader = Pick your experiments!
 experimentListHeaderWithFeatured = Try all of our experiments
 
-// An individual experiment in the listing of all Test Pilot experiments.
-[[experimentCard]]
-// Small button on experiment card that links to a survey for feedback submission
+## An individual experiment in the listing of all Test Pilot experiments.
+# Small button on experiment card that links to a survey for feedback submission
 experimentCardFeedback = Feedback
 experimentCardManage = Manage
 experimentCardGetStarted = Get Started
-// also used in NewsUpdateDialog
+# Also used in NewsUpdateDialog
 experimentCardLearnMore = Learn More
 
-// A modal prompt shown when a user disables an experiment.
-[[feedback]]
+## A modal prompt shown when a user disables an experiment.
 feedbackSubmitButton = Take a quick survey
 feedbackUninstallTitle = Thank You!
 feedbackUninstallCopy =
@@ -117,18 +102,15 @@ feedbackUninstallCopy =
     a lot! Please check out our other experiments,
     and stay tuned for more to come!
 
-// A modal prompt shown before the feedback survey for some experiments.
-[[experimentPreFeedback]]
+## A modal prompt shown before the feedback survey for some experiments.
 experimentPreFeedbackTitle = {$title} feedback
 experimentPreFeedbackLinkCopy = Give feedback about the {$title} experiment
 
-// A splash shown on top of the experiment page when Test Pilot is not installed.
-[[experimentPromo]]
+## A splash shown on top of the experiment page when Test Pilot is not installed.
 experimentPromoHeader = Ready for Takeoff?
 experimentPromoSubheader = We're building next-generation features for Firefox. Install Test Pilot to try them!
 
-// The experiment detail page.
-[[experimentPage]]
+## The experiment detail page.
 isEnabledStatusMessage = {$title} is enabled.
 installErrorMessage = Uh oh. {$title} could not be enabled. Try again later.
 otherExperiments = Try out these experiments as well
@@ -153,19 +135,17 @@ discussExperiment = Discuss { $title }
 tourDoneButton = Done
 userCountContainerAlt = Just launched!
 highlightPrivacy = Your privacy
-experimentGradReportButton=Graduation Report
+experimentGradReportButton = Graduation Report
 experimentGradReportPendingTitle = This experiment has ended
 experimentGradReportPendingCopy = We are working on a full report. Check back soon for the details.
-experimentGradReportReady=We have prepared a full graduation report.
+experimentGradReportReady = We have prepared a full graduation report.
 experimentGoToLink = Go to { $title }
 startedDateLabel = Experiment Start Date: <b>{$startedDate}</b>
 
-// news updates dialog.
-[[newsUpdatesDialog]]
+## News updates dialog.
 nonExperimentDialogHeaderLink = Test Pilot
 
-// Label shown next to a series of icons indicating whether an experiment is available as an add-on, mobile app, and/or web site
-[[experimentPlatform]]
+## Label shown next to a series of icons indicating whether an experiment is available as an add-on, mobile app, and/or web site
 experimentPlatformWebAddonMobile = Firefox / web / mobile experiment
 experimentPlatformWebAddon = Firefox / web experiment
 experimentPlatformWebMobile = web / mobile experiment
@@ -174,15 +154,13 @@ experimentPlatformWeb = web experiment
 experimentPlatformAddon = Firefox experiment
 experimentPlatformMobileApp = mobile experiment
 
-// Shown when an experiment requires a version of Firefox newer than the user's.
-[[upgradeNotice]]
+## Shown when an experiment requires a version of Firefox newer than the user's.
 upgradeNoticeTitle = {$title} requires Firefox {$min_release} or later.
 upgradeNoticeLink = How to update Firefox.
 versionChangeNotice = {$experiment_title} is not supported in this version of Firefox.
 versionChangeNoticeLink = Get the current version of Firefox.
 
-// Shown while uninstalling Test Pilot.
-[[uninstall]]
+## Shown while uninstalling Test Pilot.
 retireDialogTitle = Uninstall Test Pilot?
 retireMessageUpdate = As you wish. This will uninstall Test Pilot. You can disable individual experiments from the Firefox Add-ons Manager.
 retireEmailMessage = To opt out of email updates, simply click the <em>unsubscribe</em> link on any Test Pilot email.
@@ -193,34 +171,30 @@ retirePageHeadline = Thanks for flying!
 retirePageMessage = Hope you had fun experimenting with us. <br> Come back any time.
 retirePageSurveyButton = Take a quick survey
 
-// Shown to users after installing Test Pilot if a restart is required.
-[[restartIntro]]
+## Shown to users after installing Test Pilot if a restart is required.
 restartIntroLead = Preflight checklist
 restartIntroOne = Restart your browser
 restartIntroTwo = Locate the Test Pilot add-on
 restartIntroThree = Select your experiments
 
-// Shown on a page presented to users three days after installing their first experiment.
-[[share]]
+## Shown on a page presented to users three days after installing their first experiment.
 sharePrimary = Love Test Pilot? Help us find some new recruits.
 shareSecondary = or just copy and paste this link...
 shareEmail = E-mail
 shareCopy = Copy
 
-// Shown on pages of retired or retiring experiments.
+## Shown on pages of retired or retiring experiments.
 eolIntroMessage = {$title} is ending on {$completedDate}
 eolNoticeLink = Learn more
 eolDisableMessage = The {$title} experiment has ended. Once you uninstall it you won't be able to re-install it through Test Pilot again.
 completedDateLabel = Experiment End Date: <b>{$completedDate}</b>
 
-// A warning shown to users looking at experiments incompatible with add-ons they already have installed.
-[[incompatible]]
+## A warning shown to users looking at experiments incompatible with add-ons they already have installed.
 incompatibleHeader = This experiment may not be compatible with add-ons you have installed.
 incompatibleSubheader = We recommend <a>disabling these add-ons</a> before activating this experiment:
 
-// A form prompting the user to sign up for the Test Pilot Newsletter.
-[[newsletterForm]]
-newsletterFormEmailPlaceholder
+## A form prompting the user to sign up for the Test Pilot Newsletter.
+newsletterFormEmailPlaceholder =
     .placeholder = Your email here
 newsletterFormDisclaimer = We will only send you Test Pilot-related information.
 newsletterFormPrivacyNotice = I'm okay with Mozilla handling my info as explained in <a>this privacy notice</a>.
@@ -228,49 +202,42 @@ newsletterFormPrivacyAgreementRequired = Please check this box if you want to pr
 newsletterFormSubmitButton = Sign Up Now
 newsletterFormSubmitButtonSubmitting = Submitting...
 
-// A section of the footer containing a newsletter signup form.
-[[newsletterFooter]]
+## A section of the footer containing a newsletter signup form.
 newsletterFooterError = There was an error submitting your email address. Try again?
 newsletterFooterHeader = Stay Informed
 newsletterFooterBody = Find out about new experiments and see test results for experiments you've tried.
 newsletterFooterSuccessHeader = Thanks!
 newsletterFooterSuccessBody = If you haven't previously confirmed a subscription to a Mozilla-related newsletter you may have to do so. Please check your inbox or your spam filter for an email from us.
 
-// A warning shown to users when the experiment is not available in their language
-[[localeWarning]]
+## A warning shown to users when the experiment is not available in their language
 localeNotTranslatedWarningTitle = This experiment has not been translated to your language ({$locale_code}).
 localeWarningSubtitle = You can still enable it if you like.
 
-// An alternate splash page shown to users who have had Test Pilot installed for some time, but have no experiments installed.
-[[experimentsListNoneInstalled]]
+## An alternate splash page shown to users who have had Test Pilot installed for some time, but have no experiments installed.
 experimentsListNoneInstalledHeader = Let's get this baby off the ground!
 experimentsListNoneInstalledSubheader = Ready to try a new Test Pilot experiment? Select one to enable, take it for a spin, and let us know what you think.
 experimentsListNoneInstalledCTA = Not interested? <a>Let us know why</a>.
 
-// Shown to users who do not have JavaScript enabled.
-[[noscript]]
+## Shown to users who do not have JavaScript enabled.
 noScriptHeading = Uh oh...
 noScriptMessage = Test Pilot requires JavaScript.<br>Sorry about that.
 noScriptLink = Find out why
 
-// Text of a button to toggle visibility of a list of past experiments.
-[[pastExperiments]]
+## Text of a button to toggle visibility of a list of past experiments.
 viewPastExperiments = View Past Experiments
 hidePastExperiments = Hide Past Experiments
 
-// Text of warnings to the user if various error conditions are detected
-[[warnings]]
-warningGenericTitle=Something is wrong!
-warningGenericDetail=Something has gone wrong with Test Pilot. Please <a>file a bug</a> and mention this error message.
-warningUpgradeFirefoxTitle=Upgrade Firefox to continue!
-warningUpgradeFirefoxDetail=Test Pilot requires the latest version of Firefox. <a>Upgrade Firefox</a> to get started.
-warningHttpsRequiredTitle=HTTPS required!
-warningHttpsRequiredDetail=Test Pilot must be accessed over HTTPS. Please see <a>our documentation</a> for details.
-warningMissingPrefTitle=Developing Test Pilot?
-warningMissingPrefDetail=When running Test Pilot locally or in development environments, special configuration is required. Please see <a>our documentation</a> for details.
-warningBadHostnameTitle=Unapproved hostname!
-warningBadHostnameDetail=The Test Pilot site may only be accessed from testpilot.firefox.com, testpilot.stage.mozaws.net, testpilot.dev.mozaws.net, or example.com:8000. Please see <a>our documentation</a> for details.
+## Text of warnings to the user if various error conditions are detected
+warningGenericTitle = Something is wrong!
+warningGenericDetail = Something has gone wrong with Test Pilot. Please <a>file a bug</a> and mention this error message.
+warningUpgradeFirefoxTitle = Upgrade Firefox to continue!
+warningUpgradeFirefoxDetail = Test Pilot requires the latest version of Firefox. <a>Upgrade Firefox</a> to get started.
+warningHttpsRequiredTitle = HTTPS required!
+warningHttpsRequiredDetail = Test Pilot must be accessed over HTTPS. Please see <a>our documentation</a> for details.
+warningMissingPrefTitle = Developing Test Pilot?
+warningMissingPrefDetail = When running Test Pilot locally or in development environments, special configuration is required. Please see <a>our documentation</a> for details.
+warningBadHostnameTitle = Unapproved hostname!
+warningBadHostnameDetail = The Test Pilot site may only be accessed from testpilot.firefox.com, testpilot.stage.mozaws.net, testpilot.dev.mozaws.net, or example.com:8000. Please see <a>our documentation</a> for details.
 
-// This string does not appear in app, but we will use it to localize our `no script` message
+## This string does not appear in app, but we will use it to localize our `no script` message
 jsDisabledWarning = Test Pilot requires JavaScript. Sorry about that.
-

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -1,6 +1,6 @@
 siteName = Firefox Test Pilot
 
-## Page titles, put in the <title> HTML tag.
+## Page titles, shown as title of HTML pages.
 pageTitleDefault = Firefox Test Pilot
 pageTitleLandingPage = Firefox Test Pilot
 pageTitleExperimentListPage = Firefox Test Pilot - Experiments
@@ -37,6 +37,7 @@ landingEnablingButton = Enabling…
 
 ## Related to a one click to install test pilot and an experiment.
 oneClickInstallMinorCta = Install Test Pilot &amp;
+# $title is replaced by the name of an experiment
 oneClickInstallMajorCta = Enable {$title}
 
 ## Homepage messaging for users not on Firefox or with an old version of Firefox.
@@ -60,6 +61,9 @@ onboardingMessage = We put an icon in your toolbar so you can always find Test P
 ## Error message pages.
 errorHeading = Whoops!
 errorMessage = Looks like we broke something. <br> Maybe try again later.
+# 404 is the HTTP standard response code for a page not found. This title is a
+# word play in English, being "Oh" both an exclamation and the pronunciation of
+# the number 0.
 notFoundHeader = Four Oh Four!
 
 ## A modal prompt to sign up for the Test Pilot newsletter.


### PR DESCRIPTION
* `#` for comment sigil
* no more sections,`##` for section comments
* equal sign on empty value
* also used spaces around equal sign consistently

CC @pike