### PR TITLE
make tours optional for add-on experiments

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
@@ -33,7 +33,8 @@ export default function DetailsOverview({
   highlightMeasurementPanel,
   flashMeasurementPanel,
   doShowTourDialog,
-  surveyURL
+  surveyURL,
+  hasTour
 }: DetailsOverviewType) {
   const { measurements } = experiment;
   const l10nId = (pieces: string) => experimentL10nId(experiment, pieces);
@@ -60,7 +61,8 @@ export default function DetailsOverview({
               doShowPreFeedbackDialog,
               flashMeasurementPanel,
               uninstallExperimentWithSurvey,
-              surveyURL
+              surveyURL,
+              hasTour
             }}
           />
         </div>
@@ -69,7 +71,7 @@ export default function DetailsOverview({
         <section className="user-count">
           <LaunchStatus {...{ experiment, graduated }} />
         </section>
-        {!graduated && <StatsSection {...{ experiment, doShowTourDialog, sendToGA }} />}
+        {!graduated && <StatsSection {...{ experiment, doShowTourDialog, sendToGA, hasTour }} />}
         <ContributorsSection {...{ experiment, l10nId }} />
         {!graduated &&
           measurements &&
@@ -115,11 +117,12 @@ export const StatsSection = ({
     bug_report_url,
     discourse_url
   },
-  sendToGA
+  sendToGA,
+  hasTour
 }: StatsSectionType) => {
   return <section className="stats-section">
     <ul>
-      {!web_url &&
+      {!web_url && hasTour &&
           <li>
             <Localized id="tourLink">
               <a className="showTour" onClick={evt => {

--- a/frontend/src/app/containers/ExperimentPage/index.js
+++ b/frontend/src/app/containers/ExperimentPage/index.js
@@ -184,6 +184,7 @@ export class ExperimentDetail extends React.Component {
     }
 
     const { title, survey_url, tour_steps } = experiment;
+    const hasTour = typeof tour_steps !== "undefined";
 
     setPageTitleL10N("pageTitleExperiment", experiment);
 
@@ -231,7 +232,8 @@ export class ExperimentDetail extends React.Component {
             onSubmit={() => this.setState({ showDisableDialog: false })}
           />}
 
-        {showTourDialog &&
+        {/* Only show the tour dialog if there are tour steps in the experiment YAML */}
+        {hasTour && showTourDialog &&
           <ExperimentTourDialog
             {...this.props}
             onCancel={() => this.setState({ showTourDialog: false })}
@@ -318,7 +320,8 @@ export class ExperimentDetail extends React.Component {
                     highlightMeasurementPanel,
                     flashMeasurementPanel,
                     doShowTourDialog,
-                    l10nId
+                    l10nId,
+                    hasTour
                   }}
                 />
                 <DetailsDescription

--- a/frontend/src/app/containers/ExperimentPage/tests.js
+++ b/frontend/src/app/containers/ExperimentPage/tests.js
@@ -80,6 +80,12 @@ describe("app/containers/ExperimentPage:ExperimentDetail", () => {
           copy: "Testing"
         }
       ],
+      tour_steps: [
+        {
+          image: "/hello.jpg",
+          copy: "spiral pizza"
+        }
+      ],
       min_release: 48.0,
       error: false
     };
@@ -776,15 +782,17 @@ describe("app/containers/ExperimentPage/ExperimentPreFeedbackDialog", () => {
 
 describe("app/containers/ExperimentPage/DetailsOverview:StatsSection", () => {
 
-  let doShowTourDialog, mockClickEvent, props, sendToGA, subject;
+  let doShowTourDialog, mockClickEvent, props, sendToGA, hasTour, subject;
   beforeEach(() => {
     mockClickEvent = {};
     doShowTourDialog = sinon.spy();
     sendToGA = sinon.spy();
+    hasTour = true;
     props = {
       experiment: {},
       doShowTourDialog,
-      sendToGA
+      sendToGA,
+      hasTour
     };
     subject = shallow(<StatsSection {...props} />);
   });


### PR DESCRIPTION
Makes it so we don't need a tour for add-on experiments that handle their own onboarding