### PR TITLE
use react-router to navigate to /retire & removed navigateTo. 

### DIFF
--- a/frontend/src/app/components/ExperimentCardList/stories.js
+++ b/frontend/src/app/components/ExperimentCardList/stories.js
@@ -35,7 +35,6 @@ const baseProps = {
   isAfterCompletedDate: () => false,
   isExperimentEnabled: (e) => e.enabled === true,
   sendToGA: action("sendToGA"),
-  navigateTo: action("navigateTo"),
   installed: {},
   clientUUID: "867-5309"
 };

--- a/frontend/src/app/components/ExperimentCardList/tests.js
+++ b/frontend/src/app/components/ExperimentCardList/tests.js
@@ -20,8 +20,7 @@ describe("app/components/ExperimentCardList", () => {
       // required by ExperimentRowCard {...this.props}
       hasAddon: true,
       eventCategory: "test category",
-      sendToGA: sinon.spy(),
-      navigateTo: sinon.spy()
+      sendToGA: sinon.spy()
     };
     subject = shallow(<ExperimentCardList {...props} />);
   });

--- a/frontend/src/app/components/ExperimentRowCard/index.js
+++ b/frontend/src/app/components/ExperimentRowCard/index.js
@@ -28,7 +28,6 @@ type ExperimentRowCardProps = {
   clientUUID: ?string,
   eventCategory: string,
   sendToGA: Function,
-  navigateTo: Function,
   isAfterCompletedDate: Function
 }
 

--- a/frontend/src/app/components/ExperimentRowCard/stories.js
+++ b/frontend/src/app/components/ExperimentRowCard/stories.js
@@ -29,7 +29,6 @@ const baseProps = {
   eventCategory: "storybook",
   isAfterCompletedDate: () => false,
   sendToGA: action("sendToGA"),
-  navigateTo: action("navigateTo"),
   installed: {},
   clientUUID: "867-5309"
 };

--- a/frontend/src/app/components/ExperimentRowCard/tests.js
+++ b/frontend/src/app/components/ExperimentRowCard/tests.js
@@ -45,7 +45,6 @@ describe("app/components/ExperimentRowCard", () => {
       isFirefox: true,
       isMinFirefox: true,
       eventCategory: "test category",
-      navigateTo: sinon.spy(),
       sendToGA: sinon.spy(),
       isAfterCompletedDate: sinon.spy()
     };

--- a/frontend/src/app/components/FeaturedExperiment/stories.js
+++ b/frontend/src/app/components/FeaturedExperiment/stories.js
@@ -33,7 +33,6 @@ const baseProps = {
   isAfterCompletedDate: () => false,
   installAddon: action("installAddon"),
   sendToGA: action("sendToGA"),
-  navigateTo: action("navigateTo"),
   clientUUID: "867-5309"
 };
 

--- a/frontend/src/app/components/FeaturedExperiment/tests.js
+++ b/frontend/src/app/components/FeaturedExperiment/tests.js
@@ -32,7 +32,6 @@ describe("app/components/FeaturedExperiment", () => {
       isMinFirefox: true,
       installed: [],
       eventCategory: "test category",
-      navigateTo: sinon.spy(),
       sendToGA: sinon.spy(),
       isExperimentEnabled: sinon.spy()
     };

--- a/frontend/src/app/components/Header/tests.js
+++ b/frontend/src/app/components/Header/tests.js
@@ -120,14 +120,6 @@ describe("Header", () => {
           .simulate("click", mockClickEvent);
       };
 
-      it("should ping GA and show retire dialog on retire item click", () => {
-        clickItem("menuRetire");
-        expect(preventDefault.called).to.be.true;
-        expect(subject.state("showRetireDialog")).to.be.true;
-        expect(subject.find("RetireConfirmationDialog")).to.have.property("length", 1);
-        expectMenuGA("Retire");
-      });
-
       it("should ping GA and and close menu on discuss clicks", () => {
         clickItem("menuDiscuss");
         expectMenuGA("Discuss");

--- a/frontend/src/app/components/MainInstallButton/tests.js
+++ b/frontend/src/app/components/MainInstallButton/tests.js
@@ -21,7 +21,6 @@ describe("app/components/MainInstallButton", () => {
       installAddon: sinon.spy(() => Promise.resolve()),
       isExperimentEnabled: sinon.spy(),
       enableExperiment: sinon.spy(() => Promise.resolve()),
-      navigateTo: sinon.spy(),
       varianttests: {
         installButtonBorder: "default"
       }

--- a/frontend/src/app/components/PastExperiments/stories.js
+++ b/frontend/src/app/components/PastExperiments/stories.js
@@ -35,7 +35,6 @@ const baseProps = {
   isAfterCompletedDate: () => false,
   isExperimentEnabled: (e) => e.enabled === true,
   sendToGA: action("sendToGA"),
-  navigateTo: action("navigateTo"),
   installed: {},
   clientUUID: "867-5309"
 };

--- a/frontend/src/app/components/RetireConfirmationDialog/index.js
+++ b/frontend/src/app/components/RetireConfirmationDialog/index.js
@@ -1,6 +1,7 @@
 // @flow
 import { Localized } from "fluent-react/compat";
 import React from "react";
+import { withRouter } from "react-router-dom";
 
 import LocalizedHtml from "../LocalizedHtml";
 
@@ -8,10 +9,10 @@ type RetireConfirmationDialogProps = {
   uninstallAddon: Function,
   onDismiss: Function,
   sendToGA: Function,
-  navigateTo?: Function
+  history: Object
 }
 
-export default class RetireConfirmationDialog extends React.Component {
+export class RetireConfirmationDialog extends React.Component {
   props: RetireConfirmationDialogProps
 
   modalContainer: Object
@@ -56,7 +57,7 @@ export default class RetireConfirmationDialog extends React.Component {
   }
 
   proceed(e: Object) {
-    const { sendToGA, navigateTo, uninstallAddon } = this.props;
+    const { sendToGA, uninstallAddon, history } = this.props;
     e.preventDefault();
     uninstallAddon();
     sendToGA("event", {
@@ -64,9 +65,7 @@ export default class RetireConfirmationDialog extends React.Component {
       eventAction: "button click",
       eventLabel: "Retire"
     });
-    if (typeof navigateTo !== "undefined") {
-      navigateTo("/retire");
-    }
+    history.push("/retire");
   }
 
   cancel(e: Object) {
@@ -87,3 +86,5 @@ export default class RetireConfirmationDialog extends React.Component {
     }
   }
 }
+
+export default withRouter(RetireConfirmationDialog);

--- a/frontend/src/app/components/RetireConfirmationDialog/tests.js
+++ b/frontend/src/app/components/RetireConfirmationDialog/tests.js
@@ -6,7 +6,7 @@ import sinon from "sinon";
 import { shallow } from "enzyme";
 import { findLocalizedById } from "../../../../test/app/util";
 
-import RetireConfirmationDialog from "./index";
+import { RetireConfirmationDialog } from "./index";
 
 describe("app/components/RetireConfirmationDialog", () => {
   let props, mockClickEvent, subject,
@@ -15,7 +15,9 @@ describe("app/components/RetireConfirmationDialog", () => {
     props = {
       uninstallAddon: sinon.spy(),
       onDismiss: sinon.spy(),
-      navigateTo: sinon.spy(),
+      history: {
+        push: sinon.spy()
+      },
       sendToGA: sinon.spy()
     };
     mockClickEvent = {
@@ -49,8 +51,8 @@ describe("app/components/RetireConfirmationDialog", () => {
   it("should uninstall the addon and ping GA when the proceed button is clicked", () => {
     findLocalizedById(subject, "retireSubmitButton").find("button").simulate("click", mockClickEvent);
     expect(props.uninstallAddon.called).to.be.true;
-    expect(props.navigateTo.called).to.be.true;
-    expect(props.navigateTo.lastCall.args[0]).to.equal("/retire");
+    expect(props.history.push.called).to.be.true;
+    expect(props.history.push.lastCall.args[0]).to.equal("/retire");
     expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
       eventCategory: "HomePage Interactions",
       eventAction: "button click",
@@ -61,8 +63,8 @@ describe("app/components/RetireConfirmationDialog", () => {
   it("should uninstall the addon and ping GA when the <Enter> key is pressed", () => {
     subject.find(".modal-container").simulate("keyDown", mockEnterKeyDownEvent);
     expect(props.uninstallAddon.called).to.be.true;
-    expect(props.navigateTo.called).to.be.true;
-    expect(props.navigateTo.lastCall.args[0]).to.equal("/retire");
+    expect(props.history.push.called).to.be.true;
+    expect(props.history.push.lastCall.args[0]).to.equal("/retire");
     expect(props.sendToGA.lastCall.args).to.deep.equal(["event", {
       eventCategory: "HomePage Interactions",
       eventAction: "button click",

--- a/frontend/src/app/containers/App/index.js
+++ b/frontend/src/app/containers/App/index.js
@@ -297,9 +297,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   chooseTests: () => dispatch(chooseTests()),
-  navigateTo: path => {
-    window.location = path;
-  },
   enableExperiment: (experiment, eventCategory, eventLabel) => enableExperiment(dispatch, experiment, sendToGA, eventCategory, eventLabel),
   disableExperiment: experiment => disableExperiment(dispatch, experiment),
   setHasAddon: installed => dispatch(addonActions.setHasAddon(installed)),
@@ -335,7 +332,6 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     },
     openWindow: (href, name) => window.open(href, name),
     getWindowLocation: () => window.location,
-    replaceState: (state, title, location) => window.history.replaceState(state, title, location),
     addScrollListener: listener =>
       window.addEventListener("scroll", listener),
     removeScrollListener: listener =>

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -99,7 +99,6 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
       installedAddons: [],
       params: {},
       uninstallAddon: sinon.spy(),
-      navigateTo: sinon.spy(),
       isAfterCompletedDate: sinon.stub().returns(false),
       isExperimentEnabled: sinon.spy(),
       sendToGA: sinon.spy(),

--- a/frontend/src/app/containers/HomePage/HomePageWithAddon.js
+++ b/frontend/src/app/containers/HomePage/HomePageWithAddon.js
@@ -38,7 +38,6 @@ type HomePageWithAddonProps = {
   isExperimentEnabled: Function,
   isAfterCompletedDate: Function,
   enableExperiment: Function,
-  navigateTo: Function,
   isMinFirefox: boolean,
   isFirefox: boolean
 }

--- a/frontend/src/app/containers/HomePage/stories.js
+++ b/frontend/src/app/containers/HomePage/stories.js
@@ -52,7 +52,6 @@ const cardListProps = {
   isAfterCompletedDate: () => false,
   isExperimentEnabled: e => e.enabled === true,
   sendToGA: action("sendToGA"),
-  navigateTo: action("navigateTo"),
   installed: {},
   clientUUID: "867-5309"
 };

--- a/frontend/src/app/containers/HomePage/tests.js
+++ b/frontend/src/app/containers/HomePage/tests.js
@@ -108,7 +108,6 @@ describe("app/containers/HomePageWithAddon", () => {
       experimentsWithoutFeatured: [ { title: "foo" }, { title: "bar" } ],
       hasAddon: true,
       uninstallAddon: sinon.spy(),
-      navigateTo: sinon.spy(),
       newsletterForm: {succeeded: true},
       majorNewsUpdates: [
         {

--- a/frontend/src/app/containers/types.js
+++ b/frontend/src/app/containers/types.js
@@ -13,6 +13,5 @@ export type SendToGAProps = {
 
 // TODO: Reorg this vague grab-bag into more descriptive types
 export type MiscAppProps = {
-  installAddon: Function,
-  navigateTo: Function
+  installAddon: Function
 };

--- a/frontend/test/app/containers/OnboardingPage-test.js
+++ b/frontend/test/app/containers/OnboardingPage-test.js
@@ -9,7 +9,6 @@ import OnboardingPage from "../../../src/app/containers/OnboardingPage";
 describe("app/containers/OnboardingPage", () => {
   it("should render onboarding page", () => {
     const props = {
-      navigateTo: sinon.spy(),
       uninstallAddon: sinon.spy(),
       openWindow: sinon.spy(),
       sendToGA: sinon.spy()


### PR DESCRIPTION
fixes #3466 

also removed all `navigateTo` references since it's no longer used.