### PR TITLE
make web button secondary if addon exists

### DIFF
--- a/docs/metrics/ga.md
+++ b/docs/metrics/ga.md
@@ -74,6 +74,7 @@ Here are the current events on the website as of this writing, grouped by their 
 | Click on Install from experiment details page | install button click | Install the Add-on from `${experiment title}`|
 | Click on the "Try out these experiments as well" section | Open detail page | try out `{experiment title}` |
 | Click Enable Experiment | Enable Experiment | `{experiment title}` |
+| Click Link to Web Experiment | Go to Web Experiment | `{experiment title}` |
 | Click Disable Experiment | Disable Experiment | `{experiment title}` |
 | Click Give Feedback for experiment | Give Feedback | `{experiment title}` |
 | Click Give Feedback for experiment from PreFeedback | PreFeedback Confirm | `{experiment title}` |

--- a/frontend/src/app/components/Footer/index.js
+++ b/frontend/src/app/components/Footer/index.js
@@ -154,8 +154,6 @@ export default class Footer extends React.Component {
               <a href="https://www.mozilla.org/privacy/websites/#cookies" className="boilerplate">Cookies</a>
             </Localized>
           </div>
-          <br/>
-          <hr/>
         </div>
       </footer>
     );

--- a/frontend/src/app/components/Footer/index.scss
+++ b/frontend/src/app/components/Footer/index.scss
@@ -3,7 +3,7 @@
 
 #main-footer {
   @include respond-to('not-small') {
-    padding: $grid-unit * 2 0 $grid-unit;
+    padding: $grid-unit * 2 0;
   }
 
   @include respond-to('small') {
@@ -105,6 +105,7 @@
   background-repeat: no-repeat;
   background-size: auto 32px;
   height: 32px;
+  margin-top: 12px;
   opacity: .9;
   transition: opacity 150ms;
   width: 112px;
@@ -118,7 +119,7 @@ footer {
   background: $black;
 
   .uninstall-header {
-    color: $red-60;
+    color: $red-70;
   }
 }
 

--- a/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
@@ -176,24 +176,26 @@ export const WebExperimentControls = ({
   web_url,
   title,
   slug,
-  sendToGA
+  sendToGA,
+  platforms,
+  validVersion
 }: WebExperimentControlsType) => {
   function handleGoToLink() {
     sendToGA("event", {
       eventCategory: "ExperimentDetailsPage Interactions",
-      eventAction: "Enable Experiment",
+      eventAction: "Go to Web Experiment",
       eventLabel: title,
       dimension11: slug
     });
   }
-
+  const buttonType = platforms.includes("addon") && validVersion ? "secondary" : "default";
   return (
     <a
       href={web_url}
       onClick={handleGoToLink}
       target="_blank"
       rel="noopener noreferrer"
-      className="button default"
+      className={classnames("button", buttonType)}
     >
       <Localized id="experimentGoToLink" $title={title}>
         <span className="default-text">
@@ -220,9 +222,9 @@ function createButton({
   userAgent,
   validVersion
 }: EnableButtonType) {
-  const { slug, title, web_url, ios_url, android_url } = experiment;
-  if (platform === "web") {
-    return <WebExperimentControls {...{ key: web_url, web_url, title, slug, sendToGA }} />;
+  const { slug, title, web_url, ios_url, android_url, platforms } = experiment;
+  if (platform === "web" && web_url) {
+    return <WebExperimentControls {...{ key: web_url, web_url, title, slug, sendToGA, platforms, validVersion }} />;
   } else if (platform === "addon") {
     if (graduated && enabled) {
       return (


### PR DESCRIPTION
I touched a bit of CSS in the new footer (which looks great btw!) but this patch is mostly to ensure that for experiments with web and add-on components, the web button is secondary to the add-on button where the user has a valid firefox version