### PR TITLE
Rework hardcoded image paths as webpack dependencies

### DIFF
--- a/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
+++ b/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
@@ -12,6 +12,8 @@ import MainInstallButton from "../MainInstallButton";
 import MobileDialog from "../MobileDialog";
 import LayoutWrapper from "../LayoutWrapper";
 
+import iconMobileWhite from "../../../images/mobile-white.svg";
+
 import type { InstalledExperiments } from "../../reducers/addon";
 
 type FeaturedButtonProps = {
@@ -154,7 +156,7 @@ export default class FeaturedButton extends React.Component {
             <a
               className="button primary icon-button main-install__button"
               onClick={this.doShowMobileAppDialog}>
-              <img src="/static/images/mobile-white.svg" />
+              <img src={iconMobileWhite} />
               <Localized id="mobileDialogTitle">
                 <span>Get the App</span>
               </Localized>

--- a/frontend/src/app/components/GraduatedNotice/index.js
+++ b/frontend/src/app/components/GraduatedNotice/index.js
@@ -3,6 +3,8 @@ import React from "react";
 
 import "./index.scss";
 
+import iconInfo from "../../../images/info-16.svg";
+
 class GraduatedNoticeButton extends React.Component {
   render() {
     return <Localized id="experimentGradReportButton">
@@ -30,7 +32,7 @@ export default class GraduatedNotice extends React.Component {
       </Localized>;
     }
     return <div className="graduated-notice">
-      <img className="graduated-notice-image" src="/static/images/info-16.svg" width="40" height="40"/>
+      <img className="graduated-notice-image" src={iconInfo} width="40" height="40"/>
       <div className="graduated-notice-text">
         <Localized id="experimentGradReportPendingTitle">
           <h1>

--- a/frontend/src/app/components/MobileDialog/index.js
+++ b/frontend/src/app/components/MobileDialog/index.js
@@ -11,6 +11,9 @@ import Loading from "../Loading";
 
 import "./index.scss";
 
+import iconIos from "../../../images/ios-light.svg";
+import iconGoogle from "../../../images/google-play.png";
+
 import { subscribeToBasket, subscribeToBasketSMS, acceptedSMSCountries } from "../../lib/utils";
 
 type MobileDialogProps = {
@@ -91,7 +94,7 @@ export default class MobileDialog extends React.Component {
 
     const headerMessage = ios_url ? (<LocalizedHtml id="mobileDialogMessageIOS" $title={title}>
       <p>Download <b>{title}</b> from the iOS App Store.</p></LocalizedHtml>) : (<LocalizedHtml id="mobileDialogMessageAndroid" $title={title}><p>Download <b>{title}</b> from the Google Play Store.</p></LocalizedHtml>);
-    const headerImg = ios_url ? (<a href={ios_url} onClick={handleAppLinkClick} target="_blank" rel="noopener noreferrer"><img className="mobile-header-img" src="/static/images/ios-light.svg"/></a>) : (<a href={android_url} onClick={handleAppLinkClick} target="_blank" rel="noopener noreferrer"><img className="mobile-header-img" src="/static/images/google-play.png"/></a>);
+    const headerImg = ios_url ? (<a href={ios_url} onClick={handleAppLinkClick} target="_blank" rel="noopener noreferrer"><img className="mobile-header-img" src={iconIos}/></a>) : (<a href={android_url} onClick={handleAppLinkClick} target="_blank" rel="noopener noreferrer"><img className="mobile-header-img" src={iconGoogle}/></a>);
 
     const learnMoreLink = "https://www.mozilla.org/privacy/websites/#campaigns";
 

--- a/frontend/src/app/containers/ExperimentPage/ExperimentButtons.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentButtons.js
@@ -14,6 +14,17 @@ import type {
   WebExperimentButtonType
 } from "./types";
 
+// Import all the icon images as webpack dependencies
+import iconFeedbackDefault from "../../../images/feedback.svg";
+import iconFeedbackWhite from "../../../images/feedback-white.svg";
+import iconExperimentTypeAddonDefault from "../../../images/experiment-type-addon.svg";
+import iconExperimentTypeAddonWhite from "../../../images/experiment-type-addon-white.svg";
+import iconExperimentTypeWebDefault from "../../../images/experiment-type-web.svg";
+import iconExperimentTypeWebWhite from "../../../images/experiment-type-web-white.svg";
+import iconExperimentTypeMobileWhite from "../../../images/experiment-type-mobile-white.svg";
+import iconIos from "../../../images/ios-light.svg";
+import iconGoogle from "../../../images/google-play.png";
+
 export const FeedbackButton = ({
   title,
   slug,
@@ -41,7 +52,6 @@ export const FeedbackButton = ({
       });
     }
   };
-  const iconPath = `/static/images/feedback${color === "default" ? "-white" : ""}.svg`;
 
   return (
     <a
@@ -53,7 +63,9 @@ export const FeedbackButton = ({
       target="_blank"
       rel="noopener noreferrer"
     >
-      <img src={iconPath} />
+      <img
+        src={color === "default" ? iconFeedbackDefault : iconFeedbackWhite}
+      />
       <Localized id="giveFeedback">
         <span className="default-text">Give Feedback</span>
       </Localized>
@@ -61,13 +73,15 @@ export const FeedbackButton = ({
   );
 };
 
-export const MobileTriggerButton = ({ doShowMobileAppDialog }: MobileTriggerButtonType) => {
+export const MobileTriggerButton = ({
+  doShowMobileAppDialog
+}: MobileTriggerButtonType) => {
   return (
     <a
       className="button mobile-trigger default icon-button"
       onClick={doShowMobileAppDialog}
     >
-      <img src="/static/images/mobile-white.svg" />
+      <img src={iconExperimentTypeMobileWhite} />
       <Localized id="mobileDialogTitle">
         <span>Get the App</span>
       </Localized>
@@ -75,7 +89,11 @@ export const MobileTriggerButton = ({ doShowMobileAppDialog }: MobileTriggerButt
   );
 };
 
-export const GraduatedButton = ({ doShowEolDialog, isDisabling, title }: GraduatedButtonType) => {
+export const GraduatedButton = ({
+  doShowEolDialog,
+  isDisabling,
+  title
+}: GraduatedButtonType) => {
   return (
     <button
       key="graduated-button"
@@ -86,7 +104,7 @@ export const GraduatedButton = ({ doShowEolDialog, isDisabling, title }: Graduat
       })}
     >
       <span className="state-change-inner" />
-      <img src="/static/images/experiment-type-addon-white.svg" />
+      <img src={iconExperimentTypeAddonWhite} />
       <Localized id="disableExperimentTransition">
         <span className="transition-text">Disabling...</span>
       </Localized>
@@ -112,7 +130,7 @@ export const UninstallButton = ({
       })}
     >
       <span className="state-change-inner" />
-      <img src="/static/images/experiment-type-addon.svg" />
+      <img src={iconExperimentTypeAddonDefault} />
       <Localized id="disableExperimentTransition">
         <span className="transition-text">Disabling...</span>
       </Localized>
@@ -138,7 +156,7 @@ export const InstallTestPilotButton = ({
       })}
     >
       <div className="state-change-inner" />
-      <img src="/static/images/experiment-type-addon-white.svg" />
+      <img src={iconExperimentTypeAddonWhite} />
       <div className="one-click-cta-text">
         {!isEnabling && (
           <LocalizedHtml id="oneClickInstallMinorCta">
@@ -165,47 +183,43 @@ export const EnableExperimentButton = ({
   isEnabling,
   title,
   color
-}: EnableExperimentButtonType) => {
-  const iconPath = `/static/images/experiment-type-addon${color === "default" ? "-white" : ""}.svg`;
+}: EnableExperimentButtonType) => (
+  <button
+    key="install-button"
+    onClick={installExperiment}
+    id="install-button"
+    className={classnames(["button", "icon-button", color], {
+      "state-change": isEnabling
+    })}
+  >
+    <span className="state-change-inner" />
+    <img
+      src={
+        color === "default"
+          ? iconExperimentTypeAddonDefault
+          : iconExperimentTypeAddonWhite
+      }
+    />
+    <Localized id="enableExperimentTransition">
+      <span className="transition-text">Enabling...</span>
+    </Localized>
+    <Localized id="enableExperiment" $title={title}>
+      <span className="default-text">Enable {title}</span>
+    </Localized>
+  </button>
+);
 
-  return (
-    <button
-      key="install-button"
-      onClick={installExperiment}
-      id="install-button"
-      className={classnames(["button", "icon-button", color], {
-        "state-change": isEnabling
-      })}
-    >
-      <span className="state-change-inner" />
-      <img src={iconPath}/>
-      <Localized id="enableExperimentTransition">
-        <span className="transition-text">Enabling...</span>
-      </Localized>
-      <Localized id="enableExperiment" $title={title}>
-        <span className="default-text">Enable {title}</span>
-      </Localized>
-    </button>
-  );
-};
-
-export const MobileStoreButton = ({ url, platform }: MobileStoreButtonType) => {
-  const src =
-    platform === "ios"
-      ? "/static/images/ios-light.svg"
-      : "/static/images/google-play.png";
-  return (
-    <a
-      key={url}
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="button mobile"
-    >
-      <img src={src} />
-    </a>
-  );
-};
+export const MobileStoreButton = ({ url, platform }: MobileStoreButtonType) => (
+  <a
+    key={url}
+    href={url}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="button mobile"
+  >
+    <img src={platform === "ios" ? iconIos : iconGoogle} />
+  </a>
+);
 
 export const WebExperimentButton = ({
   color,
@@ -214,8 +228,6 @@ export const WebExperimentButton = ({
   title,
   web_url
 }: WebExperimentButtonType) => {
-  const iconPath = `/static/images/experiment-type-web${color === "default" ? "-white" : ""}.svg`;
-
   function handleGoToLink() {
     sendToGA("event", {
       eventCategory: "ExperimentDetailsPage Interactions",
@@ -232,7 +244,13 @@ export const WebExperimentButton = ({
       rel="noopener noreferrer"
       className={classnames("button icon-button", color)}
     >
-      <img src={iconPath} />
+      <img
+        src={
+          color === "default"
+            ? iconExperimentTypeWebDefault
+            : iconExperimentTypeWebWhite
+        }
+      />
       <Localized id="experimentGoToLink" $title={title}>
         <span className="default-text">Go to {title}</span>
       </Localized>

--- a/frontend/src/app/containers/RestartPage.js
+++ b/frontend/src/app/containers/RestartPage.js
@@ -7,6 +7,7 @@ import Banner from "../components/Banner";
 import LayoutWrapper from "../components/LayoutWrapper";
 import View from "../components/View";
 
+import imageRestart from "../../images/restart-graphic@2x.jpg";
 
 type RestartProps = {
   experimentTitle: string,
@@ -33,7 +34,7 @@ export default class Restart extends React.Component {
         <Banner>
           <LayoutWrapper flexModifier="row-around-breaking">
             <div className="restart-image">
-              <img src="/static/images/restart-graphic@2x.jpg" width="208" height="273"/>
+              <img src={imageRestart} width="208" height="273"/>
             </div>
             <div className="banner__copy">
               <Localized id="restartIntroLead">

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -18,6 +18,12 @@ const THUMBNAIL_TWITTER = config.PRODUCTION_URL + "/static/images/thumbnail-twit
 const META_TITLE = "Firefox Test Pilot";
 const META_DESCRIPTION = "Test new Features. Give us feedback. Help build Firefox.";
 
+// HACK: Ignore non-JS imports used for asset dependencies in Webpack
+require.extensions[".scss"] = function() {};
+require.extensions[".svg"] = () => "";
+require.extensions[".png"] = () => "";
+require.extensions[".jpg"] = () => "";
+
 gulp.task("pages-misc", () => {
   // We just need a dummy file to get a stream going; we're going to ignore
   // the contents in buildLandingPage

--- a/frontend/test-setup.js
+++ b/frontend/test-setup.js
@@ -7,6 +7,9 @@ Enzyme.configure({ adapter: new Adapter() });
 
 // HACK: Ignore non-JS imports used for asset dependencies in Webpack
 require.extensions[".scss"] = function() {};
+require.extensions[".svg"] = () => "";
+require.extensions[".png"] = () => "";
+require.extensions[".jpg"] = () => "";
 
 // We need jsdom for enzyme mount()'ed components - mainly the sticky header
 // scroll handler stuff on the experiments page.


### PR DESCRIPTION
- Add .svg, .png, & .jpg to import ignores in tests.

- Also ignore webpack-style imports in static page generation for now.

Fixes #3683