### PR TITLE
Fixes #3061: Firefox Free Download button shows animation when hovered

### DIFF
--- a/frontend/src/app/components/MainInstallButton/index.scss
+++ b/frontend/src/app/components/MainInstallButton/index.scss
@@ -66,6 +66,18 @@
   user-select: none;
   width: 280px;
 
+  &:hover .main-install__badge {
+    animation: bounce 0.15s infinite alternate;
+     @keyframes bounce {
+      from {
+        transform: translateY(0px);
+      }
+      to {
+        transform: translateY(3px);
+      }
+    } 
+  }
+
   .layout-wrapper--column-center & {
     margin-left: auto;
     margin-right: auto;
@@ -84,7 +96,6 @@
     padding: 14px;
     position: absolute;
     right: 2px;
-    transition-duration: 150ms;
     width: 16px;
   }
 

--- a/frontend/src/app/components/MainInstallButton/index.scss
+++ b/frontend/src/app/components/MainInstallButton/index.scss
@@ -67,7 +67,7 @@
   width: 280px;
 
   &:hover .main-install__badge {
-    animation: bounce 0.15s infinite alternate;
+    animation: bounce 0.4s infinite alternate;
      @keyframes bounce {
       from {
         transform: translateY(0px);


### PR DESCRIPTION
## Fixes #3061 
### BEFORE:
Button before adding animaton looked like [this](https://drive.google.com/open?id=1qy_8n3HKuvjc32ZCHhdGUrZHVYUv7oRQ)
### AFTER:
Button after adding animation looked like [this](https://drive.google.com/open?id=13fu2U1TIf12mfPswnD66Kv35uj2T-kFX)
### DESCRIPTION: 
- I added a new css class `&:hover .main-install__badge` inside the `.main-install__download` class to apply animation to the `badge` when download button is being hovered.
- The animation specifications are taken from [this](https://mozilla.github.io/testpilot-assets/Test_Pilot_Website/01_Measurements/Photonized_Txp_Website_Final/#artboard0) file, please let me know if you think I need to change something in it.