### PR TITLE
FIx #3717 [Mobile] The "More experiments" button is partially overlapped by the "App Store" Lockbox button fixed.

### DIFF
--- a/frontend/src/app/components/FeaturedExperiment/index.scss
+++ b/frontend/src/app/components/FeaturedExperiment/index.scss
@@ -266,6 +266,7 @@
 
       border: 0;
       margin: 0;
+      z-index : 2;
 
       img {
         height: 60px;

--- a/frontend/src/app/containers/HomePage/index.scss
+++ b/frontend/src/app/containers/HomePage/index.scss
@@ -38,6 +38,7 @@
     position: relative;
     text-align: center;
     transition: background-color 125ms, background-position 125ms, box-shadow 125ms;
+    z-index : 1;
 
     &:hover {
       background-color: $transparent-white-2;


### PR DESCRIPTION
[Mobile] The "More experiments" button is partially overlapped by the "App Store" Lockbox button fixed.

![screen shot 2018-08-15 at 19 36 47](https://user-images.githubusercontent.com/17615573/44152479-458aac94-a0c3-11e8-9d2d-0eb334308f72.png)
