### PR TITLE
Enable polling in webpack file watchers

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,6 +102,9 @@ module.exports = {
     // filename: "[name].[hash].js"
     filename: "[name].js"
   },
+  watchOptions: {
+    poll: 1000
+  },
   node: {
     crypto: false
   },


### PR DESCRIPTION
So I noticed on my Windows machine that webpack wasn't rebuilding the site on file edits. I think that's because my editor locks files and webpack file watchers don't catch changes. 

This seems to fix it by changing to polling for changes rather than watching file system events. Appears to work without too much burden on my machine. I *think* this should work fine on OS X and Linux, but worth a check.