### PR TITLE
Fixes #3865 The "Shutting down..." animation words seem to overlap on Italian localization Corrected.

### DIFF
--- a/frontend/src/app/containers/RetirePage/index.scss
+++ b/frontend/src/app/containers/RetirePage/index.scss
@@ -10,6 +10,7 @@
   h1 {
     font-style: oblique;
     font-weight: 300;
+    line-height: 1.5;
   }
 
   > * {


### PR DESCRIPTION
Fixes #3865 The "Shutting down..." animation words seem to overlap on Italian localization Corrected.

![screen shot 2018-09-23 at 11 53 16 am](https://user-images.githubusercontent.com/17615573/45924886-6e01aa00-bf28-11e8-8298-2d995e506e7e.png)

![screen shot 2018-09-23 at 11 54 27 am](https://user-images.githubusercontent.com/17615573/45924887-6e01aa00-bf28-11e8-9e70-23a65b246b8c.png)
