### PR TITLE
Fixes#3876 Removes oval shaped experiment logo

### DIFF
--- a/frontend/src/app/containers/ExperimentPage/index.scss
+++ b/frontend/src/app/containers/ExperimentPage/index.scss
@@ -10,8 +10,8 @@
   }
 
   & .experiment-icon-wrapper {
-    border-radius: 50%;
-    height: 64px;
+    border-radius: 0;
+    height: 80px;
     width: 109%;
   }
 
@@ -27,6 +27,8 @@
   @include respond-to('not-small') {
 
     & .experiment-icon-wrapper {
+      border-radius: 50%;
+      height: 64px;
       clip-path: circle(32px at center);
       flex: 0 0 64px;
     }


### PR DESCRIPTION
Removed oval shaped experiment logo.
Applying border-radius:50% when screen size greater than 769px only. Otherwise applies border-radius: 0 as earlier.

**Mobile View -** 

![screenshot 11](https://user-images.githubusercontent.com/19373793/45915589-f9b9fe80-be74-11e8-9a52-de0c2419d2c4.png)




**Desktop View -** 

![screenshot 16](https://user-images.githubusercontent.com/19373793/45915612-5ae1d200-be75-11e8-8e2a-14c92452445b.png)
