### PR TITLE
Remove links to contribute and change log for Advance

### DIFF
--- a/content-src/experiments/advance.yaml
+++ b/content-src/experiments/advance.yaml
@@ -1,7 +1,5 @@
 addon_id: support@laserlike.com
 bug_report_url: "https://github.com/laserlikeinc/firefox-addon/issues"
-changelog_url: "https://github.com/laserlikeinc/firefox-addon/releases"
-contribute_url: "https://github.com/laserlikeinc/firefox-addon"
 contributors:
   -
     avatar: /static/images/experiments/advance/avatars/advance-avatar.png

--- a/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
+++ b/frontend/src/app/containers/ExperimentPage/DetailsOverview.js
@@ -141,11 +141,13 @@ export const StatsSection = ({
               <Localized id="changelog"><span>Changelog</span></Localized>
             </a>
           </li>}
-      <li>
-        <a href={contribute_url}>
-          <Localized id="contribute"><span>Contribute</span></Localized>
-        </a>
-      </li>
+      {contribute_url &&
+          <li>
+            <a href={contribute_url}>
+              <Localized id="contribute"><span>Contribute</span></Localized>
+            </a>
+          </li>
+      }
       <li>
         <a href={bug_report_url}>
           <Localized id="bugReports"><span>Bug Reports</span></Localized>


### PR DESCRIPTION
They don't publish a change log and you can't contribute to the repository (https://github.com/LaserlikeInc/firefox-addon/issues/72), so it doesn't make sense to have these links.