### PR TITLE
Fixes #3925 [Featured experiment] Mobile platform download buttons have the different colors

### DIFF
--- a/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
+++ b/frontend/src/app/components/FeaturedExperiment/FeaturedButton.js
@@ -169,7 +169,7 @@ export default class FeaturedButton extends Component<FeaturedButtonProps, Featu
             <React.Fragment>
               <div className="main-install__spacer"></div>
               <div className="mobile-button-wrap">
-                <MobileTriggerIOSButton doShowMobileAppDialog={this.doShowMobileAppDialog} color={"primary"} />
+                <MobileTriggerIOSButton doShowMobileAppDialog={this.doShowMobileAppDialog} color={"default"} />
                 <MobileTriggerAndroidButton doShowMobileAppDialog={this.doShowMobileAppDialog} color={"primary"} />
               </div>
               { this.renderLegalLink() }

--- a/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
+++ b/frontend/src/app/containers/ExperimentPage/ExperimentControls.js
@@ -170,7 +170,7 @@ function createButtons({
         {(platforms.includes("ios")) &&
           <MobileTriggerIOSButton {...{ doShowMobileAppDialog, color: "default" }} />}
         {(platforms.includes("android")) &&
-          <MobileTriggerAndroidButton {...{ doShowMobileAppDialog, color: "default" }} />}
+          <MobileTriggerAndroidButton {...{ doShowMobileAppDialog, color: "primary" }} />}
       </Fragment>);
     }
 


### PR DESCRIPTION
Fixes #3925 [Featured experiment] Mobile platform download buttons have the different colors

![screenshot 2018-11-02 at 1 46 37 am](https://user-images.githubusercontent.com/17615573/47877321-9773f680-de41-11e8-856f-813cd848ca89.png)

![screenshot 2018-11-02 at 1 45 05 am](https://user-images.githubusercontent.com/17615573/47877322-9773f680-de41-11e8-84f8-d5bff99be60e.png)
