### PR TITLE
Stop using symlinks to generate legal pages from node_modules

### DIFF
--- a/frontend/src/pages/privacy
+++ b/frontend/src/pages/privacy
@@ -1,1 +1,0 @@
-../../../node_modules/legal-docs/firefox_testpilot_PrivacyNotice

--- a/frontend/src/pages/terms
+++ b/frontend/src/pages/terms
@@ -1,1 +1,0 @@
-../../../node_modules/legal-docs/firefox_testpilot_Terms


### PR DESCRIPTION
Tried a bunch of different ways to get things working under Windows, but for some reason I just keep running into issues with these symlinks. 

On Windows (but not Linux), it seems like there's an issue going from a clean checkout with symlinks to directories that don't exist yet - i.e. the legal page symlinks under `frontend/src/pages` point to nothing until after the first `npm install`.

I could have sworn this worked in the past, but apparently makes for unhappiness now.