### PR TITLE
some tiny tweaks to experiment controls

### DIFF
--- a/frontend/src/app/components/ExperimentPlatforms/index.scss
+++ b/frontend/src/app/components/ExperimentPlatforms/index.scss
@@ -7,11 +7,21 @@
   font-family: 'Fira Sans Book', sans-serif;
   font-size: 13px;
   font-weight: normal;
+  line-height: 16px;
   margin: 0;
 
   .platform-copy,
   .platform-icon {
     margin-bottom: 5px;
+
+    .details-header & {
+      margin-bottom: 0;
+    }
+  }
+
+  .platform-copy {
+    align-items: center;
+    display: flex;
   }
 
   .platform-icon {
@@ -20,14 +30,12 @@
     background-size: 16px;
     height: 16px;
     margin-right: 6px;
-    margin-top: -4px;
     opacity: .5;
     width: 16px;
   }
 
   .platform-icon-web {
     background-image: url('./img/experiment-type-web.svg');
-    margin-top: -2px;
   }
 
   .platform-icon-addon {

--- a/frontend/src/app/containers/ExperimentPage/DetailsHeader.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsHeader.js
@@ -77,7 +77,7 @@ export default class DetailsHeader extends React.Component {
           flexModifier="row-between-breaking"
         >
           <div className={`experiment-icon-wrapper-${slug} experiment-icon-wrapper`}>
-            <img className="experiment-icon" src={thumbnail} />
+            <div className="experiment-icon" style={{backgroundImage: `url(${thumbnail})`}} />
           </div>
           <header>
             <h1>

--- a/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
@@ -100,6 +100,17 @@ export default function ExperimentControls({
   } else if (enabled) {
     controls = (
       <div className="experiment-controls">
+        <a
+          id="feedback-button"
+          onClick={handleFeedback}
+          className="button default"
+          href={surveyURL}
+          target="_blank"
+          rel="noopener noreferrer">
+          <Localized id="giveFeedback">
+            <span className="default-text">Give Feedback</span>
+          </Localized>
+        </a>
         <button
           onClick={uninstallExperimentWithSurvey}
           id="uninstall-button"
@@ -117,17 +128,6 @@ export default function ExperimentControls({
             </span>
           </Localized>
         </button>
-        <a
-          id="feedback-button"
-          onClick={handleFeedback}
-          className="button default"
-          href={surveyURL}
-          target="_blank"
-          rel="noopener noreferrer">
-          <Localized id="giveFeedback">
-            <span className="default-text">Give Feedback</span>
-          </Localized>
-        </a>
       </div>
     );
   } else if (validVersion) {

--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -15,17 +15,16 @@
     width: 200%;
   }
 
+  .experiment-icon {
+    background-position: center center;
+    background-size: 32px 32px;
+  }
+
   & .spacer {
     flex: 1 0 auto;
   }
 
   @include respond-to('not-small') {
-    &:not(.has-status) {
-      .status-bar {
-        display: block;
-        visibility: hidden;
-      }
-    }
 
     & .experiment-icon-wrapper {
       clip-path: circle(32px at center);
@@ -92,9 +91,10 @@
 
   .button {
     border-radius: 3px;
+    font-size: 18px;
     height: 100%;
-    margin-top: 8px;
-    padding: 4px;
+    margin-top: 12px;
+    padding: 6px 4px;
     width: 100%;
   }
 
@@ -116,12 +116,20 @@
   span {
     text-wrap: nowrap;
   }
+
+  .default,
+  #one-click-button {
+    box-shadow: 0 2px 0 $transparent-black-2, 0 -2px 0 $transparent-black-2 inset;
+    text-shadow: 0 2px 0 $transparent-black-1;
+  }
 }
 
 #one-click-button {
   border: 0;
+  border-radius: $large-border-radius;
   display: flex;
   flex-direction: column;
+  padding: 12px 4px;
 }
 
 .privacy-link {
@@ -130,7 +138,6 @@
   text-align: center;
 
   .legal-section {
-    font-weight: 300;
     line-height: 15px;
     margin: 0;
 
@@ -143,6 +150,11 @@
 }
 
 .details-header {
+
+  @include respond-to('not-small') {
+    padding: 20px 10px 10px;
+  }
+
   h1 {
     display: flex;
     flex: 1;


### PR DESCRIPTION
This PR makes some little fine-tuning adjustments to the new sidebar controls UI

* Makes the button font a bit bigger
* bumps the font weight of legal text to normal (300 wght looks off on non-retina displays)
* adds a bit of white space around the title bar
* resets the plaform icons to better center align

![screen shot 2018-05-03 at 12 44 39 pm](https://user-images.githubusercontent.com/3323249/39572616-31d1c6c8-4ed0-11e8-980a-55d43b223ae7.png)

![screen shot 2018-05-03 at 12 48 21 pm](https://user-images.githubusercontent.com/3323249/39572648-53adb81a-4ed0-11e8-974f-54d96c956496.png)
