### PR TITLE
#Fixes:3565- resolved the wrong positioning of error message

### DIFF
--- a/frontend/src/app/containers/HomePage/HomePageNoAddon.js
+++ b/frontend/src/app/containers/HomePage/HomePageNoAddon.js
@@ -67,7 +67,7 @@ export default class HomePageNoAddon extends React.Component {
     </Banner>;
 
     const featuredSection = featuredExperiment ? (<Banner background={true}>
-      <LayoutWrapper flexModifier="row-between-breaking">
+      <LayoutWrapper flexModifier="row-center">
         <FeaturedExperiment {...this.props}
           experiment={featuredExperiment}
           eventCategory="FeaturedExperiment Interactions"


### PR DESCRIPTION
### Fixes #3565 
### BEFORE:
<img width="1440" alt="screen shot 2018-08-22 at 3 29 26 am" src="https://user-images.githubusercontent.com/35342019/44432031-ff929a80-a5bd-11e8-81e2-b0d40d26de95.png">

### AFTER:
<img width="1440" alt="screen shot 2018-08-22 at 1 17 11 am" src="https://user-images.githubusercontent.com/35342019/44432026-fefa0400-a5bd-11e8-8fe9-9542583133e0.png">

### DESCRIPTION:
- Changed css class from `row-between-breaking` -> `row-center` -> `LayoutWrapper` component in `HomePageNoAddon.js` which positioned the error message to center as shown in screenshots.
- I have tested for Side-view.yaml too, It works just fine now.


