### PR TITLE
Fixes #3564: Resolves experiment enable error that is wrongly displayed on two rows on languages with longer words

### DIFF
--- a/frontend/src/styles/_base.scss
+++ b/frontend/src/styles/_base.scss
@@ -1,6 +1,6 @@
 html {
   box-sizing: border-box;
-  font-size: 62.5%;
+  font-size: 55%;
 }
 
 *,


### PR DESCRIPTION
## Fixes #3564 
### BEFORE:
<img width="1406" alt="screen shot 2018-09-20 at 1 38 31 pm" src="https://user-images.githubusercontent.com/35342019/45804825-c6436c80-bcda-11e8-98ad-c3381d224beb.png">

### AFTER:

<img width="1439" alt="screen shot 2018-09-20 at 1 37 57 pm" src="https://user-images.githubusercontent.com/35342019/45804842-d9563c80-bcda-11e8-9b6e-13498923b083.png">

### DESCRIPTION: 
I adjusted the `font-size` so that languages with longer words can also fit in the banner.