### PR TITLE
Allow changing local dev server host with HOST env var

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,6 +116,7 @@ module.exports = {
     }
   },
   devServer: {
+    host: process.env.HOST || "127.0.0.1",
     port: process.env.PORT || 8000,
     allowedHosts: ["example.com"],
     publicPath: "/",


### PR DESCRIPTION
I just started trying to outsource some CPU cycles to a remote AWS box for Test Pilot builds & etc. This change helps me specify the host network on which the server should open the port, which helps me get access to it from home. (i.e. I have a security group limiting the box to access from my IP, so I host the dev server on the public IP of the EC2 box rather than internally limited to 127.0.0.1 by default)