### PR TITLE
Add page title

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   <link href="./index.css" rel="stylesheet">
   <link href="locales/{locale}/app.ftl" rel="localization">
   <script defer src="./lib/fluent-web-bundle.js"></script>
-  <title></title>
+  <title>Firefox Test Pilot</title>
 </head>
 <body>
   <div class="stars"></div>


### PR DESCRIPTION
This just hardcodes the `<title>` tag.

Not sure if we wanted to try and hook it up to Pontoon/fluent instead (if the `-product` string even gets translated ever).

Ref #4024 