### PR TITLE
refactored email and tour popups

### DIFF
--- a/frontend/src/app/actions/addon.js
+++ b/frontend/src/app/actions/addon.js
@@ -21,12 +21,11 @@ function setInstalled(installed: InstalledExperiments): SetInstalledAction {
 
 export default {
   setInstalled,
+  txpInstalled: makeSimpleActionCreator("TXP_INSTALLED"),
   setHasAddon: makeSimpleActionCreator("SET_HAS_ADDON"),
   setClientUuid: makeSimpleActionCreator("SET_CLIENT_UUID"),
   setInstalledAddons: makeSimpleActionCreator("SET_INSTALLED_ADDONS"),
-  manuallyEnableExperiment: makeSimpleActionCreator("MANUALLY_ENABLE_EXPERIMENT"),
-  manuallyDisableExperiment: makeSimpleActionCreator("MANUALLY_DISABLE_EXPERIMENT"),
+  experimentInstalled: makeSimpleActionCreator("EXPERIMENT_INSTALLED"),
   enableExperiment: makeSimpleActionCreator("ENABLE_EXPERIMENT"),
-  disableExperiment: makeSimpleActionCreator("DISABLE_EXPERIMENT"),
-  requireRestart: makeSimpleActionCreator("REQUIRE_RESTART")
+  disableExperiment: makeSimpleActionCreator("DISABLE_EXPERIMENT")
 };

--- a/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
+++ b/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
@@ -19,8 +19,7 @@ type FeaturedButtonProps = {
   eventCategory: string,
   hasAddon: any,
   installed: InstalledExperiments,
-  sendToGA: Function,
-  postInstallCallback: Function
+  sendToGA: Function
 }
 
 type FeaturedButtonState = {
@@ -101,7 +100,7 @@ export default class FeaturedButton extends React.Component {
 
   render() {
     const { experiment, installed, clientUUID,
-      hasAddon, enabled, postInstallCallback } = this.props;
+      hasAddon, enabled } = this.props;
     const { slug, survey_url, title } = experiment;
 
     let Buttons;
@@ -134,7 +133,6 @@ export default class FeaturedButton extends React.Component {
           <MainInstallButton {...this.props}
             experimentTitle={title}
             experiment={experiment}
-            postInstallCallback={postInstallCallback}
             experimentLegalLink={this.renderLegalLink()}
             eventCategory="HomePage Interactions"
             eventLabel="Install the Add-on" />

--- a/frontend/src/app/components/FeaturedExperiment/index.js
+++ b/frontend/src/app/components/FeaturedExperiment/index.js
@@ -5,7 +5,6 @@ import React from "react";
 import { Link } from "react-router-dom";
 
 import { experimentL10nId } from "../../lib/utils";
-import ExperimentTourDialog from "../ExperimentTourDialog";
 import FeaturedStatus from "./FeaturedStatus";
 import FeaturedButton from "./FeaturedButton";
 
@@ -25,45 +24,22 @@ type FeaturedExperimentProps = {
   clientUUID?: string,
   eventCategory: string,
   isExperimentEnabled: Function,
-  enableExperiment: Function,
-  navigateTo: Function,
   sendToGA: Function
-}
-
-type FeaturedExperimentState = {
-  showTourDialog: boolean
 }
 
 export default class FeaturedExperiment extends React.Component {
   props: FeaturedExperimentProps
-  state: FeaturedExperimentState
 
   constructor(props: FeaturedExperimentProps) {
     super(props);
-    this.state = {
-      showTourDialog: false
-    };
   }
 
   l10nId(pieces: string) {
     return experimentL10nId(this.props.experiment, pieces);
   }
 
-  postInstallCallback() {
-    this.setState({ showTourDialog: true });
-  }
-
-  onTourDialogComplete() {
-    const { navigateTo } = this.props;
-    this.setState({ showTourDialog: false });
-    if (window.location.pathname !== "/experiments") {
-      navigateTo("/experiments");
-    }
-  }
-
   render() {
     const { experiment, enabled } = this.props;
-    const { showTourDialog } = this.state;
     const { description, title, subtitle, slug, video_url, error } = experiment;
 
     return (
@@ -101,7 +77,7 @@ export default class FeaturedExperiment extends React.Component {
           </Localized>}
 
           <div className="featured-experiment__actions">
-            <FeaturedButton {...this.props} postInstallCallback={this.postInstallCallback.bind(this)} />
+            <FeaturedButton {...this.props} />
           </div>
 
 
@@ -113,11 +89,6 @@ export default class FeaturedExperiment extends React.Component {
               frameBorder="0"
               allowFullScreen />
           </div>
-
-          {showTourDialog && <ExperimentTourDialog {...this.props}
-            onCancel={this.onTourDialogComplete.bind(this)}
-            onComplete={this.onTourDialogComplete.bind(this)}
-          />}
         </div>
       </div>
     );

--- a/frontend/src/app/components/types.js
+++ b/frontend/src/app/components/types.js
@@ -12,5 +12,4 @@ export type MainInstallButtonProps = {
   experiment?: Object,
   experimentTitle: string,
   installCallback?: Function,
-  postInstallCallback?: Function
 } & VariantTestsProps & MiscAppProps & SendToGAProps & BrowserEnvProps;

--- a/frontend/src/app/containers/App/index.js
+++ b/frontend/src/app/containers/App/index.js
@@ -300,9 +300,8 @@ const mapDispatchToProps = dispatch => ({
   navigateTo: path => {
     window.location = path;
   },
-  enableExperiment: experiment => enableExperiment(dispatch, experiment, sendToGA),
+  enableExperiment: (experiment, eventCategory, eventLabel) => enableExperiment(dispatch, experiment, sendToGA, eventCategory, eventLabel),
   disableExperiment: experiment => disableExperiment(dispatch, experiment),
-  requireRestart: () => dispatch(addonActions.requireRestart()),
   setHasAddon: installed => dispatch(addonActions.setHasAddon(installed)),
   newsletterForm: {
     setEmail: email =>

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -102,7 +102,6 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
       navigateTo: sinon.spy(),
       isAfterCompletedDate: sinon.stub().returns(false),
       isExperimentEnabled: sinon.spy(),
-      requireRestart: sinon.spy(),
       sendToGA: sinon.spy(),
       openWindow: sinon.spy(),
       enableExperiment: sinon.spy(),
@@ -262,24 +261,6 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
       expect(subject.find(".experiment-video")).to.have.property("length", 1);
     });
 
-    it("should show the tour dialog if shouldShowTourDialog is true and experiment then becomes enabled", () => {
-      // Flag the tour dialog to be shown, but experiment isn't enabled yet.
-      subject.setState({ shouldShowTourDialog: true });
-
-      // Tour dialog isn't shown yet...
-      expect(subject.state("shouldShowTourDialog")).to.be.true;
-      expect(subject.state("showTourDialog")).to.be.false;
-      expect(subject.find("ExperimentTourDialog")).to.have.property("length", 0);
-
-      // Enable the experiment...
-      subject.setProps({ isExperimentEnabled: () => true });
-
-      // Now show the tour dialog...
-      expect(subject.state("shouldShowTourDialog")).to.be.false;
-      expect(subject.state("showTourDialog")).to.be.true;
-      expect(subject.find("ExperimentTourDialog")).to.have.property("length", 1);
-    });
-
     it("should display a call-to-action to try other experiments", () => {
       const experiment = setExperiment(mockExperiment);
       expect(subject.find(".banner__subtitle")).to.have.property("length", 1);
@@ -298,19 +279,6 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
         expect(subject.find("MainInstallButton")).to.have.property("length", 0);
       });
 
-      it("should show an email dialog if the visit-count cookie is set to 2", () => {
-        const getCookie = sinon.spy(() => "2");
-        const removeCookie = sinon.spy();
-        props = { ...props, hasAddon: true, getCookie, removeCookie };
-        subject = shallow(<ExperimentDetail {...props} />);
-        setExperiment(mockExperiment);
-
-        expect(subject.find("EmailDialog")).to.have.property("length", 1);
-
-        subject.setState({ showEmailDialog: false });
-        expect(subject.find("EmailDialog")).to.have.property("length", 0);
-      });
-
       it('should not show a "Disable" button', () =>
         expect(subject.find("#uninstall-button")).to.have.property("length", 0));
       it('should not show a "Give Feedback" button', () =>
@@ -320,15 +288,14 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
       it('should show an "Your privacy" button', () =>
         expect(subject.find(".highlight-privacy")).to.have.property("length", 1));
 
-      it('should enable experiment and schedule tour when "Enable" clicked', () => {
+      it('should enable experiment when "Enable" clicked', () => {
         const experiment = setExperiment(mockExperiment);
         subject.find("#install-button").simulate("click", mockClickEvent);
 
-        expect(props.enableExperiment.lastCall.args)
-          .to.deep.equal([experiment]);
+        expect(props.enableExperiment.lastCall.args[0])
+          .to.deep.equal(experiment);
         expect(subject.state("isEnabling")).to.be.true;
         expect(subject.state("isDisabling")).to.be.false;
-        expect(subject.state("shouldShowTourDialog")).to.be.true;
         expect(subject.state("progressButtonWidth"))
           .to.equal(mockClickEvent.target.offsetWidth);
         expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {

--- a/frontend/src/app/containers/HomePage/HomePageNoAddon.js
+++ b/frontend/src/app/containers/HomePage/HomePageNoAddon.js
@@ -22,7 +22,6 @@ type HomePageNoAddonProps = {
   experimentsWithoutFeatured: Array<Object>,
   featuredExperiments: Array<Object>,
   isAfterCompletedDate: Function,
-  navigateTo: Function,
   isMinFirefox: boolean,
   isExperimentEnabled: Function,
   enableExperiment: Function,
@@ -33,7 +32,7 @@ export default class HomePageNoAddon extends React.Component {
   props: HomePageNoAddonProps
 
   render() {
-    const { isAfterCompletedDate, featuredExperiments, navigateTo,
+    const { isAfterCompletedDate, featuredExperiments,
       experimentsWithoutFeatured, enableExperiment, isExperimentEnabled } = this.props;
 
     if (experimentsWithoutFeatured.length === 0) { return null; }
@@ -61,11 +60,7 @@ export default class HomePageNoAddon extends React.Component {
 
       {!featuredExperiment && <MainInstallButton {...this.props}
         eventCategory="HomePage Interactions"
-        eventLabel="Install the Add-on"
-        postInstallCallback={() => {
-          if (window.location.pathname !== "/experiments")navigateTo("/experiments");
-        }}
-      />}
+        eventLabel="Install the Add-on" />}
     </Banner>;
 
     const featuredSection = featuredExperiment ? (<Banner background={true}>
@@ -132,11 +127,7 @@ export default class HomePageNoAddon extends React.Component {
             </LayoutWrapper>
             <LayoutWrapper flexModifier="column-center">
               <div className="centered">
-                <MainInstallButton {...this.props} eventCategory="HomePage Interactions" eventLabel="Install the Add-on" postInstallCallback={() => {
-                  if (window.location.pathname !== "/experiments") {
-                    navigateTo("/experiments");
-                  }
-                }}/>
+                <MainInstallButton {...this.props} eventCategory="HomePage Interactions" eventLabel="Install the Add-on" />
               </div>
             </LayoutWrapper>
           </Banner>

--- a/frontend/src/app/containers/HomePage/index.js
+++ b/frontend/src/app/containers/HomePage/index.js
@@ -8,18 +8,7 @@ import "./index.scss";
 
 export default class HomePage extends React.Component {
   render() {
-    const {
-      hasAddon,
-      replaceState,
-      getCookie
-    } = this.props;
-
-    if (hasAddon === null) {
-      // If we are rendering the / page on the server, assume the addon is not installed.
-      return <HomePageNoAddon {...this.props} />;
-    }
-    if (getCookie("visit-count") === undefined && hasAddon) {
-      replaceState({}, "", "/experiments");
+    if (this.props.hasAddon) {
       return <HomePageWithAddon {...this.props} />;
     }
     return <HomePageNoAddon {...this.props} />;

--- a/frontend/src/app/containers/HomePage/tests.js
+++ b/frontend/src/app/containers/HomePage/tests.js
@@ -31,9 +31,7 @@ describe("app/containers/HomePage", () => {
       experiments: [],
       experimentsWithoutFeatured: [],
       hasAddon: false,
-      isFirefox: false,
-      replaceState: sinon.spy(),
-      getCookie: sinon.spy(() => "2")
+      isFirefox: false
     };
     subject = shallow(<HomePage {...props} />);
   });
@@ -41,14 +39,12 @@ describe("app/containers/HomePage", () => {
   it("should return HomePageNoAddon if hasAddon is false", () => {
     expect(subject.find("HomePageNoAddon")).to.have.property("length", 1);
     expect(subject.find("HomePageWithAddon")).to.have.property("length", 0);
-    expect(props.replaceState.called).to.be.false;
   });
 
   it("should return HomePageWithAddon if hasAddon is true", () => {
-    subject.setProps({ hasAddon: true, getCookie: sinon.spy(() => undefined) });
+    subject.setProps({ hasAddon: true });
     expect(subject.find("HomePageWithAddon")).to.have.property("length", 1);
     expect(subject.find("HomePageNoAddon")).to.have.property("length", 0);
-    expect(props.replaceState.called).to.be.true;
   });
 });
 
@@ -180,19 +176,10 @@ describe("app/containers/HomePageWithAddon", () => {
     expect(subject.find("FeaturedExperiment")).to.have.property("length", 1);
   });
 
-  it("should show an email dialog if the URL contains utm_campaign=restart-required",  () => {
-    const getWindowLocation = sinon.spy(() =>
-      ({ search: "utm_campaign=restart-required" }));
-    props = { ...props, getWindowLocation };
-    subject = shallow(<HomePageWithAddon {...props} />);
-    expect(subject.find("EmailDialog")).to.have.property("length", 1);
-
-    subject.setState({ showEmailDialog: false });
-    expect(subject.find("EmailDialog")).to.have.property("length", 0);
-  });
-
-  it("should show an email dialog if the visit-count cookie is set to 2", () => {
-    const getCookie = sinon.spy(name => "2");
+  it("should show an email dialog if the txp-installed cookie exists", () => {
+    const getCookie = sinon.stub();
+    getCookie.withArgs("txp-installed").onFirstCall().returns("1");
+    getCookie.returns(null);
     props = { ...props, getCookie };
     subject = shallow(<HomePageWithAddon {...props} />);
     expect(subject.find("EmailDialog")).to.have.property("length", 1);

--- a/frontend/src/app/containers/types.js
+++ b/frontend/src/app/containers/types.js
@@ -13,7 +13,6 @@ export type SendToGAProps = {
 
 // TODO: Reorg this vague grab-bag into more descriptive types
 export type MiscAppProps = {
-  requireRestart: boolean,
   installAddon: Function,
   navigateTo: Function
 };

--- a/frontend/src/app/index.js
+++ b/frontend/src/app/index.js
@@ -16,7 +16,6 @@ import App from "./containers/App";
 
 import { BrowserRouter, Route, Switch } from "react-router-dom";
 import HomePage from "./containers/HomePage";
-import HomePageWithAddon from "./containers/HomePage/HomePageWithAddon";
 import ExperimentPage from "./containers/ExperimentPage";
 import NewsFeedPage from "./containers/NewsFeedPage";
 import RetirePage from "./containers/RetirePage";
@@ -42,7 +41,7 @@ function routes() {
   return <BrowserRouter>
     <Switch>
       <Route exact path="/" render={appFactoryFor(HomePage)} />
-      <Route exact path="/experiments" render={appFactoryFor(HomePageWithAddon)} />
+      <Route exact path="/experiments" render={appFactoryFor(HomePage)} />
       <Route path="/experiments/:slug" render={appFactoryFor(ExperimentPage)} />
       <Route exact path="/news" render={appFactoryFor(NewsFeedPage)} />
       <Route exact path="/onboarding" render={appFactoryFor(OnboardingPage)} />

--- a/frontend/src/app/reducers/addon.js
+++ b/frontend/src/app/reducers/addon.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { Experiment } from "./experiments";
+import cookies from "js-cookie";
 
 type RestartState = {
   isRequired: boolean,
@@ -127,24 +128,6 @@ function setClientUuid(
   return { ...state, clientUUID };
 }
 
-function manuallyEnableExperiment(
-  state: AddonState,
-  { payload: experiment }: ExperimentPayloadAction
-): AddonState {
-  const newInstalled = { ...state.installed };
-  newInstalled[experiment.addon_id] = { manuallyDisabled: false, ...experiment };
-  return { ...state, installed: newInstalled };
-}
-
-function manuallyDisableExperiment(
-  state: AddonState,
-  { payload: experiment }: ExperimentPayloadAction
-): AddonState {
-  const newInstalled = { ...state.installed };
-  newInstalled[experiment.addon_id] = { manuallyDisabled: true, ...experiment };
-  return { ...state, installed: newInstalled };
-}
-
 function enableExperiment(
   state: AddonState,
   { payload: experiment }: ExperimentPayloadAction
@@ -161,15 +144,6 @@ function disableExperiment(
   const newInstalled = { ...state.installed };
   delete newInstalled[experiment.addon_id];
   return { ...state, installed: newInstalled };
-}
-
-function requireRestart(state: AddonState): AddonState {
-  return {
-    ...state,
-    restart: {
-      isRequired: true
-    }
-  };
 }
 
 export function getInstalled(state: AddonState): InstalledExperiments {
@@ -196,6 +170,9 @@ export default function addonReducer(state: ?AddonState, action: AddonActions): 
   }
 
   switch (action.type) {
+    case "TXP_INSTALLED":
+      cookies.set("txp-installed", "1");
+      return setHasAddon(state, {type: "SET_HAS_ADDON", payload: true});
     case "SET_HAS_ADDON":
       return setHasAddon(state, action);
     case "SET_INSTALLED":
@@ -204,16 +181,13 @@ export default function addonReducer(state: ?AddonState, action: AddonActions): 
       return setInstalledAddons(state, action);
     case "SET_CLIENT_UUID":
       return setClientUuid(state, action);
+    case "EXPERIMENT_INSTALLED":
+      cookies.set("exp-installed", action.payload.addon_id);
+      return enableExperiment(state, { type: "ENABLE_EXPERIMENT", payload: action.payload });
     case "ENABLE_EXPERIMENT":
       return enableExperiment(state, action);
     case "DISABLE_EXPERIMENT":
       return disableExperiment(state, action);
-    case "MANUALLY_ENABLE_EXPERIMENT":
-      return manuallyEnableExperiment(state, action);
-    case "MANUALLY_DISABLE_EXPERIMENT":
-      return manuallyDisableExperiment(state, action);
-    case "REQUIRE_RESTART":
-      return requireRestart(state);
     default:
       return state;
   }

--- a/frontend/test/ui/pages/desktop/detail.py
+++ b/frontend/test/ui/pages/desktop/detail.py
@@ -21,6 +21,10 @@ class Detail(Base):
         return self.EnabledPopup(self)
 
     @property
+    def email_popup(self):
+        return self.EmailPopup(self)
+
+    @property
     def name(self):
         """Returns the experiments name from the details page"""
         self.wait.until(lambda _: self.find_element(*self._name_locator))
@@ -46,6 +50,22 @@ class Detail(Base):
 
     class EnabledPopup(Region):
         _root_locator = (By.CSS_SELECTOR, '.tour-modal')
+        _popup_header_locator = (By.CSS_SELECTOR, '.modal-header-wrapper')
+        _close_button_locator = (By.CLASS_NAME, 'modal-cancel')
+
+        def wait_for_region_to_load(self):
+            self.wait.until(
+                lambda _: self.root.is_displayed())
+
+        def is_popup_displayed(self):
+            el = self.find_element(*self._popup_header_locator).is_displayed()
+            return el
+
+        def close(self):
+            self.find_element(*self._close_button_locator).click()
+
+    class EmailPopup(Region):
+        _root_locator = (By.CSS_SELECTOR, '.feedback-modal')
         _popup_header_locator = (By.CSS_SELECTOR, '.modal-header-wrapper')
         _close_button_locator = (By.CLASS_NAME, 'modal-cancel')
 

--- a/frontend/test/ui/test_install.py
+++ b/frontend/test/ui/test_install.py
@@ -53,7 +53,10 @@ def test_install_and_enable(base_url, selenium, firefox, notifications):
         notifications.AddOnInstallConfirmation).install()
     firefox.browser.wait_for_notification(
         notifications.AddOnInstallComplete).close()
-    assert Detail(selenium, base_url).enabled_popup.is_popup_displayed()
+    exp_detail = Detail(selenium, base_url)
+    assert exp_detail.email_popup.is_popup_displayed()
+    exp_detail.email_popup.close()
+    assert exp_detail.enabled_popup.is_popup_displayed()
 
 
 @pytest.mark.nondestructive
@@ -76,6 +79,8 @@ def test_enable_and_disable_experiment(
     firefox.browser.wait_for_notification(
         notifications.AddOnInstallComplete).close()
     exp_detail = Detail(selenium, base_url)
+    assert exp_detail.email_popup.is_popup_displayed()
+    exp_detail.email_popup.close()
     assert exp_detail.enabled_popup.is_popup_displayed()
     exp_detail.enabled_popup.close()
     experiment.disable()


### PR DESCRIPTION
fixes #3402
fixes #2866 

The `visit-count` cookie flow led to some cases where the ui state became inconsistent, mainly around less common paths of installing/uninstalling. The above issues are two examples.

This PR is meant to fix those issues. It isn't the final state I'd like this area of code to be in, and it breaks some rules around state management, but it gets the behavior to a better place. From there we can improve the overall structure and organization.

One behavioral change that's important is that now the email dialog will show before the tour on a one-click install.