### PR TITLE
Skip storybook builds when missing credentials

### DIFF
--- a/bin/deploy-storybook.sh
+++ b/bin/deploy-storybook.sh
@@ -20,6 +20,12 @@ if [ "$CIRCLE_PROJECT_USERNAME" != "mozilla" ]; then
   exit 0;
 fi
 
+# Skip builds without credentials
+if [ -z "$AWS_ACCESS_KEY_ID" || -z "$AWS_SECRET_ACCESS_KEY" ]; then;
+  echo "Skipping Storybook deploy for missing credentials";
+  exit 0;
+fi
+
 # HACK: Build static storybook with URL paths edited to include git hash
 HASH=$(git --no-pager log --format=format:"%H" -1)
 cp -r .storybook .storybook-$HASH


### PR DESCRIPTION
Not sure why these builds are happening. Maybe CircleCI changed some env vars around. This tweak should at least stop the errors by skipping the build when AWS credentials are unavailable - i.e. for every build except those specifically on mozilla repo branches.