### PR TITLE
make experiment types more detailed: Merge 6/28 with Devin's patch

### DIFF
--- a/content-src/experiments/dev-example.yaml
+++ b/content-src/experiments/dev-example.yaml
@@ -2,7 +2,7 @@ dev: true
 id: 999
 title: 'Dev Example'
 slug: dev-example
-platforms: ['addon', 'ios']
+platforms: ['addon', 'ios', 'android']
 ios_url: https://itunes.apple.com/us/app/firefox-web-browser/id989804926?mt=8
 thumbnail: /static/images/check.png
 description: >

--- a/frontend/src/app/components/ExperimentPlatforms/index.js
+++ b/frontend/src/app/components/ExperimentPlatforms/index.js
@@ -4,22 +4,19 @@ import { Localized } from "fluent-react/compat";
 
 import "./index.scss";
 
-const AVAILABLE_PLATFORMS = ["web", "addon", "mobile"];
+const AVAILABLE_PLATFORMS = ["web", "addon", "ios", "android"];
 
 export default function ExperimentPlatforms({ experiment }) {
-  const platforms = experiment.platforms.map(p => (p === "android" || p === "ios") ? "mobile" : p) || [];
-  const enabledPlatforms = AVAILABLE_PLATFORMS
-    .filter(platform => platforms.indexOf(platform) !== -1);
+  let enabledPlatforms = AVAILABLE_PLATFORMS
+    .filter(platform => experiment.platforms.includes(platform));
   if (enabledPlatforms.length === 0) { return null; }
+
+  // sort list so that l10n ids are consistent regardless of array order in YAML
+  enabledPlatforms.sort();
 
   let l10nId = "experimentPlatform" + enabledPlatforms
     .map(platform => platform.charAt(0).toUpperCase() + platform.slice(1))
     .join("");
-
-  if (l10nId === "experimentPlatformMobile") {
-    // HACK: string changed after initial commit, so the ID had to change
-    l10nId = "experimentPlatformMobileApp";
-  }
 
   return (
     <h4 className="experiment-platform">

--- a/frontend/src/app/components/ExperimentPlatforms/index.scss
+++ b/frontend/src/app/components/ExperimentPlatforms/index.scss
@@ -42,7 +42,13 @@
     background-image: url('./img/experiment-type-addon.svg');
   }
 
-  .platform-icon-mobile {
+  .platform-icon-ios,
+  .platform-icon-android {
     background-image: url('./img/experiment-type-mobile.svg');
+  }
+
+  // don't show two mobile icons if we support both platforms
+  .platform-icon-android + .platform-icon-ios {
+    display: none;
   }
 }

--- a/frontend/src/app/components/ExperimentPlatforms/tests.js
+++ b/frontend/src/app/components/ExperimentPlatforms/tests.js
@@ -36,11 +36,11 @@ describe("app/components/ExperimentPlatforms", () => {
     subject.setProps({
       experiment: {
         ...mockExperiment,
-        platforms: ["addon", "mobile", "web", "diving", "political"]
+        platforms: ["addon", "ios", "android", "web", "diving", "political"]
       }
     });
-    expect(findLocalizedById(subject, "experimentPlatformWebAddonMobile")).to.have.property("length", 1);
-    ["addon", "mobile", "web"].forEach(platform =>
+    expect(findLocalizedById(subject, "experimentPlatformAddonAndroidIosWeb")).to.have.property("length", 1);
+    ["addon", "android", "ios", "web"].forEach(platform =>
       expect(subject.find(`.platform-icon-${platform}`)).to.have.property("length", 1));
     ["diving", "political"].forEach(platform =>
       expect(subject.find(`.platform-icon-${platform}`)).to.have.property("length", 0));

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -177,13 +177,17 @@ startedDateLabel = Experiment start date: <b>{$startedDate}</b>
 nonExperimentDialogHeaderLink = Test Pilot
 
 ## Label shown next to a series of icons indicating whether an experiment is available as an add-on, mobile app, and/or web site
-experimentPlatformWebAddonMobile = Firefox / web / mobile experiment
-experimentPlatformWebAddon = Firefox / web experiment
-experimentPlatformWebMobile = web / mobile experiment
-experimentPlatformAddonMobile = Firefox / mobile experiment
-experimentPlatformWeb = web experiment
 experimentPlatformAddon = Firefox experiment
-experimentPlatformMobileApp = mobile experiment
+experimentPlatformAndroid = Android experiment
+experimentPlatformIos = iOS experiment
+experimentPlatformWeb = web experiment
+experimentPlatformAddonWeb = Firefox / web experiment
+experimentPlatformAddonAndroid = Android / Firefox experiment
+experimentPlatformAddonIos = iOS / Firefox experiment
+experimentPlatformAddonAndroidWeb = Android / Firefox / web experiment
+experimentPlatformAddonAndroidIosWeb = Android / iOS / Firefox / web experiment
+experimentPlatformAndroidWeb = Android / web experiment
+experimentPlatformAndroidIos = Android / iOS experiment
 
 ## Shown when an experiment requires a version of Firefox newer than the user's.
 upgradeNoticeTitle = {$title} requires Firefox {$min_release} or later.

--- a/locales/en-US/app.ftl
+++ b/locales/en-US/app.ftl
@@ -184,6 +184,7 @@ experimentPlatformWeb = web experiment
 experimentPlatformAddonWeb = Firefox / web experiment
 experimentPlatformAddonAndroid = Android / Firefox experiment
 experimentPlatformAddonIos = iOS / Firefox experiment
+experimentPlatformAddonAndroidIos = Android / iOS / Firefox experiment
 experimentPlatformAddonAndroidWeb = Android / Firefox / web experiment
 experimentPlatformAddonAndroidIosWeb = Android / iOS / Firefox / web experiment
 experimentPlatformAndroidWeb = Android / web experiment


### PR DESCRIPTION
@devinreams @meandavejustice this PR makes the experiment type UI a little more expressive and standardized so that instead of saying "mobile experiment" we actually declare specific device types.  ~~Would be good to get this merged with the other mobile stuff today or tomorrow!~~ 

Err, actually since this has strings we should push it to l10n with devin's PR for lockbox after we push to stage.

fixes #3634 