### PR TITLE
Fixes #3996 The "View details" button is correctly displayed

### DIFF
--- a/frontend/src/app/components/FeaturedExperiment/index.js
+++ b/frontend/src/app/components/FeaturedExperiment/index.js
@@ -100,7 +100,7 @@ export default class FeaturedExperiment extends Component<FeaturedExperimentProp
             <p className="featured-experiment__description">{description}</p>
           </Localized>
 
-          {(!enabled || isMobileExperiment) && <Localized id='moreDetail'>
+          {(!hasAddon || isMobileExperiment) && <Localized id='moreDetail'>
             <Link className="featured-experiment__details" to={`/experiments/${slug}`}
               onClick={handleDetailsLinkClick}>View Details</Link>
           </Localized>}

--- a/frontend/src/app/components/FeaturedExperiment/tests.js
+++ b/frontend/src/app/components/FeaturedExperiment/tests.js
@@ -50,10 +50,10 @@ describe("app/components/FeaturedExperiment", () => {
     expect(findLocalizedById(subject, "testingDescription")).to.have.property("length", 1);
   });
 
-  it('should have a "More Detail" button if not enabled', () => {
-    subject.setProps({ enabled: true });
+  it('should have a "More Detail" button if hasAddon', () => {
+    subject.setProps({ hasAddon: true });
     expect(findLocalizedById(subject, "moreDetail")).to.have.property("length", 0);
-    subject.setProps({ enabled: false });
+    subject.setProps({ hasAddon: false });
     expect(findLocalizedById(subject, "moreDetail")).to.have.property("length", 1);
   });
 });


### PR DESCRIPTION
Fixes #3996 The "View details" button is correctly displayed

![screenshot 2018-12-06 at 6 48 50 pm](https://user-images.githubusercontent.com/17615573/49586612-a3def800-f987-11e8-8d9c-54d7b0dea891.png)

![screenshot 2018-12-06 at 6 50 12 pm](https://user-images.githubusercontent.com/17615573/49586687-e1438580-f987-11e8-98df-ce31bfc79549.png)

![screenshot 2018-12-06 at 6 50 52 pm](https://user-images.githubusercontent.com/17615573/49586688-e1438580-f987-11e8-8388-e816aa041dba.png)
