### PR TITLE
"Privacy" checkbox does not gain the text selection pointers each time it is tapped.

### DIFF
--- a/frontend/src/app/components/NewsletterForm/index.scss
+++ b/frontend/src/app/components/NewsletterForm/index.scss
@@ -33,7 +33,6 @@
   }
 
   input[type='checkbox'] {
-    @include flex-container(row, flex-start, center);
     -moz-appearance: none;
     background: url('./img/checks.svg') no-repeat left;
     background-position: 0 0;


### PR DESCRIPTION
The "Privacy" check box is correctly checked and unchecked each time it is tapped.

Fix : #3379 