### PR TITLE
Fixes #3716 [Android] Download on the App Store button is not displayed on Firefox for Android

### DIFF
--- a/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
+++ b/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
@@ -164,8 +164,8 @@ export default class FeaturedButton extends Component<FeaturedButtonProps, Featu
       }
       return (
         <React.Fragment>
-          {platforms.includes("ios") && <MobileStoreButton {...{ url: ios_url, platform: "ios", slug, category, sendToGA }} />}
-          {platforms.includes("android") && <MobileStoreButton {...{ url: android_url, platform: "android", slug, category, sendToGA }} />}
+          {/iPad|iPhone|iPod/i.test(userAgent) && platforms.includes("ios") && <MobileStoreButton {...{ url: ios_url, platform: "ios", slug, category, sendToGA }} />}
+          {/android/i.test(userAgent) && platforms.includes("android") && <MobileStoreButton {...{ url: android_url, platform: "android", slug, category, sendToGA }} />}
         </React.Fragment>
       );
     };


### PR DESCRIPTION
Fix #3716

[Android] Download on the App Store button is not displayed on Firefox for Android

Android [ Google Nexus 6, Mobile View in Mozilla Firefox Developer Edition ]

![screen shot 2018-08-24 at 03 35 48](https://user-images.githubusercontent.com/17615573/44554538-f5ec6c80-a74e-11e8-8d30-d947ce6c35e9.png)

iOS [ iPhone 6S, Mobile View in Mozilla Firefox Developer Edition ]

![screen shot 2018-08-24 at 03 32 18](https://user-images.githubusercontent.com/17615573/44554594-30eea000-a74f-11e8-82b9-b78e51b206ab.png)
