### PR TITLE
Fix #3536.  Add SSL to font connection CSP

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -40,8 +40,8 @@ ONE_YEAR="31536000"
 
 HPKP="\"Public-Key-Pins\": \"max-age=300;pin-sha256=\\\"WoiWRyIOVNa9ihaBciRSC7XHjliYS9VwUGOIud4PB18=\\\";pin-sha256=\\\"r/mIkG3eEpVdm+u/ko/cwxzOMo1bk4TyHIlByibiA5E=\\\";pin-sha256=\\\"YLh1dUR9y6Kja30RrAn7JKnbQG/uEtLMkBgFF2Fuihg=\\\";pin-sha256=\\\"sRHdihwgkaib1P1gxX8HFszlD+7/gTfNvuAybgLPNis=\\\";\""
 
-# HACK: If this is changed, be sure to update the CSP constant in frontend/tasks/server.js
-CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'self' code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;\""
+# HACK: If this is changed, be sure to update the CSP constant in frontend/lib/dev-server.js
+CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' https://code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self'; img-src 'self' https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://ssl.google-analytics.com; style-src 'self' https://code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;\""
 HSTS="\"strict-transport-security\": \"max-age=${ONE_YEAR}; includeSubDomains; preload\""
 TYPE="\"x-content-type-options\": \"nosniff\""
 XSS="\"x-xss-protection\": \"1; mode=block\""
@@ -53,8 +53,8 @@ if [ "$DEST" = "dev" ]; then
     TEN_MINUTES="15"
     ONE_YEAR="15"
 
-    # HACK: If this is changed, be sure to update the CSP constant in frontend/tasks/server.js
-    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;\""
+    # HACK: If this is changed, be sure to update the CSP constant in frontend/lib/dev-server.js
+    CSP="\"content-security-policy\": \"default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' https://code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org https://code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;\""
 fi
 
 # build version.json if it isn't provided

--- a/frontend/lib/dev-server.js
+++ b/frontend/lib/dev-server.js
@@ -6,7 +6,7 @@ const express = require("express");
 const morgan = require("morgan");
 
 // TODO: CSP copied from bin/deploy.sh - find a way to extract automatically?
-const CSP = `default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;`;
+const CSP = `default-src 'self'; connect-src 'self' https://sentry.prod.mozaws.net https://www.google-analytics.com https://ssl.google-analytics.com https://basket.mozilla.org font-src 'self' https://code.cdn.mozilla.net; form-action 'none'; frame-ancestors 'self' https://pontoon.mozilla.org; img-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com https://www.google-analytics.com; object-src 'none'; script-src 'self' https://pontoon.mozilla.org https://ssl.google-analytics.com; style-src 'self' https://pontoon.mozilla.org https://code.cdn.mozilla.net; report-uri /__cspreport__; frame-src https://www.youtube.com;`;
 
 const DevServerHTTPSOptions = {
   key: fs.readFileSync(path.join(__dirname, "../certs/server/my-server.key.pem")),


### PR DESCRIPTION
This adds SSL.  I don't know if that's the fix or not, but it's the only thing that is different.

I dropped the comment about server.js because I can't find that file anymore.  If it exists somewhere, it sounds like it's important to update too.