### PR TITLE
Updates experiment subtitle styles (closes #3759).

### DIFF
--- a/frontend/src/app/components/ExperimentRowCard/index.scss
+++ b/frontend/src/app/components/ExperimentRowCard/index.scss
@@ -85,6 +85,10 @@
   }
 
   h4 {
+    color: $grey-70;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 15px;
     margin: 0;
   }
 

--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -205,6 +205,13 @@
     padding: 20px 10px 10px;
   }
 
+  header {
+    display: flex;
+    justify-content: center;
+    line-height: 1;
+    flex-direction: column;
+  }
+
   h1 {
 
     @include respond-to('small') {
@@ -214,11 +221,14 @@
     display: flex;
     flex: 1;
     font-weight: $weight-light;
-    margin: $grid-unit * .75;
+    margin: 0 $grid-unit * .75;
   }
 
   h4 {
-    margin: 0;
+    color: $grey-80;
+    font-size: 18px;
+    font-weight: normal;
+    margin: $grid-unit * .25 $grid-unit * .75 0;
   }
 
   .upgrade-notice {


### PR DESCRIPTION
These styles are approved by Sevaan, just need a bit of code review.

<img width="314" alt="screen shot 2018-07-31 at 2 48 48 pm" src="https://user-images.githubusercontent.com/23885/43483937-9fd0fc8c-94d2-11e8-969e-974e24a6f116.png">
<img width="533" alt="screen shot 2018-07-31 at 2 49 14 pm" src="https://user-images.githubusercontent.com/23885/43483938-a050da56-94d2-11e8-9de9-11c7b4f8610a.png">
<img width="468" alt="screen shot 2018-07-31 at 2 49 22 pm" src="https://user-images.githubusercontent.com/23885/43483939-a0681ffe-94d2-11e8-9001-b031ba748ed1.png">
