### PR TITLE
added 'key' to iframe to prevent inline changes to src

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/DetailsDescription.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsDescription.js
@@ -47,6 +47,7 @@ export default function DetailsDescription({
 
       {video_url &&
         <iframe
+          key={video_url} // see issue #3469
           width="100%"
           height="360"
           src={video_url}


### PR DESCRIPTION
without `key` react will just update `src` on the same iframe which adds a history record to the browser.

fixes #3469