### PR TITLE
Updates URL of Advance repo.

### DIFF
--- a/content-src/experiments/advance.yaml
+++ b/content-src/experiments/advance.yaml
@@ -1,5 +1,5 @@
 addon_id: support@laserlike.com
-bug_report_url: "https://github.com/laserlikeinc/firefox-addon/issues"
+bug_report_url: "https://github.com/mozilla/advance/issues"
 completed: '2018-10-17T06:00:00.000000Z'
 contributors:
   -
@@ -41,7 +41,7 @@ measurements:
 order: 1
 platforms:
   - addon
-privacy_notice_url: "https://github.com/LaserlikeInc/firefox-addon/blob/master/metrics.md"
+privacy_notice_url: "https://github.com/mozilla/advance/blob/master/metrics.md"
 privacy_preamble: "The Advance Test Pilot experiment is a collaboration between Laserlike and Mozilla."
 slug: advance
 subtitle: "Powered by Laserlike"


### PR DESCRIPTION
The original repo for Advance will be deleted soon. I forked it to a Mozilla origin to make sure that the metrics documentation lives on.