### PR TITLE
Fixes #2809: Convert JSX in pages.js to React components

### DIFF
--- a/frontend/src/app/components/Head/index.js
+++ b/frontend/src/app/components/Head/index.js
@@ -1,0 +1,58 @@
+import React from "react";
+
+type HeadProps = {
+  metaTitle: string,
+  metaDescription: string,
+  availableLocales: string,
+  canonicalPath: string,
+  imageFacebook: string,
+  imageTwitter: string
+}
+
+export default class Head extends React.Component {
+  props: HeadProps
+
+  render() {
+    const {
+      metaTitle, metaDescription,
+      availableLocales, canonicalPath,
+      imageFacebook, imageTwitter
+    } = this.props;
+
+    const canonicalUrl = `https://testpilot.firefox.com/${canonicalPath}`;
+
+    return (
+      <head>
+        <meta charSet="utf-8" />
+        <link rel="shortcut icon" href="/static/images/favicon.ico" />
+        <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
+        <link rel="stylesheet" href="/static/styles/experiments.css" />
+        <link rel="stylesheet" href="/static/app/app.css" />
+
+        <meta name="defaultLanguage" content="en-US" />
+        <meta name="availableLanguages" content={availableLocales} />
+        <meta name="viewport" content="width=device-width" />
+
+        <link rel="alternate" type="application/atom+xml" href="/feed.atom" title="Atom Feed" />
+        <link rel="alternate" type="application/rss+xml" href="/feed.rss" title="RSS Feed" />
+        <link rel="alternate" type="application/json" href="/feed.json" title="JSON Feed" />
+
+        <link rel="canonical" href={canonicalUrl} />
+
+        <title>{metaTitle}</title>
+
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={metaTitle} />
+        <meta name="twitter:title" content={metaTitle} />
+        <meta name="description" content={metaDescription} />
+        <meta property="og:description" content={metaDescription} />
+        <meta name="twitter:description" content={metaDescription} />
+        <meta name="twitter:card" content="summary" />
+        <meta property="og:image" content={imageFacebook} />
+        <meta name="twitter:image" content={imageTwitter} />
+        <meta property="og:url" content={canonicalUrl} />
+      </head>
+    );
+  }
+
+}

--- a/frontend/src/app/components/Head/tests.js
+++ b/frontend/src/app/components/Head/tests.js
@@ -1,0 +1,54 @@
+/* global describe, beforeEach, it */
+import React from "react";
+
+import Head from ".";
+
+import { expect } from "chai";
+import { shallow } from "enzyme";
+
+describe("app/components/Head", () => {
+  let subject, props;
+
+  beforeEach(() => {
+    props = {
+      metaTitle: "Firefox Test Pilot",
+      metaDescription: "Test new Features. Give us feedback. Help build Firefox.",
+
+      imageFacebook: "/static/images/thumbnail-facebook.png",
+      imageTwitter: "/static/images/thumbnail-twitter.png",
+
+      availableLocales: "en-US,fr-CA",
+      canonicalPath: "canonical/path"
+    };
+
+    subject = shallow(<Head {...props} />);
+  });
+
+  it("should contain the correct page title", () => {
+    expect(subject.find("title").text()).equals(props.metaTitle);
+  });
+
+  it("should contain the correct available locales", () => {
+    expect(subject.find(`meta [name="availableLanguages"]`).props().content).equals(props.availableLocales);
+  });
+
+  it("should contain the correct canonical URL", () => {
+    expect(subject.find(`link [rel="canonical"]`).props().href).match(new RegExp(`${props.canonicalPath}$`));
+  });
+
+  it("should contain correct Twitter metadata", () => {
+    expect(subject.find(`meta [name="twitter:title"]`).props().content).equals(props.metaTitle);
+    expect(subject.find(`meta [name="twitter:description"]`).props().content).equals(props.metaDescription);
+    expect(subject.find(`meta [name="twitter:image"]`).props().content).equals(props.imageTwitter);
+    expect(subject.find(`meta [name="twitter:card"]`).props().content).equals("summary");
+  });
+
+  it("should contain correct Facebook metadata", () => {
+    expect(subject.find(`meta [property="og:type"]`).props().content).equals("website");
+    expect(subject.find(`meta [property="og:title"]`).props().content).equals(props.metaTitle);
+    expect(subject.find(`meta [property="og:description"]`).props().content).equals(props.metaDescription);
+    expect(subject.find(`meta [property="og:image"]`).props().content).equals(props.imageFacebook);
+    expect(subject.find(`meta [property="og:url"]`).props().content).to.match(new RegExp(`${props.canonicalPath}$`));
+  });
+
+});

--- a/frontend/src/app/components/NoScript/index.js
+++ b/frontend/src/app/components/NoScript/index.js
@@ -1,0 +1,81 @@
+import React from "react";
+
+import LayoutWrapper from "../LayoutWrapper";
+import Copter from "../Copter";
+
+type NoScriptProps = {
+  showCopter: boolean
+}
+
+export default class NoScript extends React.Component {
+  props: NoScriptProps
+
+  renderCopter() {
+    if (this.props.showCopter) {
+      return <Copter />;
+    }
+    return null;
+  }
+
+  render() {
+    return <noscript>
+      <div className="full-page-wrapper centered">
+        <LayoutWrapper flexModifier="column-center">
+          <p>Test Pilot requires JavaScript. Sorry about that.</p>
+          <p>Test Pilot zahteva JavaScript. Žal nam je.</p>
+          <p>Test Pilot vyžaduje JavaScript. Ospravedlňujeme sa za problémy.</p>
+          <p>Test Pilot fereasket JavaScript. Sorry derfoar.</p>
+          <p>Test Pilot lyp JavaScript. Na ndjeni për këtë.</p>
+          <p>Test Pilot memerlukan JavaScript. Harap maaf.</p>
+          <p>Test Pilot krev JavaScript. Lei for det.</p>
+          <p>Test Pilot requiere JavaScript. Lo sentimos.</p>
+          <p>Testpilot kræver JavaScript. Beklager.</p>
+          <p>Test Pilot requiere JavaScript. Lo sentimos por ello.</p>
+          <p>Test Pilot を使うには JavaScript が必要です。申し訳ありません</p>
+
+          {this.renderCopter()}
+
+          <p>Το Test Pilot απαιτεί JavaScript. Λυπούμαστε γι&#39; αυτό.</p>
+          <p>Test Pilot requiere JavaScript. Disculpe</p>
+          <p>Siamo spiacenti, Test Pilot richiede JavaScript.</p>
+          <p>Omlouváme se, ale Test Pilot vyžaduje JavaScript.</p>
+          <p>Test Pilot requiere JavaScript. Lo sentimos.</p>
+          <p>Для работы Лётчика-испытателя необходимо включить JavaScript. Извините.</p>
+          <p>Je nam žel, ale TestPilot sej JavaScript wužaduje.</p>
+          <p>Ri Test Pilot nrajo&#39; JavaScript. Kojakuyu&#39;.</p>
+          <p>很抱歉，Test Pilot 需要 JavaScript 来运行。</p>
+          <p>Вибачте, але для роботи Test Pilot необхідний JavaScript.</p>
+          <p>Test Pilot захтева JavaScript. Жао нам је због овога.</p>
+          <p>O Test Pilot requer JavaScript. Pedimos desculpa.</p>
+          <p>Test Pilot zahtjeva JavaScript. Žao nam je zbog toga.</p>
+          <p>很抱歉，需要開啟 JavaScript 才能使用 Test Pilot</p>
+          <p>Desculpe, o Test Pilot requer JavaScript.</p>
+          <p>A Tesztpilótához JavaScript szükséges. Sajnáljuk.</p>
+          <p>Test Pilot vereist JavaScript. Sorry daarvoor.</p>
+          <p>Test Pilot საჭიროებს JavaScript-ს. ვწუხვართ, ამის გამო.</p>
+          <p>Test Pilot benötigt JavaScript. Das tut uns leid.</p>
+          <p>Test Pilot을 쓰려면 JavaScript가 필요합니다. 죄송합니다.</p>
+          <p>Désolé, Test Pilot nécessite JavaScript.</p>
+          <p>Test Pilot kräver JavaScript. Ledsen för det.</p>
+          <p>Mae Test Pilot angen JavaScript. Ymddiheuriadau.</p>
+          <p>Test Pilot requires JavaScript. Sorry about that.</p>
+          <p>Jo nam luto, ale TestPilot se JavaScript pomina.</p>
+          <p>Test Pilotu için JavaScript şarttır. Kusura bakmayın.</p>
+          <p>Test Pilot vereist JavaScript. Sorry daarvoor.</p>
+          <p>Test Pilot საჭიროებს JavaScript-ს. ვწუხვართ, ამის გამო.</p>
+          <p>Test Pilot benötigt JavaScript. Das tut uns leid.</p>
+          <p>Test Pilot을 쓰려면 JavaScript가 필요합니다. 죄송합니다.</p>
+          <p>Désolé, Test Pilot nécessite JavaScript.</p>
+          <p>Test Pilot kräver JavaScript. Ledsen för det.</p>
+          <p>Mae Test Pilot angen JavaScript. Ymddiheuriadau.</p>
+          <p>Jo nam luto, ale TestPilot se JavaScript pomina.</p>
+          <p>Test Pilotu için JavaScript şarttır. Kusura bakmayın.</p>
+        </LayoutWrapper>
+      </div>
+    </noscript>;
+  }
+}
+
+NoScript.defaultProps = {
+  showCopter: true
+};

--- a/frontend/tasks/pages.js
+++ b/frontend/tasks/pages.js
@@ -3,15 +3,17 @@ const config = require("../config.js");
 const path = require("path");
 const fs = require("fs");
 const gutil = require("gulp-util");
-const multiDest = require("gulp-multi-dest");
 const through = require("through2");
 const YAML = require("yamljs");
 const ReactDOMServer = require("react-dom/server");
 
-import Loading from "../src/app/components/Loading";
-
 import React from "react";
 import ReactMarkdown from "react-markdown";
+
+import LayoutWrapper from "../src/app/components/LayoutWrapper";
+import Head from "../src/app/components/Head";
+import Footer from "../src/app/components/Footer";
+import NoScript from "../src/app/components/NoScript";
 
 const THUMBNAIL_FACEBOOK = config.PRODUCTION_URL + "/static/images/thumbnail-facebook.png";
 const THUMBNAIL_TWITTER = config.PRODUCTION_URL + "/static/images/thumbnail-twitter.png";
@@ -200,100 +202,25 @@ function generateStaticPage(prepareForClient, pageName, pageParam, component, {
   available_locales, canonical_path, meta_title, meta_description,
   image_facebook, image_twitter, enable_pontoon
 }) {
-  const headComponent = <head>
-    <meta charSet="utf-8" />
-    <link rel="shortcut icon" href="/static/images/favicon.ico" />
-    <link rel="stylesheet" href="https://code.cdn.mozilla.net/fonts/fira.css" />
-    <link rel="stylesheet" href="/static/styles/experiments.css" />
-    <link rel="stylesheet" href="/static/app/app.css" />
-
-    <meta name="defaultLanguage" content="en-US" />
-    <meta name="availableLanguages" content={ available_locales } />
-    <meta name="viewport" content="width=device-width" />
-
-    <link rel="alternate" type="application/atom+xml" href="/feed.atom" title="Atom Feed"/>
-    <link rel="alternate" type="application/rss+xml" href="/feed.rss" title="RSS Feed"/>
-    <link rel="alternate" type="application/json" href="/feed.json" title="JSON Feed"/>
-
-    <link rel="canonical" href={ `https://testpilot.firefox.com/${canonical_path}` } />
-
-    <title>{ meta_title }</title>
-
-    <meta property="og:type" content="website" />
-    <meta property="og:title" content={ meta_title } />
-    <meta name="twitter:title" content={ meta_title } />
-    <meta name="description" content={ meta_description } />
-    <meta property="og:description" content={ meta_description } />
-    <meta name="twitter:description" content={ meta_description } />
-    <meta name="twitter:card" content="summary" />
-    <meta property="og:image" content={ image_facebook } />
-    <meta name="twitter:image" content={ image_twitter } />
-    <meta property="og:url" content={ `https://testpilot.firefox.com/${canonical_path}` } />
-  </head>;
+  const headComponent = <Head
+    metaTitle={meta_title}
+    metaDescription={meta_description}
+    canonicalPath={canonical_path}
+    availableLocales={available_locales}
+    imageFacebook={image_facebook}
+    imageTwitter={image_twitter}
+  />;
 
   const bodyComponent = <div id="static-root">
-    <noscript>
-      <div className="full-page-wrapper centered">
-        <div className="layout-wrapper layout-wrapper--column-center">
-          <p>Test Pilot zahteva JavaScript. Žal nam je.</p>
-          <p>Test Pilot vyžaduje JavaScript. Ospravedlňujeme sa za problémy.</p>
-          <p>Test Pilot fereasket JavaScript. Sorry derfoar.</p>
-          <p>Test Pilot lyp JavaScript. Na ndjeni për këtë.</p>
-          <p>Test Pilot memerlukan JavaScript. Harap maaf.</p>
-          <p>Test Pilot krev JavaScript. Lei for det.</p>
-          <p>Test Pilot requiere JavaScript. Lo sentimos.</p>
-          <p>Testpilot kræver JavaScript. Beklager.</p>
-          <p>Test Pilot requiere JavaScript. Lo sentimos por ello.</p>
-          <p>Test Pilot を使うには JavaScript が必要です。申し訳ありません</p>
-          <div className="copter">
-            <div className="copter__inner"></div>
-          </div>
-          <p>Το Test Pilot απαιτεί JavaScript. Λυπούμαστε γι' αυτό.</p>
-          <p>Test Pilot requiere JavaScript. Disculpe</p>
-          <p>Siamo spiacenti, Test Pilot richiede JavaScript.</p>
-          <p>Omlouváme se, ale Test Pilot vyžaduje JavaScript.</p>
-          <p>Test Pilot requiere JavaScript. Lo sentimos.</p>
-          <p>Для работы Лётчика-испытателя необходимо включить JavaScript. Извините.</p>
-          <p>Je nam žel, ale TestPilot sej JavaScript wužaduje.</p>
-          <p>Ri Test Pilot nrajo' JavaScript. Kojakuyu'.</p>
-          <p>很抱歉，Test Pilot 需要 JavaScript 来运行。</p>
-          <p>Вибачте, але для роботи Test Pilot необхідний JavaScript.</p>
-          <p>Test Pilot захтева JavaScript. Жао нам је због овога.</p>
-          <p>O Test Pilot requer JavaScript. Pedimos desculpa.</p>
-          <p>Test Pilot zahtjeva JavaScript. Žao nam je zbog toga.</p>
-          <p>很抱歉，需要開啟 JavaScript 才能使用 Test Pilot</p>
-          <p>Desculpe, o Test Pilot requer JavaScript.</p>
-          <p>A Tesztpilótához JavaScript szükséges. Sajnáljuk.</p>
-          <p>Test Pilot vereist JavaScript. Sorry daarvoor.</p>
-          <p>Test Pilot საჭიროებს JavaScript-ს. ვწუხვართ, ამის გამო.</p>
-          <p>Test Pilot benötigt JavaScript. Das tut uns leid.</p>
-          <p>Test Pilot을 쓰려면 JavaScript가 필요합니다. 죄송합니다.</p>
-          <p>Désolé, Test Pilot nécessite JavaScript.</p>
-          <p>Test Pilot kräver JavaScript. Ledsen för det.</p>
-          <p>Mae Test Pilot angen JavaScript. Ymddiheuriadau.</p>
-          <p>Test Pilot requires JavaScript. Sorry about that.</p>
-          <p>Jo nam luto, ale TestPilot se JavaScript pomina.</p>
-          <p>Test Pilotu için JavaScript şarttır. Kusura bakmayın.</p>
-          <p>Test Pilot vereist JavaScript. Sorry daarvoor.</p>
-          <p>Test Pilot საჭიროებს JavaScript-ს. ვწუხვართ, ამის გამო.</p>
-          <p>Test Pilot benötigt JavaScript. Das tut uns leid.</p>
-          <p>Test Pilot을 쓰려면 JavaScript가 필요합니다. 죄송합니다.</p>
-          <p>Désolé, Test Pilot nécessite JavaScript.</p>
-          <p>Test Pilot kräver JavaScript. Ledsen för det.</p>
-          <p>Mae Test Pilot angen JavaScript. Ymddiheuriadau.</p>
-          <p>Test Pilot requires JavaScript. Sorry about that.</p>
-          <p>Jo nam luto, ale TestPilot se JavaScript pomina.</p>
-          <p>Test Pilotu için JavaScript şarttır. Kusura bakmayın.</p>
-        </div>
-      </div>
-    </noscript>
-    { prepareForClient ? <script src="/static/app/vendor.js"></script> : null }
+    <NoScript />
+    {prepareForClient ? <script src="/static/app/vendor.js"></script> : null}
   </div>;
 
   return makeStaticString(prepareForClient, pageName, pageParam, headComponent, bodyComponent, component);
 }
 
 function generateStaticPageFromMarkdown(pageName, pageParam, markdown, params) {
+  // TODO: Reuse Header component
   const body = <div className="full-page-wrapper">
     <header id="main-header" className="layout-wrapper layout-wrapper--row-between-top">
       <h1>
@@ -304,27 +231,12 @@ function generateStaticPageFromMarkdown(pageName, pageParam, markdown, params) {
         <a className="blog-link" href="https://medium.com/firefox-test-pilot" target="_blank" rel="noopener noreferrer">Blog</a>
       </div>
     </header>
-    <div className="layout-wrapper static-page-content">
-      <ReactMarkdown source={ markdown } />
-    </div>
 
-    <footer id="main-footer">
-      <div id="footer-links" className="layout-wrapper layout-wrapper--row-bottom-breaking">
-        <div className="legal-links">
-          <a href="https://www.mozilla.org" className="mozilla-logo" alt="Mozilla Site"></a>
-          <a href="https://www.mozilla.org/about/legal/" className="boilerplate">Legal</a>
-          <a href="https://qsurvey.mozilla.com/s3/test-pilot-general-feedback" className="boilerplate">Give Feedback</a>
-          <a href="/about" className="boilerplate">About Test Pilot</a>
-          <a href="/privacy" className="boilerplate">Privacy</a>
-          <a href="/terms" className="boilerplate">Terms</a>
-          <a href="https://www.mozilla.org/privacy/websites/#cookies" className="boilerplate">Cookies</a>
-        </div>
-        <div className="social-links">
-          <a href="https://github.com/mozilla/testpilot" target="_blank" title="GitHub" className="link-icon github" alt="Testpilot GitHub Repo"></a>
-          <a href="https://twitter.com/FxTestPilot" target="_blank" title="Twitter" className="link-icon twitter" alt="Testpilot Twitter"></a>
-        </div>
-      </div>
-    </footer>
+    <LayoutWrapper helperClass="static-page-content">
+      <ReactMarkdown source={markdown} />
+    </LayoutWrapper>
+
+    <Footer />
     <script src="/static/app/vendor.js"></script>
     <script src="/static/scripts/locale.js"></script>
     <script src="/static/scripts/legal.js"></script>


### PR DESCRIPTION
Fixes #2809 
New components:
- NoScript 
    - Contains the `<noscript>...</noscript>` section
    - Moved the English translation of "Test Pilot requires JavaScript. Sorry about that." to the top.
- Head
    - Contains the `<head>` metadata

Markdown pages:
- Replaced container div with `LayoutWrapper`
- Replaced the `<footer>...</footer>` section with the `Footer` component. I believe this closes #3616.