### PR TITLE
Fix #3791 Experiment title and experiment type strings are centre aligned on mobile view.

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -528,4 +528,10 @@
       padding-top: 0;
     }
   }
+
+  .details-header{
+    header{
+      align-items: center;
+    }
+  }
 }


### PR DESCRIPTION
Experiment title and experiment type strings are centre aligned on mobile view.

![screen shot 2018-08-15 at 03 20 40](https://user-images.githubusercontent.com/17615573/44120843-54cf7e06-a03b-11e8-9125-5407aa687fba.png)
![screen shot 2018-08-15 at 03 20 56](https://user-images.githubusercontent.com/17615573/44120845-5521b5ea-a03b-11e8-83be-2c80fe65014a.png)
![screen shot 2018-08-15 at 03 21 06](https://user-images.githubusercontent.com/17615573/44120847-556cd8f4-a03b-11e8-993c-46c565fd2a02.png)


