### PR TITLE
put the loading spinner back

### DIFF
--- a/frontend/src/app/components/Loading/index.scss
+++ b/frontend/src/app/components/Loading/index.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/_utils';
+
 // HT: https://www.pexels.com/blog/css-only-loaders/
 .loading {
   @include flex-container(row, space-between, center);

--- a/frontend/src/app/containers/App/index.js
+++ b/frontend/src/app/containers/App/index.js
@@ -22,6 +22,7 @@ import addonActions from "../../actions/addon";
 import newsletterFormActions from "../../actions/newsletter-form";
 import RestartPage from "../RestartPage";
 import UpgradeWarningPage from "../UpgradeWarningPage";
+import Loading from "../../components/Loading";
 import {
   shouldOpenInNewTab
 } from "../../lib/utils";
@@ -50,6 +51,9 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.lastPingPathname = null;
+    this.state = {
+      loading: true
+    };
   }
 
   measurePageview() {
@@ -145,6 +149,7 @@ class App extends Component {
     );
 
     Promise.all(promises).then(() => {
+      this.setState({ loading: false });
       this.props.setLocalizations(langs);
       const staticNode = document.getElementById("static-root");
       if (staticNode) {
@@ -160,6 +165,10 @@ class App extends Component {
 
   render() {
     const { restart } = this.props.addon;
+    const { loading } = this.state;
+    if (loading) {
+      return <Loading />;
+    }
     if (restart.isRequired) {
       return <RestartPage {...this.props} />;
     }


### PR DESCRIPTION
This is *sort of* quick and dirty as it doesn't wait for the addon manager to return the installed state, but in my experience the l10n part tends to be the longer wait anyway.

fixes #3453