### PR TITLE
minor fixes to featured experiment ui

### DIFF
--- a/content-src/experiments/color.yaml
+++ b/content-src/experiments/color.yaml
@@ -1,7 +1,7 @@
 id: 17
 title: 'Color'
 slug: color
-is_featured: false
+is_featured: true
 platforms: ['addon', 'web']
 min_release: 60
 thumbnail: /static/images/experiments/color/color-thumbnail.png

--- a/frontend/src/app/components/FeaturedExperiment/index.scss
+++ b/frontend/src/app/components/FeaturedExperiment/index.scss
@@ -61,7 +61,7 @@
   .featured-experiment__header {
     @include respond-to('small') {
       @include flex-container(column, center, center);
-      margin-bottom: 20px;
+      margin-bottom: 16px;
     }
 
     @include respond-to('not-small') {
@@ -79,10 +79,11 @@
       }
 
       border-radius: 50%;
-      flex: 0 0 54px;
-      height: 54px;
-      margin: 0 10px 0 0;
-      width: 54px;
+      box-shadow: 0 0 5px $transparent-black-05;
+      flex: 0 0 64px;
+      height: 64px;
+      margin: 0 15px 0 0;
+      width: 64px;
     }
 
     .experiment-icon {
@@ -122,11 +123,11 @@
       @include flex-container(column, center, center);
     }
 
-    @include flex-container(column, space-between, flex-start);
+    @include flex-container(column, space-around, flex-start);
 
     .featured-experiment__title {
       @include respond-to('small') {
-        margin: 10px 0 20px;
+        margin: 10px 0 5px;
       }
 
       font-size: 33px;

--- a/frontend/src/app/containers/HomePage/HomePageWithAddon.js
+++ b/frontend/src/app/containers/HomePage/HomePageWithAddon.js
@@ -160,7 +160,7 @@ export default class HomePageWithAddon extends React.Component {
   }
 
   render() {
-    const { sendToGA, isAfterCompletedDate, 
+    const { sendToGA, isAfterCompletedDate,
             majorNewsUpdates, featuredExperiments, isExperimentEnabled,
             experimentsWithoutFeatured, experiments,
             enableExperiment } = this.props;
@@ -192,11 +192,13 @@ export default class HomePageWithAddon extends React.Component {
       this.setState({ showEmailDialog: false });
     };
 
+    const hasTour = featuredExperiments.length && featuredExperiment.hasOwnProperty("tour_steps");
+
     return (
       <View {...this.props}>
         {showEmailDialog &&
           <EmailDialog {...this.props} onDismiss={onEmailDialogDismissed} />}
-        {showTourDialog && <ExperimentTourDialog
+        {hasTour && showTourDialog && <ExperimentTourDialog
             experiment={featuredExperiment}
             {...this.props}
             onCancel={() => this.onTourDialogComplete(featuredExperiment, true)}


### PR DESCRIPTION
This PR adjusts the size of the experiment icon for featured experiments to match details pages and fixes a bug where featured experiments without tours still rendered a tour modal (this is the same basic fix as #3560)