### PR TITLE
make txp default slug for mozAddonManager

### DIFF
--- a/frontend/src/app/lib/InstallManager.js
+++ b/frontend/src/app/lib/InstallManager.js
@@ -19,7 +19,7 @@ function getAddonId() {
   }[window.location.host];
 }
 
-function mozAddonManagerInstall(url, sendToGA, slug = null) {
+function mozAddonManagerInstall(url, sendToGA, slug = "test-pilot-addon") {
   const start = url.indexOf("files/") + 6;
   const end = url.indexOf("@");
   const experimentTitle = url.substring(start, end);


### PR DESCRIPTION
It turns out that this is like the single most important GA event for detecting experiment installs...

if there's no slug, when this gets called, it's b/c the test pilot add-on is getting installed. We should pass that in as the default value here.