### PR TITLE
Fix #3791 experiment type strings are correctly aligned on mobile view

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -533,5 +533,9 @@
     header{
       align-items: center;
     }
+
+    .experiment-platform {
+      justify-content : center;
+    }
   }
 }


### PR DESCRIPTION
Experiment type strings are correctly aligned on mobile view.

![screen shot 2018-08-18 at 13 43 45](https://user-images.githubusercontent.com/17615573/44297311-d2f42f80-a2ec-11e8-9cd7-aa7716ea35a0.png)
![screen shot 2018-08-18 at 13 44 00](https://user-images.githubusercontent.com/17615573/44297312-d38cc600-a2ec-11e8-9068-9bd640220818.png)
