### PR TITLE
Fixes #3544 [Experiment details] Added back the experiment enable error when installing both TxP add-on and experiment.

### DIFF
--- a/frontend/src/app/lib/InstallManager.js
+++ b/frontend/src/app/lib/InstallManager.js
@@ -253,7 +253,8 @@ export function enableExperiment(dispatch, experiment, sendToGA, eventCategory, 
       err => {
         dispatch(
           updateExperiment(experiment.addon_id, {
-            inProgress: false
+            inProgress: false,
+            error: true
           })
         );
       });


### PR DESCRIPTION
Fixes #3544 [Experiment details] Added back the experiment enable error when installing both TxP add-on and experiment.

![screen shot 2018-09-25 at 11 43 20 am](https://user-images.githubusercontent.com/17615573/45996009-33c71280-c0b8-11e8-915f-9983e8494b41.png)
