### PR TITLE
Fix #3696 [Mobile] Experiment launch / expiration date displayed on mobile view.

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -273,7 +273,9 @@
   padding-top: $grid-unit * .5;
 
   .details-sections {
-    @include hide-on-small;
+    .stats-section, .contributors-section, .measurements {
+      @include hide-on-small
+    }
   }
 }
 


### PR DESCRIPTION
Fix #3696 [Mobile] Experiment launch / expiration date displayed on mobile view.

![date_on_mobile](https://user-images.githubusercontent.com/17615573/45582880-67928300-b8d5-11e8-8d1e-d2c371c2ba7b.png)
