### PR TITLE
Disable storybook builds for now

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -153,13 +153,6 @@ workflows:
       - unit_test:
           requires:
             - build
-      - storybook_deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore:
-                - l10n
       - static_deploy:
           requires:
             - unit_test


### PR DESCRIPTION
Looks like the Webpack upgrade broke Storybook. Since we're not using it, and it'll probably take an upgrade / reconfiguration of storybook, let's just disable it for now