### PR TITLE
Fixes#3752 Experiment square logo in edge fixed using border-radius

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -10,8 +10,8 @@
   }
 
   & .experiment-icon-wrapper {
-    border-radius: 0;
-    height: 80px;
+    border-radius: 50%;
+    height: 64px;
     width: 109%;
   }
 


### PR DESCRIPTION
Used border-radius:50% to fix square logo in edge as clip-path not supported.
Please let me know of any feedback!